### PR TITLE
perf(cli,query,mcp): unblock unconditional full check, stop unverified payload claims

### DIFF
--- a/packages/cli/src/check/run-check.ts
+++ b/packages/cli/src/check/run-check.ts
@@ -71,7 +71,6 @@ function emptyDiffScopeCauses(parsed: ParsedArgs): string {
   }
   return "No --diff range or --diff-file was resolvable to changed files. Pass --diff <range>, --diff-file <path>, or --scope full.";
 }
-import { walkIndexableFiles } from "../engine/ts-fallback-scanner.js";
 import { formatCheckText } from "../formatters/checks.js";
 import { fileContentHash } from "../io/file-hash.js";
 import { diffStatusFor,filesForConvention,fullRepoDiff,loadDiff,parseUnifiedDiff } from "./diff.js";
@@ -2620,7 +2619,13 @@ async function runEngineOwnedDirectDataAccessCheck(input: {
           kind: "violation",
           file_path: evidence.file_path,
           start_line: evidence.start_line,
-          end_line: evidence.end_line,
+          // The engine reports a violation at a single line (`end_line: finding.line`,
+          // check_command.rs:336), which flattens a multiline import to its first line. The
+          // import fact carries the real span and is already the source of truth for the symbol,
+          // source and fact id below, so prefer it here too. Surfaced when onboarding stopped
+          // using its own baseline pass, which read the fact directly and got 1-3 where this
+          // path got 1-1.
+          end_line: importUsed?.end_line ?? evidence.end_line,
           symbol: evidenceSymbol(importUsed?.name),
           import_source: importUsed?.value,
           fact_ids: importUsed?.fact_id ? [importUsed.fact_id] : [],
@@ -3110,6 +3115,108 @@ function graphForEngineCheck(
   };
 }
 
+/**
+ * Loop-invariant graph lookups, built once per ScanData.
+ *
+ * `graphImportResolvesToForbidden` and `exceptionContextForImport` are called once per import per
+ * in-scope file (:2510, :2517). Each used to rebuild, on every call, a Map over every evidence row
+ * and a Map over every node, then scan all nodes linearly to find one import. On dub that is 4,239
+ * calls against a 112,773-node / 205,019-edge graph - measured at 55.8ms and 36.2ms per call, 359s
+ * of a 367s `check --scope full`. Cost is `imports_in_scope x graph_size`, so it is quadratic in
+ * repo size at fixed route density: openstatus (2,185 files, 37 in scope) ran 3x faster than
+ * papermark (1,346 files, 283 in scope) despite a 78% larger graph.
+ *
+ * `forbiddenModuleFiles_` was already hoisted per convention at its other call site (:2575); this
+ * gives the same treatment to the rest.
+ *
+ * Keyed on ScanData identity. The arrays indexed here are read-only for the lifetime of a check -
+ * `graphForEngineCheck` derives new arrays with `.filter()` rather than mutating in place.
+ */
+interface GraphIndex {
+  nodesById: Map<string, ScanData["graph_nodes"][number]>;
+  /** First node per key, matching the `.find()` this replaced. */
+  importNodeByKey: Map<string, ScanData["graph_nodes"][number]>;
+  resolvedModuleEdgesByFrom: Map<string, ScanData["graph_edges"]>;
+  resolvedSymbolEdgesByFrom: Map<string, ScanData["graph_edges"]>;
+  endpointNodesByFile: Map<string, ScanData["graph_nodes"]>;
+  dataOperationNodesByFile: Map<string, ScanData["graph_nodes"]>;
+  reexportTargets: Map<string, string[]>;
+  /** Forbidden specifiers joined by NUL -> the files they resolve to. */
+  forbiddenModuleFilesByKey: Map<string, Set<string>>;
+}
+
+const graphIndexes = new WeakMap<ScanData, GraphIndex>();
+
+function graphIndexFor(checkData: ScanData): GraphIndex {
+  const cached = graphIndexes.get(checkData);
+  if (cached) {
+    return cached;
+  }
+
+  const evidenceById = new Map(checkData.graph_evidence.map((evidence) => [evidence.id, evidence]));
+  const nodesById = new Map(checkData.graph_nodes.map((node) => [node.id, node]));
+  const importNodeByKey = new Map<string, ScanData["graph_nodes"][number]>();
+  const endpointNodesByFile = new Map<string, ScanData["graph_nodes"]>();
+  const dataOperationNodesByFile = new Map<string, ScanData["graph_nodes"]>();
+
+  for (const node of checkData.graph_nodes) {
+    if (node.kind === "import_decl") {
+      const key = importNodeGraphKey(node, evidenceById);
+      // First wins: `.find()` returned the earliest match in array order.
+      if (key !== undefined && !importNodeByKey.has(key)) {
+        importNodeByKey.set(key, node);
+      }
+      continue;
+    }
+    if (node.kind !== "endpoint" && node.kind !== "data_operation") {
+      continue;
+    }
+    const nodeFilePath = stringMetadata(node.metadata, "file_path");
+    if (!nodeFilePath) {
+      continue;
+    }
+    const byFile = node.kind === "endpoint" ? endpointNodesByFile : dataOperationNodesByFile;
+    const existing = byFile.get(nodeFilePath);
+    if (existing) {
+      existing.push(node);
+    } else {
+      byFile.set(nodeFilePath, [node]);
+    }
+  }
+
+  const resolvedModuleEdgesByFrom = new Map<string, ScanData["graph_edges"]>();
+  const resolvedSymbolEdgesByFrom = new Map<string, ScanData["graph_edges"]>();
+  for (const edge of checkData.graph_edges) {
+    const byFrom = edge.kind === "IMPORT_RESOLVES_TO_MODULE"
+      ? resolvedModuleEdgesByFrom
+      : edge.kind === "IMPORT_RESOLVES_TO_SYMBOL"
+        ? resolvedSymbolEdgesByFrom
+        : undefined;
+    if (!byFrom) {
+      continue;
+    }
+    const existing = byFrom.get(edge.from);
+    if (existing) {
+      existing.push(edge);
+    } else {
+      byFrom.set(edge.from, [edge]);
+    }
+  }
+
+  const index: GraphIndex = {
+    nodesById,
+    importNodeByKey,
+    resolvedModuleEdgesByFrom,
+    resolvedSymbolEdgesByFrom,
+    endpointNodesByFile,
+    dataOperationNodesByFile,
+    reexportTargets: moduleReexportTargets(checkData),
+    forbiddenModuleFilesByKey: new Map()
+  };
+  graphIndexes.set(checkData, index);
+  return index;
+}
+
 function graphImportResolvesToForbidden(
   checkData: ScanData,
   filePath: string,
@@ -3119,12 +3226,9 @@ function graphImportResolvesToForbidden(
   if (forbiddenImports.length === 0) {
     return false;
   }
-  const evidenceById = new Map(checkData.graph_evidence.map((evidence) => [evidence.id, evidence]));
-  const nodesById = new Map(checkData.graph_nodes.map((node) => [node.id, node]));
-  const importKey = importFactGraphKey(filePath, importUsed);
-  const importNode = checkData.graph_nodes.find((node) =>
-    node.kind === "import_decl" && importNodeGraphKey(node, evidenceById) === importKey
-  );
+  const { nodesById, importNodeByKey, resolvedModuleEdgesByFrom, reexportTargets } =
+    graphIndexFor(checkData);
+  const importNode = importNodeByKey.get(importFactGraphKey(filePath, importUsed));
   if (!importNode) {
     return false;
   }
@@ -3140,10 +3244,8 @@ function graphImportResolvesToForbidden(
   // The repository tells us what a specifier means: wherever any file imports a forbidden
   // specifier and the resolver placed that edge, the target is the file it names.
   const forbiddenFiles = forbiddenModuleFiles_(checkData, forbiddenImports);
-  const reexportTargets = moduleReexportTargets(checkData);
 
-  return checkData.graph_edges
-    .filter((edge) => edge.kind === "IMPORT_RESOLVES_TO_MODULE" && edge.from === importNode.id)
+  return (resolvedModuleEdgesByFrom.get(importNode.id) ?? [])
     .some((edge) => {
       const resolved = nodesById.get(edge.to);
       const resolvedPath = resolved ? stringMetadata(resolved.metadata, "file_path") : undefined;
@@ -3174,8 +3276,16 @@ function graphImportResolvesToForbidden(
  * here, which is what keeps the T03 negative control green.
  */
 function forbiddenModuleFiles_(checkData: ScanData, forbiddenImports: string[]): Set<string> {
+  const index = graphIndexFor(checkData);
+  // Memoised per specifier set: called once per import via graphImportResolvesToForbidden, and
+  // again per convention at :2575, always with the same forbidden list within one convention.
+  const cacheKey = forbiddenImports.join("\0");
+  const cached = index.forbiddenModuleFilesByKey.get(cacheKey);
+  if (cached) {
+    return cached;
+  }
   const files = new Set<string>();
-  const nodesById = new Map(checkData.graph_nodes.map((node) => [node.id, node]));
+  const { nodesById } = index;
   for (const edge of checkData.graph_edges) {
     if (edge.kind !== "IMPORT_RESOLVES_TO_MODULE") {
       continue;
@@ -3191,6 +3301,7 @@ function forbiddenModuleFiles_(checkData: ScanData, forbiddenImports: string[]):
       files.add(targetPath);
     }
   }
+  index.forbiddenModuleFilesByKey.set(cacheKey, files);
   return files;
 }
 
@@ -3245,30 +3356,27 @@ function exceptionContextForImport(
   dataStores: string[];
   operationKinds: string[];
 } {
-  const evidenceById = new Map(checkData.graph_evidence.map((evidence) => [evidence.id, evidence]));
-  const nodesById = new Map(checkData.graph_nodes.map((node) => [node.id, node]));
-  const importKey = importFactGraphKey(filePath, importUsed);
-  const importNode = checkData.graph_nodes.find((node) =>
-    node.kind === "import_decl" && importNodeGraphKey(node, evidenceById) === importKey
-  );
-  const endpointNodes = checkData.graph_nodes.filter((node) =>
-    node.kind === "endpoint" && stringMetadata(node.metadata, "file_path") === filePath
-  );
-  const dataOperationNodes = checkData.graph_nodes.filter((node) =>
-    node.kind === "data_operation" &&
-    stringMetadata(node.metadata, "file_path") === filePath &&
+  const {
+    nodesById,
+    importNodeByKey,
+    resolvedModuleEdgesByFrom,
+    resolvedSymbolEdgesByFrom,
+    endpointNodesByFile,
+    dataOperationNodesByFile
+  } = graphIndexFor(checkData);
+  const importNode = importNodeByKey.get(importFactGraphKey(filePath, importUsed));
+  const endpointNodes = endpointNodesByFile.get(filePath) ?? [];
+  const dataOperationNodes = (dataOperationNodesByFile.get(filePath) ?? []).filter((node) =>
     stringMetadata(node.metadata, "receiver_root") === importUsed.name
   );
   const resolvedModules = importNode
-    ? checkData.graph_edges
-        .filter((edge) => edge.kind === "IMPORT_RESOLVES_TO_MODULE" && edge.from === importNode.id)
+    ? (resolvedModuleEdgesByFrom.get(importNode.id) ?? [])
         .map((edge) => nodesById.get(edge.to))
         .flatMap((node) => node ? [stringMetadata(node.metadata, "file_path")] : [])
         .filter((value): value is string => typeof value === "string")
     : [];
   const resolvedSymbols = importNode
-    ? checkData.graph_edges
-        .filter((edge) => edge.kind === "IMPORT_RESOLVES_TO_SYMBOL" && edge.from === importNode.id)
+    ? (resolvedSymbolEdgesByFrom.get(importNode.id) ?? [])
         .map((edge) => nodesById.get(edge.to)?.label)
         .filter((value): value is string => typeof value === "string")
     : [];
@@ -3362,186 +3470,6 @@ export function expireFindingsForExpiredConventions(
     expiredCount += 1;
   }
   return expiredCount;
-}
-
-export function runFullRepoCheck(
-  storage: SqliteDriftStorage,
-  parsed: ParsedArgs,
-  repoId: string,
-  now: string
-): Finding[] {
-  const repo = storage.getRepo(repoId);
-  if (!repo) {
-    return [];
-  }
-  const checkId = `check_full_${hashStable(`${repoId}:${now}`).slice(0, 16)}`;
-
-  // Bindings we detected but could not reconcile against an engine import fact.
-  // Collected rather than thrown so a single unparseable file degrades that file
-  // instead of aborting onboarding. See the reconciliation site below.
-  const importFactReconciliationGaps: Array<{
-    filePath: string;
-    line: number;
-    // Absent for a bindingless side-effect import (S10): nothing was bound.
-    symbol?: string;
-    importSource: string;
-  }> = [];
-
-  const files = walkIndexableFiles(repo.root_path).filter(isApiRoutePath);
-  const diff = {
-    // Full-repo baseline sweep over files that already exist: nothing here is added.
-    files: files.map((path) => ({ path, changedLines: new Set<number>(), isAdded: false })),
-    deletedFiles: []
-  };
-  const contract = storage.getRepoContract(repoId);
-  if (!contract) {
-    return [];
-  }
-  const latestScan = storage.listScanManifests(repoId).find((scan) => scan.status === "completed");
-  const snapshotsByPath = new Map(
-    latestScan
-      ? storage.listFileSnapshots(repoId, latestScan.id).map((snapshot) => [snapshot.file_path, snapshot])
-      : []
-  );
-  // Engine import facts, grouped by file. This is the authoritative set: the engine decides
-  // what counts as a value import, including dropping bindings used only in type positions.
-  //
-  // Baseline materialization used to re-derive imports from source with the CLI's own regex
-  // and then look the results up here by evidence key. Any disagreement between the two
-  // parsers produced a finding with no fact behind it - originally a crash (F2), later a
-  // reported parser gap (A3.3). Reading the facts directly removes the possibility: there is
-  // one parser, and it is the engine's.
-  const importFactsByFile = new Map<string, FactRecord[]>();
-  if (latestScan) {
-    for (const fact of storage.listFacts(latestScan.id, { kind: "import_used" })) {
-      importFactsByFile.set(fact.file_path, [...(importFactsByFile.get(fact.file_path) ?? []), fact]);
-    }
-  }
-
-  const findings: Finding[] = [];
-  for (const convention of contract.conventions) {
-    if (convention.kind !== "api_route_no_direct_data_access") {
-      continue;
-    }
-
-    for (const filePath of filesForConvention(diff, convention, "full")) {
-      if (isExceptedPath(filePath, convention, now)) {
-        continue;
-      }
-      for (const fact of importFactsByFile.get(filePath) ?? []) {
-        const importUsed = {
-          name: fact.name,
-          source: String(fact.value ?? ""),
-          line: fact.start_line,
-          end_line: fact.end_line
-        };
-        if (!importUsed.source) {
-          continue;
-        }
-        if (!isForbiddenImport(importUsed.source, convention.matcher.forbidden_imports ?? [])) {
-          continue;
-        }
-        if (isExceptedImport(filePath, importUsed.name, importUsed.source, convention, now)) {
-          continue;
-        }
-        const snapshot = snapshotsByPath.get(filePath);
-        const waiver = findContractWaiverForImport(filePath, importUsed.name, importUsed.source, contract, now);
-        if (waiver) {
-          const staleWaiver = waiverRequiresReapproval(
-            waiver,
-            filePath,
-            snapshot?.content_hash
-          );
-          if (staleWaiver) {
-            findings.push(waiverReapprovalFinding({
-              repoId,
-              repoContractId: contract.id,
-              conventionId: convention.id,
-              checkId,
-              scanId: snapshot?.scan_id ?? checkId,
-              filePath,
-              line: importUsed.line,
-              symbol: evidenceSymbol(importUsed.name),
-              importSource: importUsed.source,
-              fileHash: snapshot?.content_hash ?? "",
-              waiverId: waiver.id,
-              now
-            }));
-          } else {
-            continue;
-          }
-        }
-
-        const fingerprint = findingFingerprint(convention.id, filePath, importUsed.name, importUsed.source);
-        const factId: string | undefined = fact.id;
-        if (!factId) {
-          // A binding we detected has no corresponding engine fact, which means the two
-          // import parsers disagree about this file. That is a parser gap in one file,
-          // not grounds for aborting the whole run: throwing here left repos with no
-          // database at all and no way to onboard. Record it and skip the binding so the
-          // divergence is visible and attributable instead of fatal.
-          importFactReconciliationGaps.push({
-            filePath,
-            line: importUsed.line,
-            symbol: evidenceSymbol(importUsed.name),
-            importSource: importUsed.source
-          });
-          continue;
-        }
-        const finding: Finding = {
-          id: `finding_${fingerprint.slice(0, 16)}`,
-          repo_id: repoId,
-          convention_id: convention.id,
-          fingerprint,
-          title: "API route imports data access directly",
-          message: directDataAccessMessage(filePath, importUsed.name, importUsed.source),
-          severity: convention.severity,
-          enforcement_result: enforcementResultFor(convention.enforcement_mode),
-          status: "new",
-          diff_status: "touched_existing",
-          evidence_refs: [{
-            id: `evidence_${fingerprint.slice(0, 16)}`,
-            kind: "violation",
-            file_path: filePath,
-            start_line: importUsed.line,
-            end_line: importUsed.end_line,
-            symbol: evidenceSymbol(importUsed.name),
-            import_source: importUsed.source,
-            fact_ids: [factId],
-            scan_id: latestScan?.id ?? `scan_check_${hashStable(`${repoId}:${now}`).slice(0, 16)}`,
-            file_hash: snapshot?.content_hash ?? fileContentHash(join(repo.root_path, filePath)),
-            redaction_state: "none"
-          }],
-          created_at: now
-        };
-        storage.upsertFinding(finding);
-        findings.push(finding);
-      }
-    }
-  }
-
-  if (importFactReconciliationGaps.length > 0) {
-    const affectedFiles = [...new Set(importFactReconciliationGaps.map((gap) => gap.filePath))];
-    process.stderr.write(
-      `drift: ${importFactReconciliationGaps.length} import binding(s) across ${affectedFiles.length} file(s) ` +
-        `could not be reconciled against engine facts and were skipped during baseline materialization. ` +
-        `Enforcement for those bindings is degraded. Report at ` +
-        `https://github.com/dadbodgeoff/drift/issues with the paths below.\n` +
-        importFactReconciliationGaps
-          .slice(0, 20)
-          .map((gap) => `  ${gap.filePath}:${gap.line} ${gap.symbol} from ${gap.importSource}\n`)
-          .join("") +
-        (importFactReconciliationGaps.length > 20
-          ? `  ... and ${importFactReconciliationGaps.length - 20} more\n`
-          : "")
-    );
-  }
-
-  return findings;
-}
-
-function importFactEvidenceKey(filePath: string, line: number, name: string, source: string): string {
-  return `${filePath}\0${line}\0${name}\0${source}`;
 }
 
 export function checkNextCommands(

--- a/packages/cli/src/commands/contract.ts
+++ b/packages/cli/src/commands/contract.ts
@@ -1,4 +1,4 @@
-import { authorizeContextExport,DRIFT_CONTRACT_SCHEMA_VERSION,type RepoContract,RepoContractSchema } from "@drift/core";
+import { authorizeContextExport,DRIFT_CONTRACT_SCHEMA_VERSION,hasConventionEvaluator,type RepoContract,RepoContractSchema } from "@drift/core";
 import { buildRepoContractReadModel } from "@drift/query";
 import type { SqliteDriftStorage } from "@drift/storage";
 import { existsSync,mkdirSync,statSync,writeFileSync } from "node:fs";
@@ -226,6 +226,12 @@ export function importContractDryRun(
     !riskyAreaIdsUnique ? "duplicate_risky_area_ids" : undefined,
     !deniedGlobsUnique ? "duplicate_denied_globs" : undefined,
     !rejectedInferencesUnique ? "duplicate_rejected_inferences" : undefined,
+    // A hand-authored contract is the other way a kind with no evaluator reaches storage, where it
+    // would enforce nothing and still report a clean pass. Reported here rather than thrown at
+    // write time so `--dry-run` names it too, which is when someone is asking whether it is valid.
+    contract.conventions.some((convention) => !hasConventionEvaluator(convention.kind))
+      ? "convention_kind_has_no_evaluator"
+      : undefined,
     ...contractValidationReasons(contract)
   ].filter((reason): reason is string => Boolean(reason));
   const compatibility = {

--- a/packages/cli/src/commands/start.ts
+++ b/packages/cli/src/commands/start.ts
@@ -5,7 +5,7 @@ import { CommandPayload,ParsedArgs } from "../app/command-types.js";
 import { doctorCommand } from "../args/doctor-commands.js";
 import { actorFlag,stringFlag } from "../args/flag-readers.js";
 import { requiredDatabasePath,resolveRepoRoot } from "../args/repo-flags.js";
-import { runCheck,runFullRepoCheck } from "../check/run-check.js";
+import { runCheck } from "../check/run-check.js";
 import { createBaselineForFindings } from "../domain/baselines.js";
 import { betaStartResponse } from "../domain/beta-surfaces.js";
 import { materializeRepoContract } from "../domain/contract-materialization.js";
@@ -224,29 +224,22 @@ export async function startRepo(storage: SqliteDriftStorage, parsed: ParsedArgs)
   // Unified rather than extended, per Geoffrey: a second evaluation path is what produced the gap, and
   // adding a presence pass beside the data-access pass would have kept the shape that caused it.
   //
-  // **Measured cost, and why the unified path is conditional.** Running the full check at onboarding
-  // is 4-9x slower than the hand-rolled pass on large repos: cal.com 30.7s -> 115.9s (ceiling 92s)
-  // and papermark 8s -> 73.3s (ceiling 30s), both blowing the harness's onboarding budgets. The
-  // duplication was cheap precisely because it did less. So the unified path is paid only when a
-  // presence family was accepted - the case that needs it - and a repo accepting only the
-  // data-access convention keeps the fast pass and its existing timings. That is not the clean
-  // end-state; it is the honest one until the full check is fast enough to be unconditional.
+  // CV-5 item 4: now unconditional. The unified path was previously paid only when a presence family
+  // was accepted, because running the full check at onboarding cost cal.com 30.7s -> 115.9s (ceiling
+  // 92s) and papermark 8s -> 73.3s (ceiling 30s). That cost was not inherent: `check --scope full`
+  // rebuilt two whole-graph indexes once per import inside its hot loop, which hoisting removed
+  // (run-check.ts, `graphIndexFor`) - dub's full check went 367.4s -> 9.6s. With the precondition
+  // that comment named now met, the fast pass has no remaining justification and `runFullRepoCheck`
+  // is deleted rather than left as a second path that can drift again.
   const anythingAccepted = Boolean(accepted) || acceptedPresenceFamilies.length > 0;
-  const initialFindings = !anythingAccepted
-    ? []
-    : acceptedPresenceFamilies.length > 0
-      ? await onboardingBaselineFindings(
-          storage,
-          parsed,
-          result.repo.id,
-          result.scan.completed_at ?? result.scan.started_at
-        )
-      : runFullRepoCheck(
-          storage,
-          parsed,
-          result.repo.id,
-          result.scan.completed_at ?? result.scan.started_at
-        );
+  const initialFindings = anythingAccepted
+    ? await onboardingBaselineFindings(
+        storage,
+        parsed,
+        result.repo.id,
+        result.scan.completed_at ?? result.scan.started_at
+      )
+    : [];
   const baselineResult = anythingAccepted
     ? createBaselineForFindings(storage, { now, actor }, result.repo.id, initialFindings)
     : { created_count: 0, created_by_convention: {} as Record<string, number> };

--- a/packages/cli/src/domain/convention-candidates.ts
+++ b/packages/cli/src/domain/convention-candidates.ts
@@ -1,4 +1,4 @@
-import { API_ROUTE_SCOPE_GLOBS,DRIFT_CONTRACT_SCHEMA_VERSION,type AcceptedConvention,type ConventionCandidate,type ConventionStatus,type EnforcementMode,type EvidenceRef,type FactRecord,type RejectedInference,type RepoContract,type Severity } from "@drift/core";
+import { API_ROUTE_SCOPE_GLOBS,DRIFT_CONTRACT_SCHEMA_VERSION,hasConventionEvaluator,type AcceptedConvention,type ConventionCandidate,type ConventionStatus,type EnforcementMode,type EvidenceRef,type FactRecord,type RejectedInference,type RepoContract,type Severity } from "@drift/core";
 import type { SqliteDriftStorage } from "@drift/storage";
 import { join } from "node:path";
 import { fileLooksLikeDataAccess,resolveImportTarget } from "../engine/import-resolution.js";
@@ -45,6 +45,13 @@ export function acceptConventionCandidate(
   const mode = input.mode ?? candidate.suggested_enforcement_mode;
   if (mode === "block" && candidate.enforcement_capability !== "deterministic_check") {
     throw new Error("Only deterministic conventions can use --mode block. Use --mode warn, brief, or off for heuristic/briefing conventions.");
+  }
+  // Refuse rather than store a rule nothing evaluates: an accepted convention with no evaluator
+  // produces no finding on any repo and reports a clean pass, which reads as "checked, and fine".
+  if (!hasConventionEvaluator(candidate.kind)) {
+    throw new Error(
+      `Convention kind ${candidate.kind} has no evaluator, so accepting it would enforce nothing while reporting a pass. It cannot be accepted until one is implemented.`
+    );
   }
   if (input.dryRun && input.confirmed) {
     throw new Error("Use either --dry-run or --confirm, not both.");

--- a/packages/cli/src/domain/repo-map.ts
+++ b/packages/cli/src/domain/repo-map.ts
@@ -11,7 +11,8 @@ import {
   repoMapOpenFindingIds,
   repoMapRiskyAreaIds,
   type CanonicalFactRouteInput,
-  type RepoMapFile
+  type RepoMapFile,
+  repoMapFileForPayload
 } from "@drift/query";
 import type { SqliteDriftStorage } from "@drift/storage";
 import { agentEnvelopeForScan } from "./agent-envelope.js";
@@ -186,7 +187,11 @@ export function repoMapPayload(
       surface: options.surface,
       policy,
       scanStatus,
-      requireFresh: Boolean(options.requireFresh)
+      requireFresh: Boolean(options.requireFresh),
+      // Same value the payload's `redactions` reports. The envelope builds its own redactions and
+      // defaulted this to false, so a paginated map claimed `safe_to_edit` in the envelope while
+      // `redactions.context_truncated` said true one key away.
+      contextTruncated: readModel.pagination.has_more
     }),
     policy,
     readiness,
@@ -212,13 +217,15 @@ export function repoMapPayload(
     routes: phase8Security.routes,
     framework_entrypoints: frameworkEntryPoints,
     freshness_requirement: freshnessRequirement(Boolean(options.requireFresh), scanStatus),
-    files: readModel.listed_files,
+    files: readModel.listed_files.map(repoMapFileForPayload),
     redactions: {
       denied_globs: contract.context_egress.denied_globs,
       snippets_included: false,
       source_content_included: false,
       graph_context_included: Boolean(graphMap),
-      context_truncated: false
+      // Derived, not asserted: a paginated map is a subset, and `has_more` already says so. Claiming
+      // `false` here told the envelope to report `safe_to_edit` for a response that omits files.
+      context_truncated: readModel.pagination.has_more
     },
     next_commands: [
       `drift prepare "task" --repo ${repoId} --json`,

--- a/packages/cli/src/domain/scan-status.ts
+++ b/packages/cli/src/domain/scan-status.ts
@@ -1186,8 +1186,20 @@ export function assertFreshScanIfRequired(
   if (!required || !scanStatus.stale) {
     return;
   }
-  throw new Error(
-    `Scan is stale for ${repoId}. Run ${scanStatus.next_command}; omit --require-fresh to inspect stale context.`
+  // A stale scan under --require-fresh is a fail-closed refusal, which the exit-code contract
+  // (run-check.ts) codes 3. This threw a plain Error, so `prepare`, `ask`, `policy`, `findings` and
+  // `repo map` all exited 1 - the code reserved for "drift itself broke" - for a refusal Drift made
+  // deliberately and correctly. A caller distinguishing the two got the wrong answer.
+  throw new DriftError(
+    `Scan is stale for ${repoId}. Run ${scanStatus.next_command}; omit --require-fresh to inspect stale context.`,
+    {
+      code: "stale_scan",
+      userAction: `Run ${scanStatus.next_command}, or omit --require-fresh to inspect stale context.`,
+      recoveryCommands: scanStatus.next_command ? [scanStatus.next_command] : [],
+      // docs/reference/errors.md already lists stale_scan as retryable after a rescan.
+      safeToRetry: true,
+      exitCode: 3
+    }
   );
 }
 

--- a/packages/cli/src/engine/fact-extraction.ts
+++ b/packages/cli/src/engine/fact-extraction.ts
@@ -193,6 +193,7 @@ export function importFactsForFile(facts: FactRecord[], filePath: string): Array
   name: string;
   value: string;
   start_line: number;
+  end_line: FactRecord["end_line"];
 }> {
   return facts
     .filter((fact) => fact.kind === "import_used" && fact.file_path === filePath && fact.value)
@@ -200,7 +201,10 @@ export function importFactsForFile(facts: FactRecord[], filePath: string): Array
       fact_id: fact.id,
       name: fact.name,
       value: fact.value as string,
-      start_line: fact.start_line
+      start_line: fact.start_line,
+      // Carried so a multiline import keeps its real span: this projection is what check builds a
+      // finding's evidence ref from, and dropping it flattened `import {\n x \n} from "y"` to one line.
+      end_line: fact.end_line
     }));
 }
 

--- a/packages/cli/src/formatters/repo-map.ts
+++ b/packages/cli/src/formatters/repo-map.ts
@@ -1,6 +1,5 @@
 import type { FileRole } from "@drift/core";
-import type { ParserGapQuality } from "@drift/query";
-import { RepoMapFile } from "../domain/repo-map.js";
+import type { ParserGapQuality,RepoMapFilePayload } from "@drift/query";
 import { formatCounts } from "./findings.js";
 
 export function formatRepoMapText(payload: {
@@ -23,7 +22,7 @@ export function formatRepoMapText(payload: {
     next_offset: number | null;
   };
   parser_gap_quality?: ParserGapQuality;
-  files: RepoMapFile[];
+  files: RepoMapFilePayload[];
   next_commands: string[];
 }): string {
   const parserGapLines = payload.parser_gap_quality && payload.parser_gap_quality.total_count > 0
@@ -45,10 +44,12 @@ export function formatRepoMapText(payload: {
     `Page: offset ${payload.pagination.offset}, returned ${payload.pagination.returned_count}, next offset ${payload.pagination.next_offset ?? "none"}`,
     `Filter role: ${payload.filters.role ?? "all"}`,
     `Filter path: ${payload.filters.path ?? "all"}`,
-    `Roles: ${formatCounts(payload.summary.role_counts)}`,
-    `Imports: ${payload.summary.import_count}`,
-    `Exports: ${payload.summary.export_count}`,
-    `Calls: ${payload.summary.call_count}`,
+    // Scoped labels: these describe the filtered set, not the page printed below. Unlabelled, they
+    // sat under "Files: 25 of 4091" and read as repo-wide numbers.
+    `Roles (filtered): ${formatCounts(payload.summary.role_counts)}`,
+    `Imports (filtered): ${payload.summary.import_count}`,
+    `Exports (filtered): ${payload.summary.export_count}`,
+    `Calls (filtered): ${payload.summary.call_count}`,
     ...parserGapLines,
     "",
     "Files:",

--- a/packages/cli/test/cli.test.ts
+++ b/packages/cli/test/cli.test.ts
@@ -6457,7 +6457,10 @@ storage_schema_version: 33
       "--json"
     ]);
 
-    expect(result.exitCode).toBe(1);
+    // stale_scan is a fail-closed refusal, not an operational error: docs/reference/errors.md
+    // lists it with the other refusal codes at exit 3. This asserted 1 because
+    // assertFreshScanIfRequired threw a plain Error instead of a DriftError.
+    expect(result.exitCode).toBe(3);
     expect(result.stderr).toContain("Scan is stale for repo_abc.");
     expect(result.stderr).toContain("drift scan --repo-root");
     expect(result.stderr).toContain("omit --require-fresh");
@@ -6475,7 +6478,10 @@ storage_schema_version: 33
       "--json"
     ]);
 
-    expect(result.exitCode).toBe(1);
+    // stale_scan is a fail-closed refusal, not an operational error: docs/reference/errors.md
+    // lists it with the other refusal codes at exit 3. This asserted 1 because
+    // assertFreshScanIfRequired threw a plain Error instead of a DriftError.
+    expect(result.exitCode).toBe(3);
     expect(result.stderr).toContain("Scan is stale for repo_abc.");
     expect(result.stderr).toContain("drift scan --repo-root");
     expect(result.stderr).toContain("omit --require-fresh");
@@ -9842,7 +9848,10 @@ schema_version: 33,
       "--json"
     ]);
 
-    expect(prepared.exitCode).toBe(1);
+    // stale_scan is a fail-closed refusal, not an operational error: docs/reference/errors.md
+    // lists it with the other refusal codes at exit 3. This asserted 1 because
+    // assertFreshScanIfRequired threw a plain Error instead of a DriftError.
+    expect(prepared.exitCode).toBe(3);
     expect(prepared.stderr).toContain("Scan is stale for repo_abc.");
     expect(prepared.stderr).toContain("drift scan --repo-root");
     expect(prepared.stderr).toContain("omit --require-fresh");
@@ -10447,7 +10456,10 @@ schema_version: 33,
       "--json"
     ]);
 
-    expect(asked.exitCode).toBe(1);
+    // stale_scan is a fail-closed refusal, not an operational error: docs/reference/errors.md
+    // lists it with the other refusal codes at exit 3. This asserted 1 because
+    // assertFreshScanIfRequired threw a plain Error instead of a DriftError.
+    expect(asked.exitCode).toBe(3);
     expect(asked.stderr).toContain("Scan is stale for repo_abc.");
     expect(asked.stderr).toContain("drift scan --repo-root");
     expect(asked.stderr).toContain("omit --require-fresh");
@@ -10792,7 +10804,10 @@ schema_version: 33,
       "--json"
     ]);
 
-    expect(mapped.exitCode).toBe(1);
+    // stale_scan is a fail-closed refusal, not an operational error: docs/reference/errors.md
+    // lists it with the other refusal codes at exit 3. This asserted 1 because
+    // assertFreshScanIfRequired threw a plain Error instead of a DriftError.
+    expect(mapped.exitCode).toBe(3);
     expect(mapped.stderr).toContain("Scan is stale for repo_abc.");
     expect(mapped.stderr).toContain("drift scan --repo-root");
     expect(mapped.stderr).toContain("omit --require-fresh");
@@ -11862,7 +11877,10 @@ schema_version: 33,
       "--json"
     ]);
 
-    expect(result.exitCode).toBe(1);
+    // stale_scan is a fail-closed refusal, not an operational error: docs/reference/errors.md
+    // lists it with the other refusal codes at exit 3. This asserted 1 because
+    // assertFreshScanIfRequired threw a plain Error instead of a DriftError.
+    expect(result.exitCode).toBe(3);
     expect(result.stderr).toContain("Scan is stale for repo_abc.");
     expect(result.stderr).toContain("drift scan --repo-root");
     expect(result.stderr).toContain("omit --require-fresh");

--- a/packages/cli/test/frozen-contracts.test.ts
+++ b/packages/cli/test/frozen-contracts.test.ts
@@ -1,0 +1,84 @@
+import { describe, expect, it } from "vitest";
+import {
+  CHECK_EXIT_BLOCKED,
+  CHECK_EXIT_ERROR,
+  CHECK_EXIT_PASS,
+  CHECK_EXIT_REFUSED
+} from "../src/check/run-check.js";
+import {
+  agentContractFindingFingerprint,
+  canonicalHelperReuseFindingFingerprint,
+  findingFingerprint
+} from "../src/check/finding-fingerprint.js";
+
+/**
+ * Contracts that are cheap to change today and expensive once anyone depends on them.
+ *
+ * Two things are pinned here, both for the same reason: a change to either is silent. Nothing else
+ * in the suite fails, the change ships, and the damage lands on a user's CI config or a user's
+ * stored baseline rather than on a red test.
+ */
+describe("frozen contracts", () => {
+  /**
+   * Exit codes are a CI integration surface. Renumbering them turns "this diff violates the
+   * contract" into "passed" for every pipeline keyed on the old numbers, with no error anywhere.
+   *
+   * The values, not just their distinctness, are the contract - documented in run-check.ts and
+   * docs/reference/errors.md.
+   */
+  it("pins the drift check exit-code contract", () => {
+    expect(CHECK_EXIT_PASS).toBe(0);
+    expect(CHECK_EXIT_ERROR).toBe(1);
+    expect(CHECK_EXIT_BLOCKED).toBe(2);
+    expect(CHECK_EXIT_REFUSED).toBe(3);
+  });
+
+  /**
+   * Finding fingerprints are what a baseline row is keyed on. Change any hash input - the salt, the
+   * field list, the order, the separator, the path normalisation - and every stored baseline
+   * orphans at once: findings that were `pre_existing` come back `new`, and a user's first check
+   * after upgrading floods with violations for code they did not write.
+   *
+   * These are the exact five inputs as of this commit. A deliberate change means updating the
+   * expected digests here AND populating `legacyFingerprints` (run-check.ts) so old baselines still
+   * match - that parameter exists and is currently never passed a non-default value.
+   */
+  it("pins findingFingerprint inputs and digest", () => {
+    expect(
+      findingFingerprint("convention_x", "apps/web/app/api/users/route.ts", "prisma", "@/lib/prisma")
+    ).toBe("f89345641d5764b90d14c8ce1f569170c0d67bc6788356ba11764a17f83a36a5");
+  });
+
+  it("pins canonicalHelperReuseFindingFingerprint inputs and digest", () => {
+    expect(
+      canonicalHelperReuseFindingFingerprint(
+        "agent_contract_x",
+        "helper_x",
+        "apps/web/app/api/users/route.ts",
+        "getSession"
+      )
+    ).toBe("dd33bdee2934310b7fbee964d75ad7b611acff7e25bee347fae3a602bd703fe1");
+  });
+
+  it("pins agentContractFindingFingerprint inputs and digest", () => {
+    expect(
+      agentContractFindingFingerprint(
+        "module_placement",
+        "agent_contract_x",
+        "apps/web/app/api/users/route.ts",
+        "handler",
+        "service"
+      )
+    ).toBe("6781cc5e1c94fdff24b89c6d57e587c27dc38c097a140d9097b25dfe5b0bb0da");
+  });
+
+  /**
+   * Windows-style separators must normalise to the posix form, or the same finding fingerprints
+   * differently depending on the platform that produced the baseline.
+   */
+  it("normalises path separators before hashing", () => {
+    expect(findingFingerprint("c", "a\\b\\route.ts", "s", "src")).toBe(
+      findingFingerprint("c", "a/b/route.ts", "s", "src")
+    );
+  });
+});

--- a/packages/core/src/capabilities.ts
+++ b/packages/core/src/capabilities.ts
@@ -195,6 +195,34 @@ export function isExperimentalSecurityKind(kind: string): boolean {
 }
 
 /**
+ * Kinds `ConventionKindSchema` accepts that no evaluator implements.
+ *
+ * Established by searching both evaluators for every declared kind: the engine-owned
+ * `crates/drift-engine/src/check_command.rs` and the CLI-owned
+ * `packages/cli/src/check/run-check.ts`. These three appear in neither, so a contract declaring one
+ * produces no finding on any repo, ever, and nothing reports that - `check` returns a clean pass.
+ * "Accepted and silently enforcing nothing" is the one thing Drift must not let a user believe, so
+ * acceptance refuses them instead of storing an inert rule.
+ *
+ * Note this is NOT the same as experimental: `middleware_must_cover_routes` is in
+ * EXPERIMENTAL_SECURITY_CONVENTION_KINDS above, which gates default-on behaviour, not whether an
+ * implementation exists. Nor is it "no TypeScript evaluator" -
+ * `api_route_requires_service_delegation` has none but IS evaluated by the engine, so it is absent
+ * from this list.
+ *
+ * Deleting a kind from here is the LAST step of implementing it, not the first.
+ */
+export const UNIMPLEMENTED_CONVENTION_KINDS = [
+  "middleware_must_cover_routes",
+  "test_expected_for_changed_module",
+  "custom_briefing"
+] as const;
+
+export function hasConventionEvaluator(kind: string): boolean {
+  return !(UNIMPLEMENTED_CONVENTION_KINDS as readonly string[]).includes(kind);
+}
+
+/**
  * CV-3: the kinds a presence-only family may be promoted for.
  *
  * These three, and no others, because these three are the ones whose claim can be reduced to "the

--- a/packages/mcp/src/index.ts
+++ b/packages/mcp/src/index.ts
@@ -84,7 +84,9 @@ import {
   selectRelevantTests,
   type ChangeImpactRouteFlow,
   type DriftReadinessSurface,
-  type RepoMapFile,rankRelevantFiles} from "@drift/query";
+  type RepoMapFile,rankRelevantFiles,
+  repoMapFileForPayload
+} from "@drift/query";
 import { MIGRATIONS, openDriftStorage } from "@drift/storage";
 import { execFileSync } from "node:child_process";
 import { createHash } from "node:crypto";
@@ -1732,7 +1734,9 @@ function repoMapPayload(
       surface: options.surface,
       policy,
       scanStatus,
-      requireFresh: Boolean(options.requireFresh)
+      requireFresh: Boolean(options.requireFresh),
+      // Same value the payload's `redactions` reports - see the CLI repo-map payload.
+      contextTruncated: readModel.pagination.has_more
     }),
     policy,
     readiness,
@@ -1761,13 +1765,14 @@ function repoMapPayload(
     proof_freshness: phase8Security.proof_freshness,
     framework_entrypoints: frameworkEntryPoints,
     freshness_requirement: freshnessRequirement(Boolean(options.requireFresh), scanStatus),
-    files: readModel.listed_files,
+    files: readModel.listed_files.map(repoMapFileForPayload),
     redactions: {
       denied_globs: contract.context_egress.denied_globs,
       snippets_included: false,
       source_content_included: false,
       graph_context_included: Boolean(graphMap),
-      context_truncated: false
+      // Derived, not asserted - see the CLI repo-map payload for the same reasoning.
+      context_truncated: readModel.pagination.has_more
     },
     next_commands: [
       `drift prepare "task" --repo ${repoId} --json`,
@@ -2728,6 +2733,7 @@ function mcpAgentEnvelope(input: {
   scanStatus: ReturnType<typeof scanStatusPayload>;
   requireFresh: boolean;
   diagnostics?: string[];
+  contextTruncated?: boolean;
 }) {
   return createAgentEnvelopeV2({
     surface: input.surface,
@@ -2739,7 +2745,7 @@ function mcpAgentEnvelope(input: {
     },
     redactions: {
       snippets_included: false,
-      context_truncated: false
+      context_truncated: Boolean(input.contextTruncated)
     },
     diagnostics: input.diagnostics
   });

--- a/packages/query/src/index.ts
+++ b/packages/query/src/index.ts
@@ -151,6 +151,28 @@ export interface GraphRepoMap {
   };
 }
 
+/**
+ * A repo-map file as emitted to a caller.
+ *
+ * `graph_node_ids` and `evidence_ids` are omitted. Measured on dub they are 17.85 MB of the
+ * 22.5 MB `files` array - 66% of the whole 27 MB document - and nothing reads either field back
+ * off an emitted repo map. They are built once (see `buildRepoMapFiles`) and never consumed:
+ * internal graph traversal uses the `evidence_ids` on graph NODES and EDGES, a different field on
+ * a different object, and `getFindingEvidence` takes `evidence_ids` as a caller-supplied argument
+ * sourced from a finding's `evidence_refs`.
+ *
+ * Shared rather than applied at each call site, because the CLI and MCP assemble the rest of this
+ * document independently and have already been found disagreeing once (BB-5/BB-6).
+ */
+export type RepoMapFilePayload = Omit<RepoMapFile, "graph_node_ids" | "evidence_ids">;
+
+export function repoMapFileForPayload(file: RepoMapFile): RepoMapFilePayload {
+  const { graph_node_ids, evidence_ids, ...payload } = file;
+  void graph_node_ids;
+  void evidence_ids;
+  return payload;
+}
+
 export interface RepoMapFile extends GraphRepoMapFile {
   convention_ids: string[];
   risky_area_ids: string[];
@@ -825,7 +847,7 @@ export function buildRepoMapReadModel(input: {
     filtered_files: filteredFiles,
     listed_files: listedFiles,
     summary: repoMapSummary(allFiles, filteredFiles, listedFiles),
-    impact_summary: repoMapImpactSummary(listedFiles),
+    impact_summary: repoMapImpactSummary(filteredFiles),
     pagination: repoMapPagination(filteredFiles.length, listedFiles.length, input.limit, offset),
     topology: buildRepoTopology({
       repo_id: input.repoId ?? input.contract.repo_id,
@@ -914,6 +936,18 @@ export function paginateRepoMapFiles(files: RepoMapFile[], limit: number | undef
     : files.slice(offset, offset + limit);
 }
 
+/**
+ * Aggregates describe the FILTERED set, not the returned page.
+ *
+ * These were computed from `listedFiles`, so `--limit 25` on dub reported
+ * `convention_coverage_count: 493 -> 0`, `risky_file_count: 493 -> 0` and
+ * `open_finding_count: 397 -> 0` while `indexed_file_count` still read 4091, and the human
+ * formatter printed them as bare repo-level lines. Nothing marked them page-scoped, so a caller
+ * that paginated got numbers that looked repo-wide and were not.
+ *
+ * Pagination is a transport concern: `listed_file_count` and `pagination` describe the window,
+ * `filtered_file_count` sizes the set these aggregates summarise.
+ */
 export function repoMapImpactSummary(files: RepoMapFile[]): RepoMapImpactSummary {
   return {
     convention_coverage_count: files.filter((file) => file.convention_ids.length > 0).length,
@@ -928,7 +962,7 @@ export function repoMapSummary(
   listedFiles: RepoMapFile[]
 ): RepoMapSummary {
   const roleCounts: Record<string, number> = {};
-  for (const file of listedFiles) {
+  for (const file of filteredFiles) {
     for (const role of file.roles) {
       roleCounts[role] = (roleCounts[role] ?? 0) + 1;
     }
@@ -938,9 +972,9 @@ export function repoMapSummary(
     filtered_file_count: filteredFiles.length,
     listed_file_count: listedFiles.length,
     role_counts: roleCounts,
-    import_count: listedFiles.reduce((count, file) => count + file.imports.length, 0),
-    export_count: listedFiles.reduce((count, file) => count + file.exported_symbols.length, 0),
-    call_count: listedFiles.reduce((count, file) => count + file.calls.length, 0)
+    import_count: filteredFiles.reduce((count, file) => count + file.imports.length, 0),
+    export_count: filteredFiles.reduce((count, file) => count + file.exported_symbols.length, 0),
+    call_count: filteredFiles.reduce((count, file) => count + file.calls.length, 0)
   };
 }
 


### PR DESCRIPTION
`check --scope full` was quadratic in repo size for a mechanical reason. Fixing it unblocked a correctness gap that had previously been routed around rather than repaired, and the same pass removes several places where Drift asserted something it had not measured.

Every number below was measured on the corpus repos, not estimated.

## Hoist loop-invariant graph indexes

`graphImportResolvesToForbidden` and `exceptionContextForImport` run once per import per in-scope file. Each rebuilt a Map over every evidence row and a Map over every node **on every call**, then scanned all nodes linearly to find one import. `exceptionContextForImport` was additionally an eagerly-evaluated argument whose result is discarded when a convention has no exceptions — as dub's does.

Cost is `imports_in_scope × graph_size`, i.e. quadratic in repo size at fixed route density. openstatus is the control: 2,185 files and a 78% larger graph than papermark, but 3× faster, because it has 37 in-scope routes to papermark's 283.

| repo | before | after | findings |
|---|---:|---:|---|
| dub | 367.4s | **9.6s** | 397 = 397 |
| papermark | 66.1s | **2.0s** | 264 = 264 |
| openstatus | 22.2s | **3.5s** | 31 = 31 |

## Unify onboarding baseline seeding, delete `runFullRepoCheck`

That second path existed only because the full check was too slow to run at onboarding (cal.com 30.7s → 115.9s against a 92s ceiling). It opened with `if (convention.kind !== "api_route_no_direct_data_access") continue;`, so a repo whose top-ranked candidate is any **other** kind baselined zero of its pre-existing violations, and the user's first `drift check` reported them all as new. Closes CV-5-i4, which was blocked on exactly this speed precondition. −181 lines.

Baselined counts unchanged on every repo, so BB-8 has nothing to explain:

| repo | baselined | onboarding | ceiling |
|---|---|---|---|
| dub | 397 → 397 | 24.0s → 34.0s | — |
| papermark | 264 → 264 | 8.7s → 10.9s | 30s |
| calcom | 39 → 39 | 28.7s → 35.6s | 92s |

This also surfaced a real defect in `check`: the engine reports a violation at a single line (`check_command.rs:336`), flattening multiline imports, while the import fact carries the true span. 4 dub findings now carry correct spans.

## Repo-map aggregates were page-scoped

`repoMapSummary`/`repoMapImpactSummary` computed from the returned page. On dub, `--limit 25` reported `convention_coverage 493 → 0`, `risky_file 493 → 0`, `open_finding 397 → 0` while `indexed_file_count` still read 4091 — and the formatter printed them as bare repo-level lines. They now describe the filtered set; labels say so.

## Repo-map payload

`graph_node_ids` + `evidence_ids` were 17.85MB of dub's 22.5MB `files` array — 66% of the whole document — and nothing reads either field back off an emitted map. Removed via one shared projection so CLI and MCP cannot disagree about file shape (cf. BB-5/BB-6).

- CLI: 27,016,320 → **5,276,230** bytes (−80.5%)
- MCP: 23,577,889 → **3,784,856** bytes (−84%)

All 4,091 files still present.

## Convention kinds with no evaluator are refused

`middleware_must_cover_routes`, `test_expected_for_changed_module` and `custom_briefing` appear in **neither** evaluator, so accepting one enforced nothing and reported a clean pass. Now refused at candidate acceptance and as a contract-import compatibility reason, so `--dry-run` names it too. (`api_route_requires_service_delegation` has no TS evaluator but *is* evaluated by the engine, so it is deliberately not on that list.)

## `context_truncated` is derived, not asserted

Hardcoded `false` everywhere. A paginated map now reports it — and the agent envelope, which built its own redactions and defaulted to false, is fed the same value, so it can no longer claim `safe_to_edit` one key away from `context_truncated: true`.

## Frozen contracts

New `frozen-contracts.test.ts` pins exit codes and all three finding-fingerprint digests. Both change silently today: a fingerprint input change orphans every stored baseline (`pre_existing` findings return as `new`), and an exit-code change flips CI from blocked to passed.

Also fixed: `stale_scan` threw a plain `Error` and exited **1**, though `docs/reference/errors.md` lists it with the refusal codes at **3**. Six tests were asserting the old behaviour and are updated with the reason.

## Verification

- `pnpm verify:ci` exits 0, output reaches the final `beta:proof` JSON (`audit_verification.valid: true`)
- 1,060 tests pass across all 8 packages
- Determinism digest unchanged: taxonomy `f208ce7ce3bef7a0`, matching `beta-claims.json:198`
- dub `check --scope full` output identical across two runs **including order**; all 397 findings return `pre_existing`, which is the fingerprint proof — any drift would have surfaced them as `new`

## Known remaining

`repo map --limit 25` is still ~463K tokens, now dominated by `topology` (741KB) and `routes` (488KB), which don't respect `--limit` because both derive from `all_files`. Unlike the removed ID fields, topology **is** consumed, so bounding it is a contract decision left for a follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)