### PR TITLE
fix(ci): build the release engine the test suite has always required

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,7 +31,7 @@ jobs:
   verify:
     name: Verify
     runs-on: ubuntu-latest
-    timeout-minutes: 20
+    timeout-minutes: 30
 
     steps:
       - name: Checkout
@@ -54,6 +54,15 @@ jobs:
 
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
+
+      # Four CLI test files point DRIFT_ENGINE_BIN at target/release/drift-engine and fail if it is
+      # absent. Nothing in the gate built it: `pnpm test:engine` is `cargo test`, which produces a
+      # debug binary. On a developer machine the release binary is always lying around from an eval
+      # run, so the dependency was invisible until a clean runner ran the suite for the first time.
+      # `pnpm verify` now builds it too; this step is here so a build failure is legible as a build
+      # failure rather than as a test failure, and it makes the one inside verify a no-op.
+      - name: Build the release engine
+        run: pnpm build:engine
 
       - name: Verify
         run: pnpm verify:ci

--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
   },
   "scripts": {
     "build": "pnpm -r build",
+    "build:engine": "cargo build --release -p drift-engine",
     "test": "pnpm test:engine && pnpm -r test",
     "test:engine": "cargo test -p drift-engine",
     "format:engine": "cargo fmt --all",
@@ -15,7 +16,7 @@
     "lint:engine": "cargo clippy -p drift-engine --all-targets -- -D warnings",
     "test:e2e": "vitest run test/e2e --no-file-parallelism --maxWorkers=1",
     "typecheck": "pnpm -r typecheck",
-    "verify": "pnpm build && pnpm typecheck && pnpm test && pnpm test:e2e",
+    "verify": "pnpm build:engine && pnpm build && pnpm typecheck && pnpm test && pnpm test:e2e",
     "check:boundaries": "node packages/cli/scripts/check-boundaries.mjs",
     "validate:release-matrix": "node scripts/validate-engine-release-matrix.mjs",
     "validate:claims": "node scripts/validate-product-claims.mjs",


### PR DESCRIPTION
Ten tests across four files failed on the first clean-runner execution of the suite, all with the same error:

  DRIFT_ENGINE_BIN is invalid: .../target/release/drift-engine does not exist

bypass-fixtures, engine-provenance-bb2, fact-count-agreement and side-effect-import-evidence all point DRIFT_ENGINE_BIN at target/release/drift-engine. Nothing in the gate builds it — pnpm test:engine is cargo test, which produces a debug binary. On a developer machine the release binary is always present from an eval or bench run, so a real prerequisite of the suite was never declared anywhere. It surfaced the moment a machine without one ran the tests, which had not happened since May.

pnpm verify now starts with pnpm build:engine, so a fresh clone is enough to run the gate. CI builds it as its own step as well, so a build failure reads as a build failure instead of as ten test failures. Timeout 20 -> 30 minutes to cover the added release build.

## Summary

- 

## Verification

- [ ] `pnpm verify:ci`

## Drift Boundaries

- [ ] Rust remains deterministic parser/rule authority for engine behavior.
- [ ] TypeScript changes stay in orchestration, governance, policy, storage, query, or formatting layers.
- [ ] No source snippets or secrets are added to outputs, logs, fixtures, docs, or MCP payloads.
- [ ] Agent-facing JSON includes policy/redaction/freshness metadata where applicable.

## Notes

- 
