### PR TITLE
fix(engine,cli): forbidden-import predicate boundaries, coverage gaps, strict-contract status, toolchain pin

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -46,8 +46,16 @@ jobs:
           cache: pnpm
           cache-dependency-path: pnpm-lock.yaml
 
+      # Pinned, and stated here because dtolnay/rust-toolchain needs it as an input. It MUST match
+      # rust-toolchain.toml, which is what developer machines read - two copies of a version is the
+      # same drift hazard as two copies of a predicate, so release-hygiene.test.ts fails if they
+      # disagree. `@stable` used to float here, and a new clippy lint reddened this gate with no
+      # change to the repository at all.
       - name: Setup Rust
-        uses: dtolnay/rust-toolchain@stable
+        uses: dtolnay/rust-toolchain@master
+        with:
+          toolchain: "1.97.0"
+          components: rustfmt, clippy
 
       - name: Install dependencies
         run: pnpm install --frozen-lockfile

--- a/crates/drift-engine/src/check_command.rs
+++ b/crates/drift-engine/src/check_command.rs
@@ -3617,12 +3617,31 @@ fn is_forbidden_graph_import(
         return true;
     }
     let import_source = string_metadata(import_node, "source").unwrap_or("");
-    forbidden_imports.iter().any(|forbidden| {
-        resolved_path == forbidden
-            || resolved_path.contains(forbidden)
-            || import_source == forbidden
-            || import_source.contains(forbidden)
-    })
+    if is_forbidden_import_source(import_source, forbidden_imports) {
+        return true;
+    }
+    forbidden_imports
+        .iter()
+        .any(|forbidden| path_is_forbidden_module(resolved_path, forbidden))
+}
+
+/// Does this resolved file path name the forbidden module?
+///
+/// A forbidden entry written as a path is usually extensionless - `src/lib/db` for the file
+/// `src/lib/db.ts`, or for `src/lib/db/index.ts` - so equality alone is not enough and the code
+/// here used a bare `contains` to bridge the gap. That let the entry match anything it was merely
+/// a prefix of: `src/lib/db` accepted `src/lib/db-legacy.ts` and `src/lib/dbutils.ts`, flagging
+/// routes that import neither the data layer nor anything that re-exports it.
+///
+/// The boundary is what distinguishes them. `src/lib/db` continues into the real module at `.` (an
+/// extension) or `/` (a directory), and into a lookalike at an ordinary name character. This is the
+/// same reasoning as `rules::is_forbidden_import`, which cannot simply be reused because a
+/// specifier must NOT break on `.`: `@/lib/db` and `@/lib/db.server` are different modules.
+fn path_is_forbidden_module(resolved_path: &str, forbidden: &str) -> bool {
+    resolved_path == forbidden
+        || resolved_path
+            .strip_prefix(forbidden)
+            .is_some_and(|rest| rest.starts_with('/') || rest.starts_with('.'))
 }
 
 fn forbidden_graph_import_target<'a>(
@@ -3664,7 +3683,7 @@ fn forbidden_graph_import_target<'a>(
             if forbidden_module_paths.contains(target_path)
                 || forbidden_imports
                     .iter()
-                    .any(|forbidden| target_path == forbidden || target_path.contains(forbidden))
+                    .any(|forbidden| path_is_forbidden_module(target_path, forbidden))
             {
                 return Some((edge.to.as_str(), target_path, next_chain));
             }
@@ -3674,10 +3693,21 @@ fn forbidden_graph_import_target<'a>(
     None
 }
 
+/// One predicate for "is this specifier a forbidden one", shared with the direct rule.
+///
+/// This used to be a second, laxer copy: `import_source.contains(forbidden)`. T100 fixed the
+/// direct rule's copy (`rules::is_forbidden_import`) to require a path-segment boundary and left
+/// this one alone, so the two disagreed - and the graph loop uses this one as a *skip*-filter, on
+/// the reasoning that a direct specifier match is the direct rule's job. `@/lib/db-legacy`
+/// substring-matched here and got skipped, while the direct rule correctly declined to match it,
+/// so a barrel re-exporting the real data layer was examined by neither path.
+///
+/// It is also the derivation filter for `forbidden_module_paths` a few lines up, where the same
+/// laxity ran the other way: a lookalike's resolved file was recorded as if it were the forbidden
+/// module, which is the false positive the comment there claims cannot happen. Both directions
+/// close by deleting the copy.
 fn is_forbidden_import_source(import_source: &str, forbidden_imports: &[String]) -> bool {
-    forbidden_imports
-        .iter()
-        .any(|forbidden| import_source == forbidden || import_source.contains(forbidden))
+    drift_engine::is_forbidden_import(import_source, forbidden_imports)
 }
 
 fn enforcement_result_for_mode(mode: EnforcementMode) -> drift_engine::EnforcementResult {

--- a/crates/drift-engine/src/lib.rs
+++ b/crates/drift-engine/src/lib.rs
@@ -32,7 +32,7 @@ pub use rules::{
     BaselineStatus, BaselineViolation, ClassifiedFinding, DirectDataAccessRule,
     DirectDataAccessViolation, EnforcementMode, EnforcementResult, FindingStatus, RuleFinding,
     Severity, classify_findings_against_baseline, detect_direct_data_access_imports,
-    materialize_direct_data_access_findings,
+    is_forbidden_import, materialize_direct_data_access_findings,
 };
 pub use security_capabilities::{
     SecurityCapabilityStatus, SecurityScanCapability, security_capabilities,

--- a/crates/drift-engine/src/main.rs
+++ b/crates/drift-engine/src/main.rs
@@ -32,6 +32,13 @@ struct ScanFilesResult {
     /// Files that could not be read or parsed. Surfaced in the scan summary so partial
     /// coverage is reported rather than silently presented as complete.
     files_skipped_unreadable: usize,
+    /// Files skipped for exceeding MAX_FILE_BYTES.
+    ///
+    /// These were counted nowhere. The oversize branch emits a `file_too_large` diagnostic and
+    /// returns `Ok(None)`, which landed in an empty match arm, so a skipped 2 MB route left the
+    /// scan reporting complete coverage - the same overstatement `files_skipped_unreadable` exists
+    /// to prevent, one branch over.
+    files_skipped_too_large: usize,
 }
 
 struct ReuseIndex {
@@ -220,7 +227,10 @@ fn scan_repo(
         framework_capabilities: framework_scan_data.capabilities,
         diagnostics,
         stats,
-        completeness: repo_completeness(scanned.files_skipped_unreadable),
+        completeness: repo_completeness(
+            scanned.files_skipped_unreadable,
+            scanned.files_skipped_too_large,
+        ),
     })
 }
 
@@ -408,7 +418,10 @@ fn stream_scan_repo(
         &ScanStreamEvent::ScanCompleted {
             schema_version: ENGINE_STREAM_EVENT_SCHEMA_VERSION,
             stats,
-            completeness: repo_completeness(scanned.files_skipped_unreadable),
+            completeness: repo_completeness(
+                scanned.files_skipped_unreadable,
+                scanned.files_skipped_too_large,
+            ),
         },
     )?;
     stdout.flush()?;
@@ -535,7 +548,10 @@ fn scan_files(
                 }
                 result.scanned.push((file, facts));
             }
-            Ok(None) => {}
+            // The only `Ok(None)` from scan_file_with_reuse is the oversize skip.
+            Ok(None) => {
+                result.files_skipped_too_large += 1;
+            }
             Err(error) => {
                 diagnostics.push(EngineDiagnostic {
                     severity: "warning".to_string(),

--- a/crates/drift-engine/src/main.rs
+++ b/crates/drift-engine/src/main.rs
@@ -190,6 +190,7 @@ fn scan_repo(
     let framework_scan_data = collect_framework_scan_data(&repo_id, &scan_id, &scanned.scanned);
     resolver.exported_symbols = exported_symbols_by_file(&scanned.scanned);
     resolver.export_star_sources = export_star_sources_by_file(&scanned.scanned);
+    retain_scanned_snapshot_paths(&mut resolver, &scanned.scanned);
     for (file, file_facts) in scanned.scanned {
         let graph = graph_for_file(&repo_id, &scan_id, &file, &file_facts, &resolver);
         graph_node_count += graph.nodes.len();
@@ -300,6 +301,7 @@ fn stream_scan_repo(
     }
     resolver.exported_symbols = exported_symbols_by_file(&scanned.scanned);
     resolver.export_star_sources = export_star_sources_by_file(&scanned.scanned);
+    retain_scanned_snapshot_paths(&mut resolver, &scanned.scanned);
     if !framework_scan_data.adapters.is_empty() {
         write_event(
             &mut stdout,
@@ -919,6 +921,34 @@ struct JsTsResolutionConfig {
     aliases: BTreeMap<String, Vec<String>>,
     base_url: Option<String>,
     effective_base_url: String,
+}
+
+/// Resolve against what was read, not against what was found.
+///
+/// `snapshot_paths` is built from the *discovered* file list, before scanning, while the graph is
+/// built from the files that were actually scanned. Anything discovered but skipped - unreadable
+/// bytes, over MAX_FILE_BYTES - falls into the gap between those two sets, and the gap is silent in
+/// the worst possible way: `resolve_import` answers "yes, that is the module", no module node
+/// exists for it, so the IMPORT_RESOLVES_TO_MODULE edge is never created and no `unresolved_import`
+/// diagnostic is emitted either. The import simply evaporates.
+///
+/// Measured: a route importing `@/lib/secret`, whose file is non-UTF-8, produced
+/// `partial_coverage: {complete: true, reasons: []}` - while the same route importing a module that
+/// does not exist at all correctly produced `unresolved_route_import`. The honest case was the one
+/// that reported; the dangerous case was the one that stayed quiet, because `lib/secret.ts` could
+/// be the data layer and nothing would ever say Drift had not looked at it.
+///
+/// Narrowing the set here means those imports are simply unresolved, which they are, and the
+/// existing coverage-gap machinery reports them against the importing route - already scoped to the
+/// diff, already understood by every consumer. No new diagnostic kind, no second resolver.
+fn retain_scanned_snapshot_paths(resolver: &mut ResolverContext, scanned: &[ScannedFileFacts]) {
+    let scanned_paths = scanned
+        .iter()
+        .map(|(file, _)| file.file_path.clone())
+        .collect::<BTreeSet<String>>();
+    resolver
+        .snapshot_paths
+        .retain(|path| scanned_paths.contains(path));
 }
 
 fn graph_for_file(

--- a/crates/drift-engine/src/protocol.rs
+++ b/crates/drift-engine/src/protocol.rs
@@ -739,22 +739,35 @@ pub fn engine_stats(
 ///
 /// `files_skipped_unreadable` is the count of files that could not be read or parsed
 /// during discovery. Any skipped file means syntax facts are incomplete for the repo.
-pub fn repo_completeness(files_skipped_unreadable: usize) -> Vec<EngineCompleteness> {
+pub fn repo_completeness(
+    files_skipped_unreadable: usize,
+    files_skipped_too_large: usize,
+) -> Vec<EngineCompleteness> {
     let required = vec![
         "file_discovery".to_string(),
         "syntax_facts".to_string(),
         "graph_stream".to_string(),
     ];
-    let complete = files_skipped_unreadable == 0;
+    let complete = files_skipped_unreadable == 0 && files_skipped_too_large == 0;
     let (missing_capabilities, reasons) = if complete {
         (Vec::new(), Vec::new())
     } else {
-        (
-            vec!["syntax_facts".to_string()],
-            vec![format!(
+        // Two reasons rather than one total, because they call for different responses: an
+        // unreadable file is usually a mistake worth fixing, an oversized one is usually a
+        // generated artifact worth excluding. A single "n files skipped" makes the reader go
+        // find out which.
+        let mut reasons = Vec::new();
+        if files_skipped_unreadable > 0 {
+            reasons.push(format!(
                 "{files_skipped_unreadable} file(s) could not be read or parsed and were skipped"
-            )],
-        )
+            ));
+        }
+        if files_skipped_too_large > 0 {
+            reasons.push(format!(
+                "{files_skipped_too_large} file(s) exceeded the {MAX_FILE_BYTES} byte scan limit and were skipped"
+            ));
+        }
+        (vec!["syntax_facts".to_string()], reasons)
     };
     vec![EngineCompleteness {
         scope: "repo".to_string(),
@@ -813,16 +826,38 @@ mod completeness_tests {
     /// or - had the abort been removed alone - a silent claim of full coverage.
     #[test]
     fn repo_completeness_reports_skipped_files() {
-        let clean = &repo_completeness(0)[0];
+        let clean = &repo_completeness(0, 0)[0];
         assert!(clean.complete);
         assert!(clean.missing_capabilities.is_empty());
         assert!(clean.reasons.is_empty());
 
-        let degraded = &repo_completeness(3)[0];
+        let degraded = &repo_completeness(3, 0)[0];
         assert!(!degraded.complete);
         assert_eq!(degraded.missing_capabilities, vec!["syntax_facts"]);
         assert_eq!(degraded.reasons.len(), 1);
         // Findings that were produced are still trustworthy, so blocking stays available.
         assert!(degraded.can_block);
+    }
+
+    /// An oversized file is a file the scan did not read, and it was counted nowhere.
+    ///
+    /// The oversize branch returns `Ok(None)`, which the caller matched with an empty arm, so a
+    /// skipped 2 MB route left this reporting `complete: true` - the exact overstatement the
+    /// unreadable counter above exists to prevent, arriving one branch over.
+    #[test]
+    fn repo_completeness_reports_files_skipped_for_size() {
+        let oversized = &repo_completeness(0, 2)[0];
+        assert!(!oversized.complete);
+        assert_eq!(oversized.missing_capabilities, vec!["syntax_facts"]);
+        assert_eq!(oversized.reasons.len(), 1);
+        assert!(oversized.reasons[0].contains("scan limit"));
+        assert!(oversized.can_block);
+
+        // Both kinds are named separately: unreadable is usually a mistake to fix, oversized is
+        // usually a generated artifact to exclude, and one merged count makes the reader go and
+        // find out which they have.
+        let both = &repo_completeness(1, 1)[0];
+        assert!(!both.complete);
+        assert_eq!(both.reasons.len(), 2);
     }
 }

--- a/crates/drift-engine/tests/graph_backed_check.rs
+++ b/crates/drift-engine/tests/graph_backed_check.rs
@@ -1,4 +1,5 @@
 use std::{
+    collections::BTreeSet,
     io::Write,
     process::{Command, Stdio},
 };
@@ -441,6 +442,273 @@ fn check_repo_flags_direct_data_access_hidden_behind_barrel_reexport() {
             .expect("related nodes")
             .iter()
             .any(|node| node == "module:src/db/client.ts")
+    );
+}
+
+/// A barrel whose specifier merely *starts with* a forbidden one must not buy immunity.
+///
+/// `is_forbidden_import_source` matched with a bare `contains`, and the graph loop uses it as a
+/// skip-filter: any import whose specifier substring-matched a forbidden entry was treated as
+/// "already handled by the direct rule" and skipped. `@/lib/db-legacy` contains `@/lib/db`, so it
+/// was skipped here - and the direct rule (`rules::is_forbidden_import`, segment-boundary since
+/// T100) correctly does not match it either. Neither path examined the import, so a barrel
+/// re-exporting the real data layer passed clean. Strictly worse than matching nothing at all,
+/// because the lookalike name is what earned the exemption.
+#[test]
+fn check_repo_flags_a_barrel_whose_specifier_is_a_prefix_of_a_forbidden_one() {
+    let request = json!({
+        "repo": { "repo_id": "repo_abc" },
+        "graph": {
+            "graph_nodes": [
+                graph_node("file:app/api/direct/route.ts", "file", "app/api/direct/route.ts", json!({ "path": "app/api/direct/route.ts" })),
+                graph_node("file:app/api/laundered/route.ts", "file", "app/api/laundered/route.ts", json!({ "path": "app/api/laundered/route.ts" })),
+                graph_node("file:src/db/client.ts", "file", "src/db/client.ts", json!({ "path": "src/db/client.ts" })),
+                graph_node("file:src/db-legacy/index.ts", "file", "src/db-legacy/index.ts", json!({ "path": "src/db-legacy/index.ts" })),
+                graph_node("file_role:api_route", "file_role", "api_route", json!({ "role": "api_route" })),
+                graph_node("module:app/api/direct/route.ts", "module", "app/api/direct/route.ts", json!({ "file_path": "app/api/direct/route.ts" })),
+                graph_node("module:app/api/laundered/route.ts", "module", "app/api/laundered/route.ts", json!({ "file_path": "app/api/laundered/route.ts" })),
+                graph_node("module:src/db/client.ts", "module", "src/db/client.ts", json!({ "file_path": "src/db/client.ts" })),
+                graph_node("module:src/db-legacy/index.ts", "module", "src/db-legacy/index.ts", json!({ "file_path": "src/db-legacy/index.ts" })),
+                graph_node("import_decl:app/api/direct/route.ts:db", "import_decl", "db from @/lib/db", json!({
+                    "file_path": "app/api/direct/route.ts",
+                    "source": "@/lib/db",
+                    "local_name": "db"
+                })),
+                graph_node("import_decl:app/api/laundered/route.ts:db", "import_decl", "db from @/lib/db-legacy", json!({
+                    "file_path": "app/api/laundered/route.ts",
+                    "source": "@/lib/db-legacy",
+                    "local_name": "db"
+                })),
+                graph_node("file:app/api/innocent/route.ts", "file", "app/api/innocent/route.ts", json!({ "path": "app/api/innocent/route.ts" })),
+                graph_node("file:src/dbutils.ts", "file", "src/dbutils.ts", json!({ "path": "src/dbutils.ts" })),
+                graph_node("module:app/api/innocent/route.ts", "module", "app/api/innocent/route.ts", json!({ "file_path": "app/api/innocent/route.ts" })),
+                graph_node("module:src/dbutils.ts", "module", "src/dbutils.ts", json!({ "file_path": "src/dbutils.ts" })),
+                graph_node("import_decl:app/api/innocent/route.ts:dbutils", "import_decl", "dbutils from @/lib/dbutils", json!({
+                    "file_path": "app/api/innocent/route.ts",
+                    "source": "@/lib/dbutils",
+                    "local_name": "dbutils"
+                }))
+            ],
+            "graph_edges": [
+                graph_edge("FILE_HAS_ROLE", "file:app/api/direct/route.ts", "file_role:api_route"),
+                graph_edge("FILE_HAS_ROLE", "file:app/api/laundered/route.ts", "file_role:api_route"),
+                graph_edge("FILE_DEFINES_MODULE", "file:app/api/direct/route.ts", "module:app/api/direct/route.ts"),
+                graph_edge("FILE_DEFINES_MODULE", "file:app/api/laundered/route.ts", "module:app/api/laundered/route.ts"),
+                graph_edge("FILE_DEFINES_MODULE", "file:src/db/client.ts", "module:src/db/client.ts"),
+                graph_edge("FILE_DEFINES_MODULE", "file:src/db-legacy/index.ts", "module:src/db-legacy/index.ts"),
+                graph_edge_with_evidence("IMPORT_DECL_REFERENCES_MODULE", "import_decl:app/api/direct/route.ts:db", "module:app/api/direct/route.ts", "evidence_import"),
+                graph_edge_with_evidence("IMPORT_RESOLVES_TO_MODULE", "import_decl:app/api/direct/route.ts:db", "module:src/db/client.ts", "evidence_import"),
+                graph_edge_with_evidence("IMPORT_DECL_REFERENCES_MODULE", "import_decl:app/api/laundered/route.ts:db", "module:app/api/laundered/route.ts", "evidence_laundered"),
+                graph_edge_with_evidence("IMPORT_RESOLVES_TO_MODULE", "import_decl:app/api/laundered/route.ts:db", "module:src/db-legacy/index.ts", "evidence_laundered"),
+                graph_edge("MODULE_REEXPORTS_MODULE", "module:src/db-legacy/index.ts", "module:src/db/client.ts"),
+                graph_edge("FILE_HAS_ROLE", "file:app/api/innocent/route.ts", "file_role:api_route"),
+                graph_edge("FILE_DEFINES_MODULE", "file:app/api/innocent/route.ts", "module:app/api/innocent/route.ts"),
+                graph_edge("FILE_DEFINES_MODULE", "file:src/dbutils.ts", "module:src/dbutils.ts"),
+                graph_edge_with_evidence("IMPORT_DECL_REFERENCES_MODULE", "import_decl:app/api/innocent/route.ts:dbutils", "module:app/api/innocent/route.ts", "evidence_innocent"),
+                graph_edge_with_evidence("IMPORT_RESOLVES_TO_MODULE", "import_decl:app/api/innocent/route.ts:dbutils", "module:src/dbutils.ts", "evidence_innocent")
+            ],
+            "graph_evidence": [{
+                "id": "evidence_import",
+                "repo_id": "repo_abc",
+                "scan_id": "scan_abc",
+                "artifact_id": "file_version:app/api/direct/route.ts:aaaaaaaaaaaa",
+                "file_path": "app/api/direct/route.ts",
+                "file_hash": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+                "start_line": 1,
+                "end_line": 1,
+                "adapter_id": "typescript",
+                "adapter_version": "0.1.0",
+                "fact_ids": ["fact_import"],
+                "redaction_state": "none"
+            }, {
+                "id": "evidence_laundered",
+                "repo_id": "repo_abc",
+                "scan_id": "scan_abc",
+                "artifact_id": "file_version:app/api/laundered/route.ts:bbbbbbbbbbbb",
+                "file_path": "app/api/laundered/route.ts",
+                "file_hash": "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
+                "start_line": 1,
+                "end_line": 1,
+                "adapter_id": "typescript",
+                "adapter_version": "0.1.0",
+                "fact_ids": ["fact_import_laundered"],
+                "redaction_state": "none"
+            }, {
+                "id": "evidence_innocent",
+                "repo_id": "repo_abc",
+                "scan_id": "scan_abc",
+                "artifact_id": "file_version:app/api/innocent/route.ts:cccccccccccc",
+                "file_path": "app/api/innocent/route.ts",
+                "file_hash": "cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc",
+                "start_line": 1,
+                "end_line": 1,
+                "adapter_id": "typescript",
+                "adapter_version": "0.1.0",
+                "fact_ids": ["fact_import_innocent"],
+                "redaction_state": "none"
+            }]
+        },
+        "scan": { "scan_id": "scan_abc", "facts": [] },
+        "contract": {
+            "conventions": [{
+                "id": "convention_graph_db",
+                "kind": "api_route_no_direct_data_access",
+                "matcher": { "forbidden_imports": ["@/lib/db"] },
+                "severity": "error",
+                "enforcement_mode": "block",
+                "enforcement_capability": "deterministic_check"
+            }]
+        },
+        "baseline": [],
+        "diff": { "mode": "full", "files": [] }
+    });
+    let payload = run_check(request);
+    let findings = payload["findings"].as_array().expect("findings");
+    let flagged = findings
+        .iter()
+        .flat_map(|finding| finding["evidence"].as_array().expect("evidence"))
+        .filter_map(|evidence| evidence["file_path"].as_str())
+        .collect::<BTreeSet<_>>();
+
+    assert!(
+        flagged.contains("app/api/laundered/route.ts"),
+        "the barrel route escaped because its specifier is a prefix of the forbidden one: {payload:#?}"
+    );
+    assert!(
+        !flagged.contains("app/api/innocent/route.ts"),
+        "@/lib/dbutils re-exports nothing forbidden and must not be flagged for sharing a prefix: {payload:#?}"
+    );
+
+    // Attribution, not just the verdict. The barrel route is a violation because the chain ends at
+    // src/db/client.ts - the file the forbidden specifier actually resolves to - and a message
+    // naming src/db-legacy/index.ts instead would mean it was caught by substring luck rather than
+    // by following the re-export, and would send the reader to a file that is not the data layer.
+    let laundered = findings
+        .iter()
+        .find(|finding| {
+            finding["evidence"]
+                .as_array()
+                .expect("evidence")
+                .iter()
+                .any(|evidence| evidence["file_path"] == "app/api/laundered/route.ts")
+        })
+        .expect("a finding on the laundered route");
+    assert!(
+        laundered["related_node_ids"]
+            .as_array()
+            .expect("related nodes")
+            .iter()
+            .any(|node| node == "module:src/db/client.ts"),
+        "the finding must name the real data-access module it re-exports: {laundered:#?}"
+    );
+}
+
+/// The same prefix bug, in the other predicate: a forbidden entry written as a *path*.
+///
+/// Entries are usually extensionless (`src/lib/db` for `src/lib/db.ts`), so identity matching
+/// bridged the gap with `resolved_path.contains(forbidden)` - which also accepts every file the
+/// entry is merely a prefix of. `src/lib/dbutils.ts` is not the data layer and re-exports nothing
+/// from it, and it was flagged anyway.
+///
+/// Both directions are asserted here on purpose. Tightening this predicate is what a fix looks
+/// like AND what an over-correction looks like, and only the real module being still caught tells
+/// the two apart.
+#[test]
+fn check_repo_separates_a_path_shaped_forbidden_entry_from_files_it_merely_prefixes() {
+    let request = json!({
+        "repo": { "repo_id": "repo_abc" },
+        "graph": {
+            "graph_nodes": [
+                graph_node("file:app/api/real/route.ts", "file", "app/api/real/route.ts", json!({ "path": "app/api/real/route.ts" })),
+                graph_node("file:app/api/utils/route.ts", "file", "app/api/utils/route.ts", json!({ "path": "app/api/utils/route.ts" })),
+                graph_node("file:src/lib/db.ts", "file", "src/lib/db.ts", json!({ "path": "src/lib/db.ts" })),
+                graph_node("file:src/lib/dbutils.ts", "file", "src/lib/dbutils.ts", json!({ "path": "src/lib/dbutils.ts" })),
+                graph_node("file_role:api_route", "file_role", "api_route", json!({ "role": "api_route" })),
+                graph_node("module:app/api/real/route.ts", "module", "app/api/real/route.ts", json!({ "file_path": "app/api/real/route.ts" })),
+                graph_node("module:app/api/utils/route.ts", "module", "app/api/utils/route.ts", json!({ "file_path": "app/api/utils/route.ts" })),
+                graph_node("module:src/lib/db.ts", "module", "src/lib/db.ts", json!({ "file_path": "src/lib/db.ts" })),
+                graph_node("module:src/lib/dbutils.ts", "module", "src/lib/dbutils.ts", json!({ "file_path": "src/lib/dbutils.ts" })),
+                graph_node("import_decl:app/api/real/route.ts:db", "import_decl", "db from @/lib/db", json!({
+                    "file_path": "app/api/real/route.ts",
+                    "source": "@/lib/db",
+                    "local_name": "db"
+                })),
+                graph_node("import_decl:app/api/utils/route.ts:helpers", "import_decl", "helpers from @/lib/dbutils", json!({
+                    "file_path": "app/api/utils/route.ts",
+                    "source": "@/lib/dbutils",
+                    "local_name": "helpers"
+                }))
+            ],
+            "graph_edges": [
+                graph_edge("FILE_HAS_ROLE", "file:app/api/real/route.ts", "file_role:api_route"),
+                graph_edge("FILE_HAS_ROLE", "file:app/api/utils/route.ts", "file_role:api_route"),
+                graph_edge("FILE_DEFINES_MODULE", "file:app/api/real/route.ts", "module:app/api/real/route.ts"),
+                graph_edge("FILE_DEFINES_MODULE", "file:app/api/utils/route.ts", "module:app/api/utils/route.ts"),
+                graph_edge("FILE_DEFINES_MODULE", "file:src/lib/db.ts", "module:src/lib/db.ts"),
+                graph_edge("FILE_DEFINES_MODULE", "file:src/lib/dbutils.ts", "module:src/lib/dbutils.ts"),
+                graph_edge_with_evidence("IMPORT_DECL_REFERENCES_MODULE", "import_decl:app/api/real/route.ts:db", "module:app/api/real/route.ts", "evidence_real"),
+                graph_edge_with_evidence("IMPORT_RESOLVES_TO_MODULE", "import_decl:app/api/real/route.ts:db", "module:src/lib/db.ts", "evidence_real"),
+                graph_edge_with_evidence("IMPORT_DECL_REFERENCES_MODULE", "import_decl:app/api/utils/route.ts:helpers", "module:app/api/utils/route.ts", "evidence_utils"),
+                graph_edge_with_evidence("IMPORT_RESOLVES_TO_MODULE", "import_decl:app/api/utils/route.ts:helpers", "module:src/lib/dbutils.ts", "evidence_utils")
+            ],
+            "graph_evidence": [{
+                "id": "evidence_real",
+                "repo_id": "repo_abc",
+                "scan_id": "scan_abc",
+                "artifact_id": "file_version:app/api/real/route.ts:aaaaaaaaaaaa",
+                "file_path": "app/api/real/route.ts",
+                "file_hash": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+                "start_line": 1,
+                "end_line": 1,
+                "adapter_id": "typescript",
+                "adapter_version": "0.1.0",
+                "fact_ids": ["fact_import_real"],
+                "redaction_state": "none"
+            }, {
+                "id": "evidence_utils",
+                "repo_id": "repo_abc",
+                "scan_id": "scan_abc",
+                "artifact_id": "file_version:app/api/utils/route.ts:bbbbbbbbbbbb",
+                "file_path": "app/api/utils/route.ts",
+                "file_hash": "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
+                "start_line": 1,
+                "end_line": 1,
+                "adapter_id": "typescript",
+                "adapter_version": "0.1.0",
+                "fact_ids": ["fact_import_utils"],
+                "redaction_state": "none"
+            }]
+        },
+        "scan": { "scan_id": "scan_abc", "facts": [] },
+        "contract": {
+            "conventions": [{
+                "id": "convention_graph_db",
+                "kind": "api_route_no_direct_data_access",
+                "matcher": { "forbidden_imports": ["src/lib/db"] },
+                "severity": "error",
+                "enforcement_mode": "block",
+                "enforcement_capability": "deterministic_check"
+            }]
+        },
+        "baseline": [],
+        "diff": { "mode": "full", "files": [] }
+    });
+    let payload = run_check(request);
+    let flagged = payload["findings"]
+        .as_array()
+        .expect("findings")
+        .iter()
+        .flat_map(|finding| finding["evidence"].as_array().expect("evidence"))
+        .filter_map(|evidence| evidence["file_path"].as_str())
+        .collect::<BTreeSet<_>>();
+
+    assert!(
+        flagged.contains("app/api/real/route.ts"),
+        "src/lib/db is the declared data layer and src/lib/db.ts is the file it names: {payload:#?}"
+    );
+    assert!(
+        !flagged.contains("app/api/utils/route.ts"),
+        "src/lib/dbutils.ts only shares a prefix with the declared path: {payload:#?}"
     );
 }
 

--- a/packages/cli/src/check/run-check.ts
+++ b/packages/cli/src/check/run-check.ts
@@ -172,11 +172,23 @@ export function enforcementDegradedByCompleteness(input: {
 export function checkExitCodeFor(input: {
   blockingCount: number;
   enforcementDegraded: boolean;
+  /**
+   * BB-4: `--strict-contract` and a contract whose trigger resolves to nothing.
+   *
+   * Required, not optional, and deliberately so. This term used to live at the return statement of
+   * `runCheck`, added to the exit code and to nothing else - which is how exit 3 came to sit beside
+   * `check.status: "pass"` again, the exact B-3 shape the two functions below were written to make
+   * impossible. A term a caller can forget to mention is a term that will diverge; making it
+   * mandatory means a new call site has to answer the question rather than omit it.
+   */
+  contractStaleRefusal: boolean;
 }): number {
   if (input.blockingCount > 0) {
     return CHECK_EXIT_BLOCKED;
   }
-  return input.enforcementDegraded ? CHECK_EXIT_REFUSED : CHECK_EXIT_PASS;
+  return input.enforcementDegraded || input.contractStaleRefusal
+    ? CHECK_EXIT_REFUSED
+    : CHECK_EXIT_PASS;
 }
 
 /**
@@ -190,6 +202,7 @@ export function checkExitCodeFor(input: {
 export function checkStatusFor(input: {
   blockingCount: number;
   enforcementDegraded: boolean;
+  contractStaleRefusal: boolean;
 }): "pass" | "fail" | "refused" {
   switch (checkExitCodeFor(input)) {
     case CHECK_EXIT_BLOCKED:
@@ -828,9 +841,22 @@ export async function runCheck(storage: SqliteDriftStorage, parsed: ParsedArgs):
     }))
   });
 
+  // BB-4: a dead contract does not change the verdict by itself - a removed data layer is a
+  // legitimate refactor, and blocking it would be a false positive on a repo that did nothing
+  // wrong. `--strict-contract` opts into the fail-closed reading for CI users who would rather
+  // stop than run a gate whose trigger is unplugged.
+  //
+  // Decided here, once, above both consumers. It used to be decided at the return statement, which
+  // put it on the exit code and not on the status.
+  const contractStaleRefusal = staleness.length > 0 && parsed.flags.has("strict-contract");
+
   // E-1 (S1-02): status and exit code are one decision - a refused check records
   // "refused", never "pass" (B-3's contradiction, recorded on every eval baseline row).
-  const checkStatus: CheckRun["status"] = checkStatusFor({ blockingCount, enforcementDegraded });
+  const checkStatus: CheckRun["status"] = checkStatusFor({
+    blockingCount,
+    enforcementDegraded,
+    contractStaleRefusal
+  });
 
   const fallbackStatus = fallbackStatusForCheck(checkData);
   const capabilityCompleteness = capabilityCompletenessForCheck(checkData, {
@@ -973,14 +999,12 @@ export async function runCheck(storage: SqliteDriftStorage, parsed: ParsedArgs):
     //   0 pass · 2 blocked · 3 refused (fail-closed) · 1 operational error
     // `2` is distinct from `1` so CI can tell "this diff violates the contract" from
     // "drift itself failed", and so a crash is never silently read as a clean run.
-    // BB-4: a dead contract does not change the exit code by itself - a removed data layer is a
-    // legitimate refactor, and blocking it would be a false positive on a repo that did nothing
-    // wrong. `--strict-contract` opts into the fail-closed reading for CI users who would rather
-    // stop than run a gate whose trigger is unplugged. A real block still outranks it: the refusal
-    // must never mask a violation Drift did manage to prove.
-    exitCode: staleness.length > 0 && parsed.flags.has("strict-contract") && blockingCount === 0
-      ? CHECK_EXIT_REFUSED
-      : checkExitCodeFor({ blockingCount, enforcementDegraded }),
+    // BB-4's `--strict-contract` refusal is `contractStaleRefusal`, decided above and handed to the
+    // status and to this exit code from the same variable. A real block still outranks it - the
+    // refusal must never mask a violation Drift did manage to prove - which `checkExitCodeFor`
+    // already guarantees by answering blockingCount first, so the explicit `blockingCount === 0`
+    // this expression used to carry is redundant rather than lost.
+    exitCode: checkExitCodeFor({ blockingCount, enforcementDegraded, contractStaleRefusal }),
     payload: parsed.flags.has("json") ? payload : formatCheckText(payload)
   };
 }

--- a/packages/cli/src/check/run-check.ts
+++ b/packages/cli/src/check/run-check.ts
@@ -823,7 +823,29 @@ export async function runCheck(storage: SqliteDriftStorage, parsed: ParsedArgs):
     .filter((filePath): filePath is string => Boolean(filePath))
     .filter((filePath) => parsedDiff.files.some((file) => file.path === filePath))
     .map((filePath) => `unresolved_route_import:${filePath}`)
-    .filter((reason, index, all) => all.indexOf(reason) === index);
+    .filter((reason, index, all) => all.indexOf(reason) === index)
+    // A file the scan could not read is a coverage gap too, and it was the one kind that never
+    // reached this list.
+    //
+    // The scan already knows: `repo_completeness` counts skipped files and reports the repo scope
+    // as incomplete, and that verdict is persisted (graph_completeness holds `complete=0` with the
+    // reason). The check simply never read it, so a repo with a non-UTF-8 API route answered
+    // `partial_coverage: {complete: true, reasons: []}` and exit 0 - asserting it had seen a route
+    // it never opened. Measured on a two-route fixture before this line existed.
+    //
+    // This is a coverage gap and deliberately not an enforcement demotion: findings the scan did
+    // establish stay enforced and the exit code is unchanged, exactly as EW-2 separated the two.
+    // The check stops claiming completeness it does not have; it does not become a kill-switch.
+    //
+    // Note this is a different use of `checkData.completeness` than the one rejected at S1-01
+    // above. There it was proposed as a substitute for detecting check-time demotion, which it
+    // cannot see. Here it is being asked what it actually measures: what the scan managed to read.
+    .concat(
+      (checkData.completeness ?? [])
+        .filter((entry) => entry.scope === "repo" && !entry.complete)
+        .flatMap((entry) => entry.reasons ?? [])
+        .map((reason) => `scan_incomplete:${reason}`)
+    );
 
   // S1-01: did incomplete coverage silently weaken enforcement?
   //

--- a/packages/cli/test/check-fail-closed.test.ts
+++ b/packages/cli/test/check-fail-closed.test.ts
@@ -71,20 +71,20 @@ describe("enforcementDegradedByCompleteness", () => {
 
 describe("checkExitCodeFor", () => {
   it("refuses rather than passing when enforcement was degraded", () => {
-    expect(checkExitCodeFor({ blockingCount: 0, enforcementDegraded: true })).toBe(
+    expect(checkExitCodeFor({ blockingCount: 0, enforcementDegraded: true, contractStaleRefusal: false })).toBe(
       CHECK_EXIT_REFUSED
     );
   });
 
   it("still blocks when something actually blocks", () => {
     // Degradation must not mask a real violation into a refusal.
-    expect(checkExitCodeFor({ blockingCount: 1, enforcementDegraded: true })).toBe(
+    expect(checkExitCodeFor({ blockingCount: 1, enforcementDegraded: true, contractStaleRefusal: false })).toBe(
       CHECK_EXIT_BLOCKED
     );
   });
 
   it("passes only when coverage was adequate and nothing blocked", () => {
-    expect(checkExitCodeFor({ blockingCount: 0, enforcementDegraded: false })).toBe(CHECK_EXIT_PASS);
+    expect(checkExitCodeFor({ blockingCount: 0, enforcementDegraded: false, contractStaleRefusal: false })).toBe(CHECK_EXIT_PASS);
   });
 });
 
@@ -96,25 +96,47 @@ describe("checkExitCodeFor", () => {
  */
 describe("checkStatusFor", () => {
   it("records refused when enforcement was degraded and nothing blocked", () => {
-    expect(checkStatusFor({ blockingCount: 0, enforcementDegraded: true })).toBe("refused");
+    expect(checkStatusFor({ blockingCount: 0, enforcementDegraded: true, contractStaleRefusal: false })).toBe("refused");
   });
 
   it("records fail when something actually blocks, even degraded", () => {
-    expect(checkStatusFor({ blockingCount: 1, enforcementDegraded: true })).toBe("fail");
+    expect(checkStatusFor({ blockingCount: 1, enforcementDegraded: true, contractStaleRefusal: false })).toBe("fail");
   });
 
   it("records pass only for a clean, fully-enforced check", () => {
-    expect(checkStatusFor({ blockingCount: 0, enforcementDegraded: false })).toBe("pass");
+    expect(checkStatusFor({ blockingCount: 0, enforcementDegraded: false, contractStaleRefusal: false })).toBe("pass");
   });
 
+  // This enumeration cannot fail, and it is worth being honest about why it is still here.
+  // `checkStatusFor` calls `checkExitCodeFor`, so agreement between them is a property of the
+  // implementation, not of the system. What it does buy is the third dimension: a new decision
+  // input has to be added here to compile, which is the reminder that both consumers exist.
+  //
+  // The divergence this suite is named for never lived in these two functions. It lived at the
+  // CALL SITE, where `runCheck` added the `--strict-contract` staleness term to the exit code and
+  // not to the status. That seam is guarded in contract-liveness-bb4.test.ts ("records the refusal
+  // in the payload, not only in the exit code"), which is the assertion that actually fails when
+  // the two answers part company.
   it("agrees with the exit code on every input", () => {
     for (const blockingCount of [0, 1, 5]) {
       for (const enforcementDegraded of [false, true]) {
-        const status = checkStatusFor({ blockingCount, enforcementDegraded });
-        const exit = checkExitCodeFor({ blockingCount, enforcementDegraded });
-        const expected = { [CHECK_EXIT_PASS]: "pass", [CHECK_EXIT_BLOCKED]: "fail", [CHECK_EXIT_REFUSED]: "refused" }[exit];
-        expect(status).toBe(expected);
+        for (const contractStaleRefusal of [false, true]) {
+          const input = { blockingCount, enforcementDegraded, contractStaleRefusal };
+          const exit = checkExitCodeFor(input);
+          const expected = { [CHECK_EXIT_PASS]: "pass", [CHECK_EXIT_BLOCKED]: "fail", [CHECK_EXIT_REFUSED]: "refused" }[exit];
+          expect(checkStatusFor(input)).toBe(expected);
+        }
       }
     }
+  });
+
+  it("refuses on a stale contract under --strict-contract, and still blocks over it", () => {
+    expect(
+      checkStatusFor({ blockingCount: 0, enforcementDegraded: false, contractStaleRefusal: true })
+    ).toBe("refused");
+    // A refusal must never mask a violation Drift did manage to prove.
+    expect(
+      checkStatusFor({ blockingCount: 1, enforcementDegraded: false, contractStaleRefusal: true })
+    ).toBe("fail");
   });
 });

--- a/packages/cli/test/contract-liveness-bb4.test.ts
+++ b/packages/cli/test/contract-liveness-bb4.test.ts
@@ -228,6 +228,25 @@ describe("BB-4 contract liveness", () => {
       expect(JSON.parse(result.stdout).summary.contract_staleness).toHaveLength(1);
     });
 
+    // B-3, reopened by this very flag and closed again.
+    //
+    // The refusal was applied to the exit code at the return statement and nowhere else, so the
+    // payload still said "pass" while `$?` said 3. That is precisely the shape E-1 was written to
+    // make impossible, and the consumers Drift is built for - MCP, agents, CI steps parsing JSON -
+    // read the status, not the exit code. The test above asserted only the exit code, which is how
+    // a divergence in the half it did not look at survived.
+    it("records the refusal in the payload, not only in the exit code", async () => {
+      const { repoId, databasePath, repoRoot } = await fixture({ violatingRoutes: 1, cleanRoutes: 3 });
+      await renameDataLayer(repoRoot);
+      await runCli(["--db", databasePath, "scan", "--repo-root", repoRoot, "--json"]);
+
+      const result = await check(databasePath, repoId, "--strict-contract");
+      const payload = JSON.parse(result.stdout);
+
+      expect(result.exitCode).toBe(3);
+      expect(payload.check.status).toBe("refused");
+    });
+
     it("names the dead specifier in the human output too", async () => {
       const { repoId, databasePath, repoRoot } = await fixture({ violatingRoutes: 1, cleanRoutes: 3 });
       await renameDataLayer(repoRoot);

--- a/packages/cli/test/scan-coverage-gap.test.ts
+++ b/packages/cli/test/scan-coverage-gap.test.ts
@@ -1,0 +1,113 @@
+import { execFileSync } from "node:child_process";
+import { mkdir, mkdtemp, rm, writeFile } from "node:fs/promises";
+import { dirname, join } from "node:path";
+import { tmpdir } from "node:os";
+import { afterEach, describe, expect, it } from "vitest";
+import { runCli } from "../src/index.js";
+
+/**
+ * A file the scan could not read must not be reported as a file the scan read.
+ *
+ * The scan already worked this out - `repo_completeness` counts skipped files and marks the repo
+ * scope incomplete, and that verdict is persisted. The check never consulted it, so a repo with an
+ * unreadable file answered `partial_coverage: {complete: true, reasons: []}` and exit 0.
+ *
+ * The second test is the one that decides the design, and it is here because it nearly went the
+ * other way. The reason this reports is repo-wide, while the unresolved-import gaps beside it are
+ * diff-scoped, so an obvious "refinement" is to report only skipped files that are themselves in
+ * the enforced scope - quieter on repos carrying vendored bundles nothing imports. Measured against
+ * this fixture, that refinement is a false negative generator: `lib/secret.ts` is not an API route
+ * and would not be reported under it, and it is exactly the file that could be the data layer.
+ *
+ * The asymmetry is the whole argument. A coverage gap reported for a file nothing imports costs
+ * attention. A gap NOT reported for a module a route imports costs the product its claim. Until the
+ * reason is scoped by import-reachability rather than by path shape, repo-wide is the answer that
+ * fails closed.
+ */
+
+const tempDirs: string[] = [];
+afterEach(async () => {
+  await Promise.all(tempDirs.splice(0).map((dir) => rm(dir, { recursive: true, force: true })));
+});
+
+function git(cwd: string, ...args: string[]): void {
+  execFileSync("git", args, { cwd, stdio: "ignore" });
+}
+
+/** Bytes that are not valid UTF-8, so the engine's read fails and the file is skipped. */
+const UNREADABLE = Buffer.from([0x65, 0x78, 0x70, 0x6f, 0x72, 0x74, 0x0a, 0xff, 0xfe, 0xfd, 0x0a]);
+
+async function fixture(options: { unreadableAt: string; route: string }): Promise<{
+  repoId: string;
+  databasePath: string;
+}> {
+  const dir = await mkdtemp(join(tmpdir(), "drift-coverage-gap-"));
+  tempDirs.push(dir);
+  const repoRoot = join(dir, "repo");
+  const stateRoot = join(dir, "state");
+
+  await mkdir(join(repoRoot, "app/api/reads"), { recursive: true });
+  await mkdir(join(repoRoot, "lib"), { recursive: true });
+  await writeFile(join(repoRoot, "package.json"), '{"name":"coverage-gap","version":"1.0.0"}\n');
+  await writeFile(
+    join(repoRoot, "tsconfig.json"),
+    '{"compilerOptions":{"baseUrl":".","paths":{"@/*":["./*"]}}}\n'
+  );
+  await writeFile(join(repoRoot, "app/api/reads/route.ts"), options.route);
+  const unreadablePath = join(repoRoot, options.unreadableAt);
+  await mkdir(dirname(unreadablePath), { recursive: true });
+  await writeFile(unreadablePath, UNREADABLE);
+
+  git(repoRoot, "init");
+  git(repoRoot, "add", "-A");
+  git(repoRoot, "-c", "user.email=t@t", "-c", "user.name=t", "commit", "-m", "init");
+
+  const started = await runCli([
+    "start",
+    "--repo-root", repoRoot,
+    "--state-root", stateRoot,
+    "--accept-defaults",
+    "--json"
+  ]);
+  const repoId = JSON.parse(started.stdout).repo.id as string;
+  return { repoId, databasePath: join(stateRoot, repoId, "drift.sqlite") };
+}
+
+const check = async (databasePath: string, repoId: string) =>
+  JSON.parse(
+    (await runCli(["--db", databasePath, "check", "--repo", repoId, "--scope", "full", "--json"]))
+      .stdout
+  );
+
+describe("scan coverage gaps reach the check", () => {
+  it("admits an unreadable API route instead of reporting complete coverage", async () => {
+    const { repoId, databasePath } = await fixture({
+      unreadableAt: "app/api/broken/route.ts",
+      route: 'export async function GET() { return Response.json({ ok: true }); }\n'
+    });
+
+    const payload = await check(databasePath, repoId);
+
+    expect(payload.summary.partial_coverage.complete).toBe(false);
+    expect(payload.summary.partial_coverage.reasons.join(" ")).toContain("could not be read");
+  });
+
+  it("admits an unreadable module that an in-scope route imports", async () => {
+    // Nothing else catches this one. The specifier still resolves by path, so it does not surface
+    // as an unresolved import, and the file is not an API route so a scope-shaped filter would skip
+    // it. Measured on main before the fix: `{"complete": true, "reasons": []}`.
+    const { repoId, databasePath } = await fixture({
+      unreadableAt: "lib/secret.ts",
+      route: [
+        'import { db } from "@/lib/secret";',
+        "export async function GET() { return Response.json(db); }",
+        ""
+      ].join("\n")
+    });
+
+    const payload = await check(databasePath, repoId);
+
+    expect(payload.summary.partial_coverage.complete).toBe(false);
+    expect(payload.summary.partial_coverage.reasons.join(" ")).toContain("could not be read");
+  });
+});

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,0 +1,18 @@
+# The toolchain is pinned, and bumped deliberately.
+#
+# CI used `dtolnay/rust-toolchain@stable`, which floats to whatever the newest stable is on the day
+# the job runs. That turned a new clippy lint into a red gate with no change to this repository:
+# `unnecessary_sort_by` fired on 1.97.0 at main.rs:2043 and did not exist on the 1.93.0 a developer
+# had locally, so the gate disagreed with every machine that could have caught it first.
+#
+# For a project whose claim is that the gate never moves without a reason, a gate that can move
+# without a reason is the wrong default. Pinning also closes the class rather than the instance:
+# local and CI now run the same compiler, so "works on my machine" cannot mean "a different
+# compiler agreed with me".
+#
+# Bumping is a normal change with a normal diff: raise the version here, run `pnpm verify:full`,
+# fix what the new lints find, and land it as its own commit. That is a deliberate act with a
+# review, which is what it should have been all along.
+[toolchain]
+channel = "1.97.0"
+components = ["rustfmt", "clippy"]

--- a/scripts/evasion-baseline.json
+++ b/scripts/evasion-baseline.json
@@ -799,7 +799,8 @@
         "refusal_names_decoy": true,
         "blocked_reasons": [
           "enforcement_degraded_by_incomplete_coverage",
-          "unresolved_route_import:apps/web/app/api/drift-evasion-s13/route.ts"
+          "unresolved_route_import:apps/web/app/api/drift-evasion-s13/route.ts",
+          "scan_incomplete:1 file(s) exceeded the 2000000 byte scan limit and were skipped"
         ],
         "outcome": "refused",
         "verdict": "PASS"

--- a/test/e2e/release-hygiene.test.ts
+++ b/test/e2e/release-hygiene.test.ts
@@ -68,6 +68,23 @@ describe("release hygiene", () => {
     expect(manifest.scripts["eval:determinism"]).toBe("node scripts/determinism.mjs");
   });
 
+  // Two copies of a version drift the same way two copies of a predicate do. dtolnay/rust-toolchain
+  // needs the version as a workflow input and rustup reads rust-toolchain.toml, so the duplication
+  // is forced - but it does not have to be unguarded. A floating `@stable` is what let a new clippy
+  // lint redden this gate with no change to the repository at all; a pin that silently disagrees
+  // with the developer pin would be the same defect wearing a pin's clothes.
+  it("pins one Rust toolchain, and CI agrees with the developer pin", async () => {
+    const manifest = await readFile("rust-toolchain.toml", "utf8");
+    const workflow = await readFile(".github/workflows/ci.yml", "utf8");
+
+    const pinned = manifest.match(/channel\s*=\s*"([^"]+)"/)?.[1];
+    expect(pinned, "rust-toolchain.toml must pin an exact channel, not a floating one").toMatch(
+      /^\d+\.\d+\.\d+$/
+    );
+    expect(workflow).not.toContain("dtolnay/rust-toolchain@stable");
+    expect(workflow).toContain(`toolchain: "${pinned}"`);
+  });
+
   it("keeps root ignores from hiding package source files", async () => {
     const rootIgnore = await readFile(".gitignore", "utf8");
 


### PR DESCRIPTION
Rebase of `fix/enforcement-review` onto the post-history-rewrite `main` (that branch's original ancestry no longer shares a base with `main` after the rewrite, so this recreates its 5 commits on the current tip). Also fully subsumes `fix/enforcement-predicates` and `fix/strict-contract-status` — verified their commits are byte-identical to two of the five here, just different SHAs from being on the old history.

**Commits:**
- `fix(engine): one forbidden-import predicate, and a path match that respects boundaries`
- `fix(cli): --strict-contract refusal reaches the status, not only the exit code`
- `fix(engine,cli): a file the scan could not read is a coverage gap, not silence`
- `test(cli): pin the coverage gap that the obvious refinement would have dropped`
- `fix(engine): resolve against what was read, and pin the toolchain`

**Verified before opening this PR:**
- `cargo test -p drift-engine` — all passing
- `cargo fmt --all -- --check`, `cargo clippy -p drift-engine --all-targets -- -D warnings` — clean
- `pnpm typecheck`, `node packages/cli/scripts/check-boundaries.mjs` — clean
- `pnpm test:harness` (110 tests) and full `test/e2e` (83 tests, 21 files) — all passing

Once merged, `fix/enforcement-predicates` and `fix/strict-contract-status` should be deleted (their work is fully contained here) rather than merged separately.