### PR TITLE
fix(ci): fetch full history, refresh the gate pins, record the CV rou…

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,8 +34,16 @@ jobs:
     timeout-minutes: 30
 
     steps:
+      # fetch-depth: 0 is not optional. `pnpm beta:proof` runs `drift start` against a fixture, and
+      # Drift refuses to derive repo identity in a shallow clone - a shallow clone's root commit is
+      # the fetch graft, not the repository's real first commit, so the identity would silently
+      # disagree with every full checkout. actions/checkout defaults to depth 1, so the proof exited
+      # 3 (refused) the first time this gate ran. The product's own documented CI requirement
+      # applies to the product's own CI.
       - name: Checkout
         uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
 
       - name: Setup pnpm
         uses: pnpm/action-setup@v4

--- a/crates/drift-engine/src/candidate_command.rs
+++ b/crates/drift-engine/src/candidate_command.rs
@@ -1148,11 +1148,13 @@ fn scope_flavors_present<'a>(
 ) -> BTreeSet<&'static str> {
     scope_files
         .iter()
-        .map(|file| match flavors.get(*file).copied().unwrap_or("api_route") {
-            "cron_job" => "cron_job",
-            "webhook_handler" => "webhook_handler",
-            _ => "api_route",
-        })
+        .map(
+            |file| match flavors.get(*file).copied().unwrap_or("api_route") {
+                "cron_job" => "cron_job",
+                "webhook_handler" => "webhook_handler",
+                _ => "api_route",
+            },
+        )
         .collect()
 }
 
@@ -1515,9 +1517,30 @@ fn wrapping_file_count(request: &CandidateRequest, facts: &[&CheckFact]) -> usiz
 /// family - a module and its submodule - while `api/auth` and `api/middleware` are two.
 fn module_family_key(module: &str) -> String {
     const GENERIC_SEGMENTS: &[&str] = &[
-        "", ".", "..", "@", "~", "src", "lib", "libs", "app", "apps", "web", "packages", "pkg",
-        "modules", "internal", "shared", "common", "utils", "util", "helpers", "index", "dist",
-        "server", "node_modules",
+        "",
+        ".",
+        "..",
+        "@",
+        "~",
+        "src",
+        "lib",
+        "libs",
+        "app",
+        "apps",
+        "web",
+        "packages",
+        "pkg",
+        "modules",
+        "internal",
+        "shared",
+        "common",
+        "utils",
+        "util",
+        "helpers",
+        "index",
+        "dist",
+        "server",
+        "node_modules",
     ];
     let lower = module.trim().to_ascii_lowercase();
     let trimmed = lower
@@ -1562,7 +1585,6 @@ fn family_keys_match(left: &str, right: &str) -> bool {
         .strip_prefix(shorter)
         .is_some_and(|rest| rest.starts_with('/'))
 }
-
 
 struct SecurityCandidateInput<'a> {
     request: &'a CandidateRequest,

--- a/crates/drift-engine/src/check_command.rs
+++ b/crates/drift-engine/src/check_command.rs
@@ -151,10 +151,8 @@ pub fn check_repo(request: CheckRequest) -> CheckResult {
             // `control_flow_guard_dominance`, because it does not compute it - that is the whole
             // difference between this path and the one below, and the reason this one can leave
             // quarantine while that one cannot.
-            required_capabilities.extend([
-                "syntax_facts".to_string(),
-                "import_resolution".to_string(),
-            ]);
+            required_capabilities
+                .extend(["syntax_facts".to_string(), "import_resolution".to_string()]);
             presence_findings(
                 &facts,
                 &parsed_diff,
@@ -1754,20 +1752,20 @@ fn presence_findings(
         };
 
         for handler in unsatisfied {
-        let missing_code = presence_missing_code(&convention.kind);
-        // The handler is part of the fingerprint, so two unguarded methods in one file are two
-        // findings rather than one that silently stands for both.
-        let finding_fingerprint = stable_hash(&format!(
-            "{}:{}:{}:{}",
-            convention.id,
-            file_path,
-            handler.map(|fact| fact.name.as_str()).unwrap_or("*"),
-            missing_code
-        ));
-        let finding_id = format!("finding_{}", &finding_fingerprint[..16]);
-        let mut symbols = accepted.iter().cloned().collect::<Vec<_>>();
-        symbols.sort();
-        findings.push(PendingFinding {
+            let missing_code = presence_missing_code(&convention.kind);
+            // The handler is part of the fingerprint, so two unguarded methods in one file are two
+            // findings rather than one that silently stands for both.
+            let finding_fingerprint = stable_hash(&format!(
+                "{}:{}:{}:{}",
+                convention.id,
+                file_path,
+                handler.map(|fact| fact.name.as_str()).unwrap_or("*"),
+                missing_code
+            ));
+            let finding_id = format!("finding_{}", &finding_fingerprint[..16]);
+            let mut symbols = accepted.iter().cloned().collect::<Vec<_>>();
+            symbols.sort();
+            findings.push(PendingFinding {
             fingerprint: finding_fingerprint,
             convention_id: convention.id.clone(),
             rule_id: convention.kind.clone(),
@@ -1813,11 +1811,7 @@ fn presence_accepted_symbols(
         symbols.insert(symbol.clone());
     }
     if let Some(requires) = convention.requires.as_ref() {
-        for key in [
-            "auth_helpers",
-            "rate_limit_helpers",
-            "validators",
-        ] {
+        for key in ["auth_helpers", "rate_limit_helpers", "validators"] {
             if let Some(entries) = requires.get(key).and_then(|value| value.as_array()) {
                 for entry in entries {
                     if let Some(symbol) = entry.get("symbol").and_then(|value| value.as_str()) {
@@ -1909,9 +1903,7 @@ fn presence_file_in_scope(
     if !flavors.is_empty() {
         let flavor = facts
             .iter()
-            .find(|fact| {
-                fact.kind == FactKind::RouteFlavorDetected && fact.file_path == file_path
-            })
+            .find(|fact| fact.kind == FactKind::RouteFlavorDetected && fact.file_path == file_path)
             .map(|fact| fact.name.clone())
             .unwrap_or_else(|| "api_route".to_string());
         if !flavors.contains(&flavor) {

--- a/crates/drift-engine/src/facts.rs
+++ b/crates/drift-engine/src/facts.rs
@@ -1152,7 +1152,10 @@ pub fn route_flavor(file_path: &str) -> &'static str {
         })
         .collect::<Vec<_>>();
 
-    if segments.iter().any(|segment| CRON_SEGMENTS.contains(segment)) {
+    if segments
+        .iter()
+        .any(|segment| CRON_SEGMENTS.contains(segment))
+    {
         return "cron_job";
     }
     if segments

--- a/crates/drift-engine/src/main.rs
+++ b/crates/drift-engine/src/main.rs
@@ -2040,7 +2040,7 @@ fn import_bases(from_file: &str, source: &str, resolver: &ResolverContext) -> Ve
             .filter(|entry| scope_contains(&entry.scope, from_file))
             .collect();
         // Nearest baseUrl's candidates first, for the same reason as alias precedence.
-        applicable.sort_by(|left, right| right.scope.len().cmp(&left.scope.len()));
+        applicable.sort_by_key(|entry| std::cmp::Reverse(entry.scope.len()));
         for entry in applicable {
             bases.push(join_repo_path(&entry.base_url, source));
         }

--- a/crates/drift-engine/tests/convention_families_cv1.rs
+++ b/crates/drift-engine/tests/convention_families_cv1.rs
@@ -41,12 +41,22 @@ struct Route<'a> {
 
 /// A wrapper call, spanning the handler it encloses.
 fn wrapper<'a>(path: &'a str, symbol: &'a str, module: &'a str) -> Route<'a> {
-    Route { path, symbol, module, wraps: true }
+    Route {
+        path,
+        symbol,
+        module,
+        wraps: true,
+    }
 }
 
 /// A point call inside a handler - an ordinary utility, not a wrapper.
 fn point_call<'a>(path: &'a str, symbol: &'a str, module: &'a str) -> Route<'a> {
-    Route { path, symbol, module, wraps: false }
+    Route {
+        path,
+        symbol,
+        module,
+        wraps: false,
+    }
 }
 
 /// Builds an `infer-candidates` request from a list of routes, each contributing the three facts a
@@ -139,11 +149,13 @@ fn candidates_of_kind<'a>(payload: &'a Value, kind: &str) -> Vec<&'a Value> {
 /// A family candidate is the one whose matcher names more than one required call. The per-symbol
 /// candidates it supersedes each name exactly one.
 fn family_candidate<'a>(payload: &'a Value, kind: &str) -> Option<&'a Value> {
-    candidates_of_kind(payload, kind).into_iter().find(|candidate| {
-        candidate["matcher"]["required_calls"]
-            .as_array()
-            .is_some_and(|calls| calls.len() > 1)
-    })
+    candidates_of_kind(payload, kind)
+        .into_iter()
+        .find(|candidate| {
+            candidate["matcher"]["required_calls"]
+                .as_array()
+                .is_some_and(|calls| calls.len() > 1)
+        })
 }
 
 fn required_calls(candidate: &Value) -> Vec<&str> {
@@ -230,7 +242,11 @@ fn a_single_helper_produces_no_family_candidate() {
          and therefore its id: {payload:#?}"
     );
     let per_symbol = candidates_of_kind(&payload, AUTH);
-    assert_eq!(per_symbol.len(), 1, "exactly the candidate today emits: {per_symbol:#?}");
+    assert_eq!(
+        per_symbol.len(),
+        1,
+        "exactly the candidate today emits: {per_symbol:#?}"
+    );
     assert!(
         per_symbol[0].get("superseded_by").is_none(),
         "with no family there is nothing to supersede, and the field must be absent rather than \
@@ -285,9 +301,15 @@ fn a_dub_shaped_repo_yields_one_family_with_union_coverage() {
     // from `is_auth_candidate_symbol` - it joins because it resolves where `withSession` resolves,
     // which is a fact about the repo rather than a string in the engine.
     let mut routes = Vec::new();
-    for (index, symbol) in ["withSession", "withWorkspace", "withAdmin", "withTeam", "withPartner"]
-        .into_iter()
-        .enumerate()
+    for (index, symbol) in [
+        "withSession",
+        "withWorkspace",
+        "withAdmin",
+        "withTeam",
+        "withPartner",
+    ]
+    .into_iter()
+    .enumerate()
     {
         for suffix in ["a", "b"] {
             routes.push(wrapper(
@@ -301,22 +323,36 @@ fn a_dub_shaped_repo_yields_one_family_with_union_coverage() {
 
     let family = family_candidate(&payload, AUTH).expect("an auth family exists");
     let calls = required_calls(family);
-    assert_eq!(calls.len(), 5, "every same-module wrapper is a member: {calls:?}");
+    assert_eq!(
+        calls.len(),
+        5,
+        "every same-module wrapper is a member: {calls:?}"
+    );
     assert_eq!(
         calls,
-        vec!["withAdmin", "withPartner", "withSession", "withTeam", "withWorkspace"],
+        vec![
+            "withAdmin",
+            "withPartner",
+            "withSession",
+            "withTeam",
+            "withWorkspace"
+        ],
         "members are sorted, so the matcher fingerprint and candidate id are stable"
     );
 
     // Union coverage: 10 of 10 route files, where the best single shard was 2.
-    let coverage = family["scoring"]["coverage_ratio"].as_f64().expect("coverage_ratio");
+    let coverage = family["scoring"]["coverage_ratio"]
+        .as_f64()
+        .expect("coverage_ratio");
     assert!(
         coverage > 0.99,
         "coverage is the union of files satisfied by any member, not one member's share: {coverage}"
     );
 
     // Per-member evidence, so `conventions show` can answer "why is withWorkspace in this family".
-    let helpers = family["requires"]["auth_helpers"].as_array().expect("auth_helpers");
+    let helpers = family["requires"]["auth_helpers"]
+        .as_array()
+        .expect("auth_helpers");
     assert_eq!(helpers.len(), 5);
     let workspace = helpers
         .iter()
@@ -421,13 +457,24 @@ fn rate_limit_helpers_from_one_module_aggregate_into_a_family() {
     let payload = run_infer_candidates(request_from_routes(&[
         wrapper("app/api/a/route.ts", "ratelimit", "@upstash/ratelimit"),
         wrapper("app/api/b/route.ts", "ratelimit", "@upstash/ratelimit"),
-        wrapper("app/api/c/route.ts", "throttleRequest", "@upstash/ratelimit"),
-        wrapper("app/api/d/route.ts", "throttleRequest", "@upstash/ratelimit"),
+        wrapper(
+            "app/api/c/route.ts",
+            "throttleRequest",
+            "@upstash/ratelimit",
+        ),
+        wrapper(
+            "app/api/d/route.ts",
+            "throttleRequest",
+            "@upstash/ratelimit",
+        ),
     ]));
 
     let family =
         family_candidate(&payload, "api_route_requires_rate_limit").expect("a rate-limit family");
-    assert_eq!(required_calls(&family.clone()), vec!["ratelimit", "throttleRequest"]);
+    assert_eq!(
+        required_calls(&family.clone()),
+        vec!["ratelimit", "throttleRequest"]
+    );
     // Rate limit's per-symbol candidate keys its helper module under `module`, not `import`, and a
     // family that used the other key would hand the check path helpers it cannot read.
     let helpers = family["requires"]["rate_limit_helpers"]
@@ -576,8 +623,16 @@ fn sibling_directories_in_one_package_are_not_one_family() {
     let payload = run_infer_candidates(request_from_routes(&[
         wrapper("app/api/a/route.ts", "withSession", "packages/api/src/auth"),
         wrapper("app/api/b/route.ts", "withSession", "packages/api/src/auth"),
-        wrapper("app/api/c/route.ts", "withErrorHandler", "packages/api/src/middleware"),
-        wrapper("app/api/d/route.ts", "withErrorHandler", "packages/api/src/middleware"),
+        wrapper(
+            "app/api/c/route.ts",
+            "withErrorHandler",
+            "packages/api/src/middleware",
+        ),
+        wrapper(
+            "app/api/d/route.ts",
+            "withErrorHandler",
+            "packages/api/src/middleware",
+        ),
     ]));
 
     for candidate in candidates_of_kind(&payload, AUTH) {
@@ -596,8 +651,16 @@ fn a_module_and_its_submodule_are_one_family() {
     let payload = run_infer_candidates(request_from_routes(&[
         wrapper("app/api/a/route.ts", "withSession", "@/lib/auth"),
         wrapper("app/api/b/route.ts", "withSession", "@/lib/auth"),
-        wrapper("app/api/c/route.ts", "withWorkspace", "@/lib/auth/workspace"),
-        wrapper("app/api/d/route.ts", "withWorkspace", "@/lib/auth/workspace"),
+        wrapper(
+            "app/api/c/route.ts",
+            "withWorkspace",
+            "@/lib/auth/workspace",
+        ),
+        wrapper(
+            "app/api/d/route.ts",
+            "withWorkspace",
+            "@/lib/auth/workspace",
+        ),
     ]));
 
     let family = family_candidate(&payload, AUTH).expect("an auth family exists");

--- a/crates/drift-engine/tests/presence_enforcement_cv3.rs
+++ b/crates/drift-engine/tests/presence_enforcement_cv3.rs
@@ -110,10 +110,24 @@ fn a_route_calling_a_family_member_is_silent() {
         &repo_root,
         vec![
             fact("file_role_detected", "api_route", 1, 4, None, None),
-            fact("import_used", "withWorkspace", 1, 1, Some("@/lib/auth"), Some("withWorkspace")),
+            fact(
+                "import_used",
+                "withWorkspace",
+                1,
+                1,
+                Some("@/lib/auth"),
+                Some("withWorkspace"),
+            ),
             fact("route_declared", "POST", 2, 4, None, None),
             fact("symbol_called", "withWorkspace", 2, 4, None, None),
-            fact("route_returns_response", "json", 3, 3, Some("Response"), None),
+            fact(
+                "route_returns_response",
+                "json",
+                3,
+                3,
+                Some("Response"),
+                None,
+            ),
         ],
         presence_convention(),
     );
@@ -140,10 +154,24 @@ fn a_renamed_import_still_satisfies_presence() {
         vec![
             fact("file_role_detected", "api_route", 1, 4, None, None),
             // The local binding is `w`; what it resolves to is `withSession`.
-            fact("import_used", "w", 1, 1, Some("@/lib/auth"), Some("withSession")),
+            fact(
+                "import_used",
+                "w",
+                1,
+                1,
+                Some("@/lib/auth"),
+                Some("withSession"),
+            ),
             fact("route_declared", "POST", 2, 4, None, None),
             fact("symbol_called", "w", 2, 4, None, None),
-            fact("route_returns_response", "json", 3, 3, Some("Response"), None),
+            fact(
+                "route_returns_response",
+                "json",
+                3,
+                3,
+                Some("Response"),
+                None,
+            ),
         ],
         presence_convention(),
     );
@@ -172,7 +200,14 @@ fn a_same_named_local_function_does_not_satisfy_presence() {
             // No import_used fact: nothing resolves this call anywhere.
             fact("route_declared", "POST", 2, 4, None, None),
             fact("symbol_called", "withSession", 2, 4, None, None),
-            fact("route_returns_response", "json", 3, 3, Some("Response"), None),
+            fact(
+                "route_returns_response",
+                "json",
+                3,
+                3,
+                Some("Response"),
+                None,
+            ),
         ],
         presence_convention(),
     );
@@ -199,7 +234,14 @@ fn a_convention_with_no_accepted_helpers_produces_no_findings() {
         vec![
             fact("file_role_detected", "api_route", 1, 1, None, None),
             fact("route_declared", "POST", 1, 1, None, None),
-            fact("route_returns_response", "json", 1, 1, Some("Response"), None),
+            fact(
+                "route_returns_response",
+                "json",
+                1,
+                1,
+                Some("Response"),
+                None,
+            ),
         ],
         convention,
     );
@@ -225,7 +267,14 @@ fn the_finding_claims_presence_and_never_protection() {
         vec![
             fact("file_role_detected", "api_route", 1, 1, None, None),
             fact("route_declared", "POST", 1, 1, None, None),
-            fact("route_returns_response", "json", 1, 1, Some("Response"), None),
+            fact(
+                "route_returns_response",
+                "json",
+                1,
+                1,
+                Some("Response"),
+                None,
+            ),
         ],
         presence_convention(),
     );
@@ -297,13 +346,34 @@ fn a_guard_called_after_the_sink_is_a_documented_non_catch() {
         &repo_root,
         vec![
             fact("file_role_detected", "api_route", 1, 7, None, None),
-            fact("import_used", "withWorkspace", 1, 1, Some("@/lib/auth"), Some("withWorkspace")),
+            fact(
+                "import_used",
+                "withWorkspace",
+                1,
+                1,
+                Some("@/lib/auth"),
+                Some("withWorkspace"),
+            ),
             fact("import_used", "db", 2, 2, Some("@/lib/db"), Some("db")),
             fact("route_declared", "POST", 3, 7, None, None),
             // The sink runs first; the guard is called after it.
-            fact("data_operation_detected", "findMany", 4, 4, Some("db.thing"), Some("read:thing")),
+            fact(
+                "data_operation_detected",
+                "findMany",
+                4,
+                4,
+                Some("db.thing"),
+                Some("read:thing"),
+            ),
             fact("symbol_called", "withWorkspace", 5, 5, None, None),
-            fact("route_returns_response", "json", 6, 6, Some("Response"), None),
+            fact(
+                "route_returns_response",
+                "json",
+                6,
+                6,
+                Some("Response"),
+                None,
+            ),
         ],
         presence_convention(),
     );
@@ -341,19 +411,44 @@ fn only_the_unwrapped_handler_of_a_multi_handler_route_is_reported() {
         &repo_root,
         vec![
             fact("file_role_detected", "api_route", 1, 7, None, None),
-            fact("import_used", "withSession", 1, 1, Some("@/lib/auth"), Some("withSession")),
+            fact(
+                "import_used",
+                "withSession",
+                1,
+                1,
+                Some("@/lib/auth"),
+                Some("withSession"),
+            ),
             fact("import_used", "db", 2, 2, Some("@/lib/db"), Some("db")),
             fact("route_declared", "GET", 3, 3, None, None),
             fact("symbol_called", "withSession", 3, 3, None, None),
             fact("route_declared", "POST", 4, 7, None, None),
-            fact("data_operation_detected", "create", 5, 5, Some("db.thing"), Some("write:thing")),
-            fact("route_returns_response", "json", 6, 6, Some("Response"), None),
+            fact(
+                "data_operation_detected",
+                "create",
+                5,
+                5,
+                Some("db.thing"),
+                Some("write:thing"),
+            ),
+            fact(
+                "route_returns_response",
+                "json",
+                6,
+                6,
+                Some("Response"),
+                None,
+            ),
         ],
         presence_convention(),
     );
 
     let findings = payload["findings"].as_array().expect("findings");
-    assert_eq!(findings.len(), 1, "exactly the unguarded handler: {payload:#?}");
+    assert_eq!(
+        findings.len(),
+        1,
+        "exactly the unguarded handler: {payload:#?}"
+    );
     assert!(
         findings[0]["message"]
             .as_str()
@@ -380,7 +475,14 @@ fn two_unwrapped_handlers_are_two_findings() {
             fact("file_role_detected", "api_route", 1, 2, None, None),
             fact("route_declared", "GET", 1, 1, None, None),
             fact("route_declared", "POST", 2, 2, None, None),
-            fact("route_returns_response", "json", 1, 1, Some("Response"), None),
+            fact(
+                "route_returns_response",
+                "json",
+                1,
+                1,
+                Some("Response"),
+                None,
+            ),
         ],
         presence_convention(),
     );
@@ -402,11 +504,25 @@ fn a_wrapper_enclosing_its_handler_satisfies_that_handler() {
         &repo_root,
         vec![
             fact("file_role_detected", "api_route", 1, 4, None, None),
-            fact("import_used", "withSession", 1, 1, Some("@/lib/auth"), Some("withSession")),
+            fact(
+                "import_used",
+                "withSession",
+                1,
+                1,
+                Some("@/lib/auth"),
+                Some("withSession"),
+            ),
             fact("route_declared", "POST", 2, 4, None, None),
             // The call spans the whole handler.
             fact("symbol_called", "withSession", 2, 4, None, None),
-            fact("route_returns_response", "json", 3, 3, Some("Response"), None),
+            fact(
+                "route_returns_response",
+                "json",
+                3,
+                3,
+                Some("Response"),
+                None,
+            ),
         ],
         presence_convention(),
     );
@@ -437,7 +553,14 @@ fn a_namespace_import_satisfies_presence() {
             fact("import_used", "auth", 1, 1, Some("@/lib/auth"), Some("*")),
             fact("route_declared", "POST", 2, 4, None, None),
             fact("symbol_called", "withSession", 2, 4, Some("auth"), None),
-            fact("route_returns_response", "json", 3, 3, Some("Response"), None),
+            fact(
+                "route_returns_response",
+                "json",
+                3,
+                3,
+                Some("Response"),
+                None,
+            ),
         ],
         presence_convention(),
     );
@@ -465,7 +588,14 @@ fn a_namespace_property_from_an_unimported_object_does_not_satisfy() {
             fact("file_role_detected", "api_route", 1, 4, None, None),
             fact("route_declared", "POST", 2, 4, None, None),
             fact("symbol_called", "withSession", 2, 4, Some("helpers"), None),
-            fact("route_returns_response", "json", 3, 3, Some("Response"), None),
+            fact(
+                "route_returns_response",
+                "json",
+                3,
+                3,
+                Some("Response"),
+                None,
+            ),
         ],
         presence_convention(),
     );
@@ -505,12 +635,33 @@ fn a_convention_without_the_presence_marker_still_gets_the_dominance_proof() {
         &repo_root,
         vec![
             fact("file_role_detected", "api_route", 1, 7, None, None),
-            fact("import_used", "withWorkspace", 1, 1, Some("@/lib/auth"), Some("withWorkspace")),
+            fact(
+                "import_used",
+                "withWorkspace",
+                1,
+                1,
+                Some("@/lib/auth"),
+                Some("withWorkspace"),
+            ),
             fact("import_used", "db", 2, 2, Some("@/lib/db"), Some("db")),
             fact("symbol_called", "withWorkspace", 3, 3, None, None),
             fact("route_declared", "POST", 4, 7, None, None),
-            fact("data_operation_detected", "findMany", 5, 5, Some("db.thing"), Some("read:thing")),
-            fact("route_returns_response", "json", 6, 6, Some("Response"), None),
+            fact(
+                "data_operation_detected",
+                "findMany",
+                5,
+                5,
+                Some("db.thing"),
+                Some("read:thing"),
+            ),
+            fact(
+                "route_returns_response",
+                "json",
+                6,
+                6,
+                Some("Response"),
+                None,
+            ),
         ],
         convention,
     );
@@ -636,10 +787,24 @@ fn a_wrapper_imported_through_a_barrel_satisfies_presence() {
         vec![
             fact("file_role_detected", "api_route", 1, 4, None, None),
             // The specifier is the barrel; the imported name is still the accepted symbol.
-            fact("import_used", "withSession", 1, 1, Some("@/lib"), Some("withSession")),
+            fact(
+                "import_used",
+                "withSession",
+                1,
+                1,
+                Some("@/lib"),
+                Some("withSession"),
+            ),
             fact("route_declared", "POST", 2, 4, None, None),
             fact("symbol_called", "withSession", 2, 4, None, None),
-            fact("route_returns_response", "json", 3, 3, Some("Response"), None),
+            fact(
+                "route_returns_response",
+                "json",
+                3,
+                3,
+                Some("Response"),
+                None,
+            ),
         ],
         presence_convention(),
     );
@@ -683,7 +848,14 @@ fn a_same_named_wrapper_from_an_unrelated_module_also_satisfies_presence() {
             ),
             fact("route_declared", "POST", 2, 4, None, None),
             fact("symbol_called", "withSession", 2, 4, None, None),
-            fact("route_returns_response", "json", 3, 3, Some("Response"), None),
+            fact(
+                "route_returns_response",
+                "json",
+                3,
+                3,
+                Some("Response"),
+                None,
+            ),
         ],
         presence_convention(),
     );
@@ -720,7 +892,12 @@ fn a_wrong_flavour_member_is_reported_and_the_message_names_what_was_expected() 
         }]
     });
 
-    let cron_fact = |kind: &str, name: &str, start: usize, end: usize, value: Option<&str>, imported: Option<&str>| {
+    let cron_fact = |kind: &str,
+                     name: &str,
+                     start: usize,
+                     end: usize,
+                     value: Option<&str>,
+                     imported: Option<&str>| {
         let mut out = json!({
             "kind": kind,
             "file_path": "app/api/cron/rollup/route.ts",
@@ -728,8 +905,12 @@ fn a_wrong_flavour_member_is_reported_and_the_message_names_what_was_expected() 
             "start_line": start,
             "end_line": end
         });
-        if let Some(value) = value { out["value"] = json!(value); }
-        if let Some(imported) = imported { out["imported_name"] = json!(imported); }
+        if let Some(value) = value {
+            out["value"] = json!(value);
+        }
+        if let Some(imported) = imported {
+            out["imported_name"] = json!(imported);
+        }
         out
     };
     let payload = run(
@@ -737,10 +918,24 @@ fn a_wrong_flavour_member_is_reported_and_the_message_names_what_was_expected() 
         vec![
             cron_fact("file_role_detected", "api_route", 1, 1, None, None),
             cron_fact("route_flavor_detected", "cron_job", 1, 1, None, None),
-            cron_fact("import_used", "withSession", 1, 1, Some("@/lib/auth"), Some("withSession")),
+            cron_fact(
+                "import_used",
+                "withSession",
+                1,
+                1,
+                Some("@/lib/auth"),
+                Some("withSession"),
+            ),
             cron_fact("route_declared", "POST", 1, 1, None, None),
             cron_fact("symbol_called", "withSession", 1, 1, None, None),
-            cron_fact("route_returns_response", "json", 1, 1, Some("Response"), None),
+            cron_fact(
+                "route_returns_response",
+                "json",
+                1,
+                1,
+                Some("Response"),
+                None,
+            ),
         ],
         convention,
     );
@@ -768,7 +963,11 @@ fn a_test_file_calling_wrappers_is_not_a_route_and_stays_silent() {
     let repo_root = temp_repo();
     let spec = repo_root.join("app/api/things/route.test.ts");
     fs::create_dir_all(spec.parent().expect("parent")).expect("mkdir");
-    fs::write(&spec, "it(\"wraps\", () => { withSession(() => null); });\n").expect("write");
+    fs::write(
+        &spec,
+        "it(\"wraps\", () => { withSession(() => null); });\n",
+    )
+    .expect("write");
 
     let test_fact = |kind: &str, name: &str| {
         json!({

--- a/crates/drift-engine/tests/route_flavor_differential_cv2.rs
+++ b/crates/drift-engine/tests/route_flavor_differential_cv2.rs
@@ -34,12 +34,18 @@ const EXPECTED: &[(&str, &str)] = &[
     ("apps/cron/app/api/users/route.ts", "api_route"),
     ("apps/cron/app/api/cron/rollup/route.ts", "cron_job"),
     // Cron, including dub's real shape.
-    ("apps/web/app/(ee)/api/cron/aggregate-clicks/route.ts", "cron_job"),
+    (
+        "apps/web/app/(ee)/api/cron/aggregate-clicks/route.ts",
+        "cron_job",
+    ),
     ("app/api/cron/rollup/route.ts", "cron_job"),
     ("app/api/jobs/nightly/route.ts", "cron_job"),
     ("app/api/scheduled/digest/route.ts", "cron_job"),
     // Webhooks, including dub's real shape.
-    ("apps/web/app/(ee)/api/appsflyer/webhook/route.ts", "webhook_handler"),
+    (
+        "apps/web/app/(ee)/api/appsflyer/webhook/route.ts",
+        "webhook_handler",
+    ),
     ("app/api/webhooks/stripe/route.ts", "webhook_handler"),
     // Both signals: a scheduled job that replays webhooks is a job. Pinned so it cannot silently flip.
     ("app/api/cron/webhooks/replay/route.ts", "cron_job"),
@@ -63,9 +69,10 @@ fn engine_route_flavor_matches_the_core_predicate_table() {
 /// file and fails when a case here is missing from it, so the two cannot quietly drift apart.
 #[test]
 fn every_case_in_this_table_is_also_asserted_in_typescript() {
-    let ts_test = std::fs::read_to_string(
-        concat!(env!("CARGO_MANIFEST_DIR"), "/../../packages/core/test/route-flavor-cv2.test.ts"),
-    )
+    let ts_test = std::fs::read_to_string(concat!(
+        env!("CARGO_MANIFEST_DIR"),
+        "/../../packages/core/test/route-flavor-cv2.test.ts"
+    ))
     .expect("the core route-flavour test must exist - it is the other half of this differential");
 
     let missing = EXPECTED
@@ -112,8 +119,14 @@ fn scanning_a_route_emits_its_flavour_as_a_fact() {
         })
     };
 
-    assert_eq!(flavor_of("app/api/users/route.ts").as_deref(), Some("api_route"));
-    assert_eq!(flavor_of("app/api/cron/rollup/route.ts").as_deref(), Some("cron_job"));
+    assert_eq!(
+        flavor_of("app/api/users/route.ts").as_deref(),
+        Some("api_route")
+    );
+    assert_eq!(
+        flavor_of("app/api/cron/rollup/route.ts").as_deref(),
+        Some("cron_job")
+    );
     assert_eq!(
         flavor_of("app/api/webhooks/stripe/route.ts").as_deref(),
         Some("webhook_handler")
@@ -140,7 +153,10 @@ fn a_non_route_file_gets_no_flavour_fact() {
         .iter()
         .filter(|fact| fact["kind"] == "route_flavor_detected")
         .count();
-    assert_eq!(flavors, 0, "a library module is not a route and has no flavour");
+    assert_eq!(
+        flavors, 0,
+        "a library module is not a route and has no flavour"
+    );
 }
 
 fn scan_repo(repo_root: &std::path::Path) -> serde_json::Value {
@@ -281,10 +297,30 @@ fn a_repo_with_no_flavour_signal_yields_one_unconditioned_family() {
     // matcher fingerprint - and so the candidate id - of every family on every repo that has no cron
     // routes, churning accepted contracts for nothing.
     let payload = infer(request_from_routes(&[
-        Route { path: "app/api/a/route.ts", symbol: "withSession", module: "@/lib/auth", flavor: "api_route" },
-        Route { path: "app/api/b/route.ts", symbol: "withSession", module: "@/lib/auth", flavor: "api_route" },
-        Route { path: "app/api/c/route.ts", symbol: "withWorkspace", module: "@/lib/auth", flavor: "api_route" },
-        Route { path: "app/api/d/route.ts", symbol: "withWorkspace", module: "@/lib/auth", flavor: "api_route" },
+        Route {
+            path: "app/api/a/route.ts",
+            symbol: "withSession",
+            module: "@/lib/auth",
+            flavor: "api_route",
+        },
+        Route {
+            path: "app/api/b/route.ts",
+            symbol: "withSession",
+            module: "@/lib/auth",
+            flavor: "api_route",
+        },
+        Route {
+            path: "app/api/c/route.ts",
+            symbol: "withWorkspace",
+            module: "@/lib/auth",
+            flavor: "api_route",
+        },
+        Route {
+            path: "app/api/d/route.ts",
+            symbol: "withWorkspace",
+            module: "@/lib/auth",
+            flavor: "api_route",
+        },
     ]));
 
     let found = families(&payload, AUTH);
@@ -302,12 +338,42 @@ fn a_cron_route_is_not_in_scope_for_the_session_family() {
     // The session family must be conditioned to app routes, or - accepted in block mode - it flags
     // every cron route for missing a wrapper it was never meant to use.
     let payload = infer(request_from_routes(&[
-        Route { path: "app/api/a/route.ts", symbol: "withSession", module: "@/lib/auth", flavor: "api_route" },
-        Route { path: "app/api/b/route.ts", symbol: "withSession", module: "@/lib/auth", flavor: "api_route" },
-        Route { path: "app/api/c/route.ts", symbol: "withWorkspace", module: "@/lib/auth", flavor: "api_route" },
-        Route { path: "app/api/d/route.ts", symbol: "withWorkspace", module: "@/lib/auth", flavor: "api_route" },
-        Route { path: "app/api/cron/e/route.ts", symbol: "verifyQstashSignature", module: "@/lib/cron", flavor: "cron_job" },
-        Route { path: "app/api/cron/f/route.ts", symbol: "verifyQstashSignature", module: "@/lib/cron", flavor: "cron_job" },
+        Route {
+            path: "app/api/a/route.ts",
+            symbol: "withSession",
+            module: "@/lib/auth",
+            flavor: "api_route",
+        },
+        Route {
+            path: "app/api/b/route.ts",
+            symbol: "withSession",
+            module: "@/lib/auth",
+            flavor: "api_route",
+        },
+        Route {
+            path: "app/api/c/route.ts",
+            symbol: "withWorkspace",
+            module: "@/lib/auth",
+            flavor: "api_route",
+        },
+        Route {
+            path: "app/api/d/route.ts",
+            symbol: "withWorkspace",
+            module: "@/lib/auth",
+            flavor: "api_route",
+        },
+        Route {
+            path: "app/api/cron/e/route.ts",
+            symbol: "verifyQstashSignature",
+            module: "@/lib/cron",
+            flavor: "cron_job",
+        },
+        Route {
+            path: "app/api/cron/f/route.ts",
+            symbol: "verifyQstashSignature",
+            module: "@/lib/cron",
+            flavor: "cron_job",
+        },
     ]));
 
     let session = families(&payload, AUTH)
@@ -332,12 +398,42 @@ fn each_flavour_is_scored_against_its_own_denominator() {
     // 2 of 2 app routes, not 2 of 6 files. Scored globally it would read 0.33 and look far weaker than
     // the convention actually is.
     let payload = infer(request_from_routes(&[
-        Route { path: "app/api/a/route.ts", symbol: "withSession", module: "@/lib/auth", flavor: "api_route" },
-        Route { path: "app/api/b/route.ts", symbol: "withSession", module: "@/lib/auth", flavor: "api_route" },
-        Route { path: "app/api/cron/c/route.ts", symbol: "verifyQstashSignature", module: "@/lib/cron", flavor: "cron_job" },
-        Route { path: "app/api/cron/d/route.ts", symbol: "verifyQstashSignature", module: "@/lib/cron", flavor: "cron_job" },
-        Route { path: "app/api/cron/e/route.ts", symbol: "verifyHmacSignature", module: "@/lib/cron", flavor: "cron_job" },
-        Route { path: "app/api/cron/f/route.ts", symbol: "verifyHmacSignature", module: "@/lib/cron", flavor: "cron_job" },
+        Route {
+            path: "app/api/a/route.ts",
+            symbol: "withSession",
+            module: "@/lib/auth",
+            flavor: "api_route",
+        },
+        Route {
+            path: "app/api/b/route.ts",
+            symbol: "withSession",
+            module: "@/lib/auth",
+            flavor: "api_route",
+        },
+        Route {
+            path: "app/api/cron/c/route.ts",
+            symbol: "verifyQstashSignature",
+            module: "@/lib/cron",
+            flavor: "cron_job",
+        },
+        Route {
+            path: "app/api/cron/d/route.ts",
+            symbol: "verifyQstashSignature",
+            module: "@/lib/cron",
+            flavor: "cron_job",
+        },
+        Route {
+            path: "app/api/cron/e/route.ts",
+            symbol: "verifyHmacSignature",
+            module: "@/lib/cron",
+            flavor: "cron_job",
+        },
+        Route {
+            path: "app/api/cron/f/route.ts",
+            symbol: "verifyHmacSignature",
+            module: "@/lib/cron",
+            flavor: "cron_job",
+        },
     ]));
 
     let cron = families(&payload, AUTH)
@@ -356,17 +452,49 @@ fn a_flavour_with_no_members_of_its_own_yields_no_family() {
     // Conditioning must not invent an empty family for a flavour the repo has but has no convention
     // for. Two cron routes with no shared helper produce no cron family - not one with zero members.
     let payload = infer(request_from_routes(&[
-        Route { path: "app/api/a/route.ts", symbol: "withSession", module: "@/lib/auth", flavor: "api_route" },
-        Route { path: "app/api/b/route.ts", symbol: "withSession", module: "@/lib/auth", flavor: "api_route" },
-        Route { path: "app/api/c/route.ts", symbol: "withWorkspace", module: "@/lib/auth", flavor: "api_route" },
-        Route { path: "app/api/d/route.ts", symbol: "withWorkspace", module: "@/lib/auth", flavor: "api_route" },
-        Route { path: "app/api/cron/e/route.ts", symbol: "runRollup", module: "@/lib/jobs", flavor: "cron_job" },
-        Route { path: "app/api/cron/f/route.ts", symbol: "runDigest", module: "@/lib/jobs", flavor: "cron_job" },
+        Route {
+            path: "app/api/a/route.ts",
+            symbol: "withSession",
+            module: "@/lib/auth",
+            flavor: "api_route",
+        },
+        Route {
+            path: "app/api/b/route.ts",
+            symbol: "withSession",
+            module: "@/lib/auth",
+            flavor: "api_route",
+        },
+        Route {
+            path: "app/api/c/route.ts",
+            symbol: "withWorkspace",
+            module: "@/lib/auth",
+            flavor: "api_route",
+        },
+        Route {
+            path: "app/api/d/route.ts",
+            symbol: "withWorkspace",
+            module: "@/lib/auth",
+            flavor: "api_route",
+        },
+        Route {
+            path: "app/api/cron/e/route.ts",
+            symbol: "runRollup",
+            module: "@/lib/jobs",
+            flavor: "cron_job",
+        },
+        Route {
+            path: "app/api/cron/f/route.ts",
+            symbol: "runDigest",
+            module: "@/lib/jobs",
+            flavor: "cron_job",
+        },
     ]));
 
     let found = families(&payload, AUTH);
     assert!(
-        found.iter().all(|(_, flavor, _)| flavor.as_deref() != Some("cron_job")),
+        found
+            .iter()
+            .all(|(_, flavor, _)| flavor.as_deref() != Some("cron_job")),
         "no cron family should exist - neither cron helper repeats across two files: {found:?}"
     );
 }
@@ -376,12 +504,42 @@ fn a_helper_used_in_two_flavours_belongs_to_both_families() {
     // Assignment follows the evidence. A wrapper genuinely used on app and cron routes is a member of
     // each family, and pretending otherwise would understate one of them.
     let payload = infer(request_from_routes(&[
-        Route { path: "app/api/a/route.ts", symbol: "withSession", module: "@/lib/auth", flavor: "api_route" },
-        Route { path: "app/api/b/route.ts", symbol: "withSession", module: "@/lib/auth", flavor: "api_route" },
-        Route { path: "app/api/c/route.ts", symbol: "withAudit", module: "@/lib/auth", flavor: "api_route" },
-        Route { path: "app/api/cron/d/route.ts", symbol: "withAudit", module: "@/lib/auth", flavor: "cron_job" },
-        Route { path: "app/api/cron/e/route.ts", symbol: "withSession", module: "@/lib/auth", flavor: "cron_job" },
-        Route { path: "app/api/cron/f/route.ts", symbol: "withAudit", module: "@/lib/auth", flavor: "cron_job" },
+        Route {
+            path: "app/api/a/route.ts",
+            symbol: "withSession",
+            module: "@/lib/auth",
+            flavor: "api_route",
+        },
+        Route {
+            path: "app/api/b/route.ts",
+            symbol: "withSession",
+            module: "@/lib/auth",
+            flavor: "api_route",
+        },
+        Route {
+            path: "app/api/c/route.ts",
+            symbol: "withAudit",
+            module: "@/lib/auth",
+            flavor: "api_route",
+        },
+        Route {
+            path: "app/api/cron/d/route.ts",
+            symbol: "withAudit",
+            module: "@/lib/auth",
+            flavor: "cron_job",
+        },
+        Route {
+            path: "app/api/cron/e/route.ts",
+            symbol: "withSession",
+            module: "@/lib/auth",
+            flavor: "cron_job",
+        },
+        Route {
+            path: "app/api/cron/f/route.ts",
+            symbol: "withAudit",
+            module: "@/lib/auth",
+            flavor: "cron_job",
+        },
     ]));
 
     let found = families(&payload, AUTH);
@@ -399,14 +557,54 @@ fn a_helper_used_in_two_flavours_belongs_to_both_families() {
 fn family_candidate_ids_stay_stable_across_runs_when_conditioned() {
     let build = || {
         request_from_routes(&[
-            Route { path: "app/api/a/route.ts", symbol: "withSession", module: "@/lib/auth", flavor: "api_route" },
-            Route { path: "app/api/b/route.ts", symbol: "withSession", module: "@/lib/auth", flavor: "api_route" },
-            Route { path: "app/api/c/route.ts", symbol: "withWorkspace", module: "@/lib/auth", flavor: "api_route" },
-            Route { path: "app/api/d/route.ts", symbol: "withWorkspace", module: "@/lib/auth", flavor: "api_route" },
-            Route { path: "app/api/cron/e/route.ts", symbol: "verifyHmacSignature", module: "@/lib/cron", flavor: "cron_job" },
-            Route { path: "app/api/cron/f/route.ts", symbol: "verifyHmacSignature", module: "@/lib/cron", flavor: "cron_job" },
-            Route { path: "app/api/cron/g/route.ts", symbol: "verifyWebhookSignature", module: "@/lib/cron", flavor: "cron_job" },
-            Route { path: "app/api/cron/h/route.ts", symbol: "verifyWebhookSignature", module: "@/lib/cron", flavor: "cron_job" },
+            Route {
+                path: "app/api/a/route.ts",
+                symbol: "withSession",
+                module: "@/lib/auth",
+                flavor: "api_route",
+            },
+            Route {
+                path: "app/api/b/route.ts",
+                symbol: "withSession",
+                module: "@/lib/auth",
+                flavor: "api_route",
+            },
+            Route {
+                path: "app/api/c/route.ts",
+                symbol: "withWorkspace",
+                module: "@/lib/auth",
+                flavor: "api_route",
+            },
+            Route {
+                path: "app/api/d/route.ts",
+                symbol: "withWorkspace",
+                module: "@/lib/auth",
+                flavor: "api_route",
+            },
+            Route {
+                path: "app/api/cron/e/route.ts",
+                symbol: "verifyHmacSignature",
+                module: "@/lib/cron",
+                flavor: "cron_job",
+            },
+            Route {
+                path: "app/api/cron/f/route.ts",
+                symbol: "verifyHmacSignature",
+                module: "@/lib/cron",
+                flavor: "cron_job",
+            },
+            Route {
+                path: "app/api/cron/g/route.ts",
+                symbol: "verifyWebhookSignature",
+                module: "@/lib/cron",
+                flavor: "cron_job",
+            },
+            Route {
+                path: "app/api/cron/h/route.ts",
+                symbol: "verifyWebhookSignature",
+                module: "@/lib/cron",
+                flavor: "cron_job",
+            },
         ])
     };
     let ids = |payload: &Value| {

--- a/test/e2e/golden.test.ts
+++ b/test/e2e/golden.test.ts
@@ -38,7 +38,7 @@ describe("golden fixture CLI lifecycle", () => {
           "api_route_requires_service_delegation",
         ],
         "engine_source": "rust",
-        "facts_count": 9,
+        "facts_count": 10,
         "files_indexed": 1,
       }
     `);
@@ -281,7 +281,7 @@ describe("golden realistic repo evidence", () => {
         ],
         "diagnostics_count": 0,
         "engine_source": "rust",
-        "facts_count": 17,
+        "facts_count": 18,
         "files_indexed": 3,
       }
     `);
@@ -292,7 +292,7 @@ describe("golden realistic repo evidence", () => {
         ],
         "diagnostics_count": 0,
         "engine_source": "rust",
-        "facts_count": 17,
+        "facts_count": 18,
         "files_indexed": 2,
       }
     `);

--- a/test/e2e/release-hygiene.test.ts
+++ b/test/e2e/release-hygiene.test.ts
@@ -19,7 +19,16 @@ describe("release hygiene", () => {
     expect(manifest.private).toBe(true);
     expect(manifest.packageManager).toBe("pnpm@10.28.0");
     expect(manifest.engines?.node).toBe(">=20.0.0");
-    expect(manifest.scripts.verify).toBe("pnpm build && pnpm typecheck && pnpm test && pnpm test:e2e");
+    // The release engine is a fixture of the test suite, not an optional convenience: four CLI
+    // test files point DRIFT_ENGINE_BIN at target/release/drift-engine and fail without it.
+    // Nothing built it, because `pnpm test:engine` is `cargo test` and that produces a debug
+    // binary. It went unnoticed for as long as it did because a developer machine always has one
+    // lying around from an eval run; the first clean runner to execute the suite failed ten tests
+    // on it. `pnpm verify` declares the dependency so a fresh clone can run the gate.
+    expect(manifest.scripts.verify).toBe(
+      "pnpm build:engine && pnpm build && pnpm typecheck && pnpm test && pnpm test:e2e"
+    );
+    expect(manifest.scripts["build:engine"]).toBe("cargo build --release -p drift-engine");
     expect(manifest.scripts["format:engine"]).toBe("cargo fmt --all");
     expect(manifest.scripts["format:engine:check"]).toBe("cargo fmt --all -- --check");
     expect(manifest.scripts["lint:engine"]).toBe("cargo clippy -p drift-engine --all-targets -- -D warnings");
@@ -41,8 +50,19 @@ describe("release hygiene", () => {
       // number - so the gate now fails on a rise and names the delta.
       // EW-7 added `pnpm eval:determinism`: determinism is the marketed claim, and it was only ever
       // measured by hand on two of the seven repos.
-      "pnpm verify && pnpm test:harness && pnpm format:engine:check && pnpm lint:engine && pnpm check:boundaries && node scripts/validate-engine-release-matrix.mjs --allow-unverified && pnpm validate:claims && pnpm beta:proof && pnpm eval:external && pnpm eval:evasion && pnpm eval:bench && pnpm eval:determinism && git diff --check",
+      //
+      // PR #102 took the four eval steps back out, and the reason matters. A hosted runner has none
+      // of the seven pinned evaluation repos and no release engine binary, and the battery does not
+      // fit in the job timeout - so from the moment CI existed, those four steps could not run
+      // there. Listing them did not execute them; it produced a gate that named an oracle it never
+      // consulted. They now live in `verify:evals`, which is a LOCAL gate, and `verify:full` is the
+      // union that any "verified" claim has to cite.
+      "pnpm verify && pnpm test:harness && pnpm format:engine:check && pnpm lint:engine && pnpm check:boundaries && node scripts/validate-engine-release-matrix.mjs --allow-unverified && pnpm validate:claims && pnpm beta:proof && git diff --check",
     );
+    expect(manifest.scripts["verify:evals"]).toBe(
+      "pnpm eval:external && pnpm eval:evasion && pnpm eval:bench && pnpm eval:determinism"
+    );
+    expect(manifest.scripts["verify:full"]).toBe("pnpm verify:ci && pnpm verify:evals");
     expect(manifest.scripts["eval:evasion"]).toBe("node scripts/evasion-matrix.mjs");
     expect(manifest.scripts["eval:bench"]).toBe("node scripts/beta-bench.mjs");
     expect(manifest.scripts["eval:determinism"]).toBe("node scripts/determinism.mjs");


### PR DESCRIPTION
…te-flavour baseline change

Three failures from the first e2e run a clean machine has done since May.

1. beta:proof exited 3 - refused - because actions/checkout defaults to depth 1 and Drift refuses to derive repo identity in a shallow clone. That refusal is correct and is the product's own documented CI requirement (docs/ci-integration.md, fetch-depth: 0); it simply had never been applied to the product's own CI. Not a bug in Drift. A bug in this workflow.

2. release-hygiene pins the gate definition string-for-string, and #102/#103 changed the gate without updating it. My regression. The pins now match, verify:evals and verify:full and build:engine are pinned too so the split is guarded the same way the original chain was, and the comment block records why the four eval steps left verify:ci.

3. The golden inline snapshots were stale on main by exactly one fact per Next.js route. Mechanism: the CV sprint's route_flavor_detected fact (candidate_command.rs:975, landed c2325cdb), which emits once per route file. next-api-direct-db 9 -> 10 (1 route), next-prisma-clean-service 17 -> 18 (1 route in 3 files), next-non-prisma-fetch-service 17 -> 18 (1 route in 2 files). node-express-api is unchanged, which is the control: it has no Next.js route, so it gains no flavour fact. No other field in any snapshot moved - not candidate_kinds, files_indexed, or diagnostics_count.

   This is a BASELINE_CHANGE with a known mechanism, not a snapshot bump to make a gate quiet. It was invisible because CI was dead and the eval battery does not cover these e2e goldens.

## Summary

- 

## Verification

- [ ] `pnpm verify:ci`

## Drift Boundaries

- [ ] Rust remains deterministic parser/rule authority for engine behavior.
- [ ] TypeScript changes stay in orchestration, governance, policy, storage, query, or formatting layers.
- [ ] No source snippets or secrets are added to outputs, logs, fixtures, docs, or MCP payloads.
- [ ] Agent-facing JSON includes policy/redaction/freshness metadata where applicable.

## Notes

- 
