### PR TITLE
feat(ci): gate migration-backed tables on having production writers and readers

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
     "validate:claims": "node scripts/validate-product-claims.mjs",
     "beta:proof": "node scripts/run-beta-proof.mjs",
     "release:proof": "node scripts/generate-release-proof.mjs",
-    "verify:ci": "pnpm verify && pnpm test:harness && pnpm format:engine:check && pnpm lint:engine && pnpm check:boundaries && node scripts/validate-engine-release-matrix.mjs --allow-unverified && pnpm validate:claims && pnpm beta:proof && git diff --check",
+    "verify:ci": "pnpm verify && pnpm test:harness && pnpm format:engine:check && pnpm lint:engine && pnpm check:boundaries && pnpm check:storage-lifecycle && node scripts/validate-engine-release-matrix.mjs --allow-unverified && pnpm validate:claims && pnpm beta:proof && git diff --check",
     "verify:evals": "pnpm eval:external && pnpm eval:evasion && pnpm eval:bench && pnpm eval:determinism",
     "verify:full": "pnpm verify:ci && pnpm verify:evals",
     "eval:external": "node scripts/external-eval.mjs",
@@ -33,10 +33,11 @@
     "eval:bench:update": "node scripts/beta-bench.mjs --update",
     "eval:determinism": "node scripts/determinism.mjs",
     "run:log": "node scripts/run-log.mjs",
-    "test:harness": "vitest run scripts/external-eval.test.mjs scripts/evasion-matrix.test.mjs scripts/validate-engine-release-matrix.test.mjs scripts/worktree-contamination.test.mjs scripts/beta-bench-ratchet.test.mjs scripts/validate-product-claims.test.mjs scripts/engine-handshake.test.mjs scripts/external-eval-start.test.mjs",
+    "test:harness": "vitest run scripts/external-eval.test.mjs scripts/evasion-matrix.test.mjs scripts/validate-engine-release-matrix.test.mjs scripts/worktree-contamination.test.mjs scripts/beta-bench-ratchet.test.mjs scripts/validate-product-claims.test.mjs scripts/engine-handshake.test.mjs scripts/external-eval-start.test.mjs scripts/storage-lifecycle.test.mjs",
     "eval:prepare": "node scripts/prepare-quality-eval.mjs",
     "eval:presence": "node scripts/presence-precision-recall.mjs",
-    "eval:presence:update": "node scripts/presence-precision-recall.mjs --update"
+    "eval:presence:update": "node scripts/presence-precision-recall.mjs --update",
+    "check:storage-lifecycle": "node scripts/storage-lifecycle.mjs"
   },
   "devDependencies": {
     "@types/node": "^22.15.0",

--- a/scripts/storage-lifecycle-baseline.json
+++ b/scripts/storage-lifecycle-baseline.json
@@ -1,0 +1,73 @@
+{
+  "what_this_is": "Storage methods that reach a migration-backed table and have no production caller. Honest current truth, not an allowlist of things that are fine. Each entry is a known gap, recorded so the class cannot grow silently and so fixing one forces removing its entry. Enforced by scripts/storage-lifecycle.mjs.",
+  "severity": {
+    "writer_orphan": "The table is never populated in production. Every read of it is empty, and any surface reporting on it is reporting on nothing.",
+    "reader_orphan": "The table IS populated and nothing in production reads it. Dead read API and storage cost, not a false signal."
+  },
+  "measured_at": {
+    "commit": "f058c310",
+    "repo": "dub",
+    "note": "Row counts below came from a real onboarding scan of ~/drift-falsification/repos/dub, which is what distinguishes a writer orphan (table empty) from a reader orphan (table populated, unread)."
+  },
+  "known_orphans": [
+    {
+      "method": "upsertParserGapV2",
+      "table": "parser_gaps",
+      "kind": "writer_orphan",
+      "rows_on_dub": 639,
+      "reason": "The V2 arm has only test callers, so no V2 row is ever written; the 639 rows are all V1. Four agent surfaces (prepare, repo map, and two MCP tools) do `[...parserGaps, ...parserGapV2]` against a permanently empty array. Either give V2 a real writer or delete the arm - the merge currently advertises a capability that produces nothing."
+    },
+    {
+      "method": "upsertSecurityBoundaryProofs",
+      "table": "security_boundary_proofs",
+      "kind": "writer_orphan",
+      "rows_on_dub": 0,
+      "reason": "Measured 0 rows after a full dub onboarding. Note the sibling `upsertSecurityBoundaryProofRuns` IS called in production (run-check.ts), so the runs path is live while this one is not; the two are easy to confuse when reading the security read-model code."
+    },
+    {
+      "method": "upsertSymbolIdentities",
+      "table": "symbol_identities",
+      "kind": "writer_orphan",
+      "rows_on_dub": 0,
+      "reason": "Measured 0 rows on dub. Found by this check rather than by either architecture audit, both of which missed it - which is the argument for the check existing."
+    },
+    {
+      "method": "getScanManifest",
+      "table": "scan_manifests",
+      "kind": "reader_orphan",
+      "reason": "Production reads scan manifests through listScanManifests instead. Single-manifest lookup is used only by tests."
+    },
+    {
+      "method": "listCheckRuns",
+      "table": "check_runs",
+      "kind": "reader_orphan",
+      "reason": "check_runs is written on every check as a provenance log and never read back to skip or explain work. The log is write-only by design today; this entry records that the read API is unused rather than that the table is."
+    },
+    {
+      "method": "listFrameworkAdapters",
+      "table": "framework_adapters",
+      "kind": "reader_orphan",
+      "reason": "One adapter row per scan on dub. Read models rebuild adapter information from normalized entrypoints rather than from this table."
+    },
+    {
+      "method": "listGraphCompleteness",
+      "table": "graph_completeness",
+      "kind": "reader_orphan",
+      "reason": "Populated per scan; completeness reaches consumers through the scan payload rather than by querying this table."
+    },
+    {
+      "method": "listModuleDependents",
+      "table": "module_dependents",
+      "kind": "reader_orphan",
+      "rows_on_dub": 15311,
+      "reason": "15,311 rows written per dub scan and never queried in production. Dependents are traversed from graph edges instead."
+    },
+    {
+      "method": "listSymbolOccurrences",
+      "table": "symbol_occurrences",
+      "kind": "reader_orphan",
+      "rows_on_dub": 41905,
+      "reason": "41,905 rows written per dub scan and never queried in production - the single largest unread table. Together with module_dependents this is roughly 57,000 rows per scan with no consumer."
+    }
+  ]
+}

--- a/scripts/storage-lifecycle.mjs
+++ b/scripts/storage-lifecycle.mjs
@@ -1,0 +1,208 @@
+#!/usr/bin/env node
+/**
+ * Every migration-backed table must be written and read by production code.
+ *
+ * The failure this exists to stop is not hypothetical and not rare. A table gets a migration, a
+ * storage method, a schema and a test - and no production caller. Nothing fails: the table simply
+ * stays empty forever while readers merge an always-empty array into their output. `ParserGapV2` is
+ * the worked example: `upsertParserGapV2` has only test callers, and four agent surfaces
+ * (`prepare`, `repo map`, and two MCP tools) do `[...parserGaps, ...parserGapV2]` against nothing.
+ *
+ * Two independent audits of this repo each found a DIFFERENT subset of this class, which is the
+ * argument for a rule rather than a third audit. This check found a third instance neither had
+ * (`upsertSymbolIdentities`), and confirmed the shape against the database: both tables whose
+ * writers have no production caller measure 0 rows on a real dub scan.
+ *
+ * SEVERITY. A missing writer and a missing reader are not the same defect:
+ *   - `writer_orphan`  the table is never populated. Every read is empty, and any surface that
+ *                      reports on it is reporting on nothing. This is the ParserGapV2 disease.
+ *   - `reader_orphan`  the table IS populated and nothing in production reads it. Cheaper - dead
+ *                      read API rather than a false signal - but it is still storage cost with no
+ *                      consumer: `symbol_occurrences` and `module_dependents` alone are ~57,000
+ *                      rows per dub scan that nothing queries.
+ *
+ * RATCHET, both directions - the shape `scripts/evasion-baseline.json` uses. The baseline records
+ * honest current truth, never hides a known gap, and fails on:
+ *   - a NEW orphan, so the class cannot grow silently;
+ *   - a baselined orphan that now HAS a production caller, so fixing one forces removing its entry
+ *     rather than leaving a stale claim behind.
+ *
+ * Deliberately static. Running the product and counting rows would be a stronger signal but a much
+ * slower and flakier gate; "no production caller" is decidable from the source and was cross-checked
+ * against real row counts when the baseline was written.
+ */
+
+import { readdirSync, readFileSync, statSync } from "node:fs";
+import { join } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const repoRoot = fileURLToPath(new URL("..", import.meta.url));
+const BASELINE_PATH = join(repoRoot, "scripts/storage-lifecycle-baseline.json");
+const STORAGE_PATH = join(repoRoot, "packages/storage/src/sqlite-storage.ts");
+const MIGRATIONS_PATH = join(repoRoot, "packages/storage/src/migrations.ts");
+
+/** Tables the migrations create. The universe this check is about. */
+function migrationTables() {
+  const source = readFileSync(MIGRATIONS_PATH, "utf8");
+  return [...source.matchAll(/CREATE TABLE IF NOT EXISTS ([a-z_]+)/g)]
+    .map((match) => match[1])
+    .filter((table) => table !== "schema_migrations")
+    .sort()
+    .filter((table, index, all) => all.indexOf(table) === index);
+}
+
+/**
+ * Attribute each SQL statement to the storage method containing it.
+ *
+ * Method-level rather than statement-level because the question is "can production reach this
+ * table", and a caller reaches a method, not a statement.
+ */
+function tableMethods(tables) {
+  const source = readFileSync(STORAGE_PATH, "utf8");
+  const starts = [...source.matchAll(/^ {2}([a-zA-Z_][a-zA-Z0-9_]*)\s*\(/gm)]
+    .map((match) => ({ index: match.index, name: match[1] }));
+  const methodAt = (position) => {
+    let name;
+    for (const entry of starts) {
+      if (entry.index <= position) {
+        name = entry.name;
+      } else {
+        break;
+      }
+    }
+    return name;
+  };
+
+  const result = {};
+  for (const table of tables) {
+    const writers = new Set();
+    const readers = new Set();
+    const write = new RegExp(`INSERT (?:OR REPLACE )?INTO ${table}\\b|UPDATE ${table}\\b|DELETE FROM ${table}\\b`, "g");
+    const read = new RegExp(`FROM ${table}\\b`, "g");
+    for (const match of source.matchAll(write)) {
+      const name = methodAt(match.index);
+      if (name) writers.add(name);
+    }
+    for (const match of source.matchAll(read)) {
+      const name = methodAt(match.index);
+      if (name) readers.add(name);
+    }
+    result[table] = { writers: [...writers].sort(), readers: [...readers].sort() };
+  }
+  return result;
+}
+
+/**
+ * Every line of production source, read once.
+ *
+ * Built as a single corpus rather than grepping per method: there are ~64 storage methods reachable
+ * from a table, and a repo-wide grep each took this gate to ~105 seconds - slow enough that it
+ * would be the longest step in `verify:ci` and get skipped locally. One filesystem walk makes it
+ * sub-second.
+ *
+ * "Production" excludes tests, build output and dependencies. A test calling a method is exactly
+ * the situation this gate exists to catch, so tests cannot count as callers.
+ */
+function productionSource() {
+  const SKIP = new Set(["node_modules", "dist", "target", ".git", "coverage", ".next", "test", "tests"]);
+  const chunks = [];
+  const visit = (directory) => {
+    for (const entry of readdirSync(directory, { withFileTypes: true })) {
+      if (entry.name.startsWith(".")) continue;
+      const full = join(directory, entry.name);
+      if (entry.isDirectory()) {
+        if (!SKIP.has(entry.name)) visit(full);
+        continue;
+      }
+      if (!/\.(ts|tsx|mts|cts|js|mjs|cjs|rs)$/.test(entry.name)) continue;
+      if (/\.test\.|\.spec\./.test(entry.name)) continue;
+      // A method cannot be its own caller.
+      if (full.endsWith("packages/storage/src/sqlite-storage.ts")) continue;
+      chunks.push(readFileSync(full, "utf8"));
+    }
+  };
+  for (const top of ["packages", "crates", "scripts"]) {
+    const path = join(repoRoot, top);
+    try {
+      if (statSync(path).isDirectory()) visit(path);
+    } catch {
+      // A missing top-level directory is not this gate's concern.
+    }
+  }
+  return chunks.join("\n");
+}
+
+const PRODUCTION_SOURCE = productionSource();
+
+/** Does anything outside tests and build output call this storage method? */
+function hasProductionCaller(method) {
+  return PRODUCTION_SOURCE.includes(`.${method}(`);
+}
+
+function main() {
+  const tables = migrationTables();
+  const methods = tableMethods(tables);
+  const baseline = JSON.parse(readFileSync(BASELINE_PATH, "utf8"));
+  const known = new Map(baseline.known_orphans.map((entry) => [entry.method, entry]));
+
+  const orphans = [];
+  for (const table of tables) {
+    for (const [role, list] of [["writer", methods[table].writers], ["reader", methods[table].readers]]) {
+      for (const method of list) {
+        if (!hasProductionCaller(method)) {
+          orphans.push({ method, table, kind: `${role}_orphan` });
+        }
+      }
+    }
+  }
+  // A method can serve several tables; report it once, by its most severe role.
+  const byMethod = new Map();
+  for (const orphan of orphans) {
+    const existing = byMethod.get(orphan.method);
+    if (!existing || (existing.kind === "reader_orphan" && orphan.kind === "writer_orphan")) {
+      byMethod.set(orphan.method, orphan);
+    }
+  }
+
+  const found = [...byMethod.values()].sort((left, right) => left.method.localeCompare(right.method));
+  const failures = [];
+
+  for (const orphan of found) {
+    if (!known.has(orphan.method)) {
+      failures.push(
+        `NEW ${orphan.kind}: ${orphan.method} (${orphan.table}) has no production caller. ` +
+          (orphan.kind === "writer_orphan"
+            ? "The table will never be populated, so every reader of it returns empty."
+            : "The table is populated and nothing in production reads it.") +
+          " Wire it up, or add it to scripts/storage-lifecycle-baseline.json with a reason."
+      );
+    }
+  }
+  for (const [method, entry] of known) {
+    if (!byMethod.has(method)) {
+      failures.push(
+        `STALE baseline entry: ${method} now HAS a production caller. Remove it from ` +
+          "scripts/storage-lifecycle-baseline.json - a baseline that still claims a fixed gap is a false record."
+      );
+    }
+  }
+
+  const writerOrphans = found.filter((orphan) => orphan.kind === "writer_orphan");
+  console.log(
+    `storage lifecycle: ${tables.length} tables, ${found.length} orphaned method(s) ` +
+      `(${writerOrphans.length} writer, ${found.length - writerOrphans.length} reader), ` +
+      `${known.size} baselined.`
+  );
+  for (const orphan of found) {
+    const entry = known.get(orphan.method);
+    console.log(`  ${orphan.kind === "writer_orphan" ? "W" : "r"} ${orphan.method} (${orphan.table})${entry ? "" : "  <-- NEW"}`);
+  }
+
+  if (failures.length > 0) {
+    console.error("");
+    for (const failure of failures) console.error(`  ${failure}`);
+    process.exit(1);
+  }
+}
+
+main();

--- a/scripts/storage-lifecycle.test.mjs
+++ b/scripts/storage-lifecycle.test.mjs
@@ -1,0 +1,88 @@
+import { execFileSync } from "node:child_process";
+import { readFileSync, writeFileSync } from "node:fs";
+import { join } from "node:path";
+import { fileURLToPath } from "node:url";
+import { afterEach, describe, expect, it } from "vitest";
+
+const repoRoot = fileURLToPath(new URL("..", import.meta.url));
+const BASELINE = join(repoRoot, "scripts/storage-lifecycle-baseline.json");
+const original = readFileSync(BASELINE, "utf8");
+
+function runGate() {
+  try {
+    const stdout = execFileSync("node", ["scripts/storage-lifecycle.mjs"], {
+      cwd: repoRoot,
+      encoding: "utf8"
+    });
+    return { exitCode: 0, output: stdout };
+  } catch (error) {
+    return {
+      exitCode: error.status ?? 1,
+      output: `${error.stdout ?? ""}${error.stderr ?? ""}`
+    };
+  }
+}
+
+/**
+ * A ratchet is only worth having if it fails. These exercise both directions, because a gate that
+ * can only ever pass is indistinguishable from no gate - and the class it guards has already been
+ * missed by two separate architecture audits.
+ */
+describe("storage lifecycle gate", () => {
+  afterEach(() => {
+    writeFileSync(BASELINE, original);
+  });
+
+  it("passes against the committed baseline", () => {
+    const result = runGate();
+    expect(result.exitCode).toBe(0);
+    expect(result.output).toContain("storage lifecycle:");
+  });
+
+  it("fails when a storage method loses its production caller", () => {
+    // Simulated by removing a known orphan from the baseline: identical to a newly-introduced one
+    // from the gate's point of view, and it needs no source edit.
+    const baseline = JSON.parse(original);
+    baseline.known_orphans = baseline.known_orphans.filter(
+      (entry) => entry.method !== "upsertSymbolIdentities"
+    );
+    writeFileSync(BASELINE, JSON.stringify(baseline, null, 2));
+
+    const result = runGate();
+    expect(result.exitCode).toBe(1);
+    expect(result.output).toContain("NEW writer_orphan: upsertSymbolIdentities");
+    // A writer orphan must say why it is the more severe kind.
+    expect(result.output).toContain("never be populated");
+  });
+
+  it("fails when the baseline still claims a gap that has been fixed", () => {
+    // Keeps the record honest in the other direction: fixing a gap forces removing its entry,
+    // so the file cannot decay into a list of things that used to be true.
+    const baseline = JSON.parse(original);
+    baseline.known_orphans.push({
+      method: "listFacts",
+      table: "facts",
+      kind: "reader_orphan",
+      reason: "synthetic - listFacts has many production callers"
+    });
+    writeFileSync(BASELINE, JSON.stringify(baseline, null, 2));
+
+    const result = runGate();
+    expect(result.exitCode).toBe(1);
+    expect(result.output).toContain("STALE baseline entry: listFacts");
+  });
+
+  it("separates writer orphans from reader orphans", () => {
+    // The distinction is the point: a missing writer means every read is empty, a missing reader
+    // means data is stored and unused. Conflating them would bury the severe case.
+    const result = runGate();
+    expect(result.output).toMatch(/\d+ writer, \d+ reader/);
+    const baseline = JSON.parse(original);
+    const writers = baseline.known_orphans.filter((entry) => entry.kind === "writer_orphan");
+    expect(writers.map((entry) => entry.method).sort()).toEqual([
+      "upsertParserGapV2",
+      "upsertSecurityBoundaryProofs",
+      "upsertSymbolIdentities"
+    ]);
+  });
+});

--- a/test/e2e/release-hygiene.test.ts
+++ b/test/e2e/release-hygiene.test.ts
@@ -33,6 +33,7 @@ describe("release hygiene", () => {
     expect(manifest.scripts["format:engine:check"]).toBe("cargo fmt --all -- --check");
     expect(manifest.scripts["lint:engine"]).toBe("cargo clippy -p drift-engine --all-targets -- -D warnings");
     expect(manifest.scripts["check:boundaries"]).toBe("node packages/cli/scripts/check-boundaries.mjs");
+    expect(manifest.scripts["check:storage-lifecycle"]).toBe("node scripts/storage-lifecycle.mjs");
     expect(manifest.scripts["validate:release-matrix"]).toBe("node scripts/validate-engine-release-matrix.mjs");
     expect(manifest.scripts["validate:claims"]).toBe("node scripts/validate-product-claims.mjs");
     expect(manifest.scripts["beta:proof"]).toBe("node scripts/run-beta-proof.mjs");
@@ -50,6 +51,10 @@ describe("release hygiene", () => {
       // number - so the gate now fails on a rise and names the delta.
       // EW-7 added `pnpm eval:determinism`: determinism is the marketed claim, and it was only ever
       // measured by hand on two of the seven repos.
+      // This change adds `pnpm check:storage-lifecycle`: a migration-backed table whose writer has
+      // no production caller is never populated, while readers merge an always-empty array into
+      // agent output. Two separate architecture audits each found a different subset of that class
+      // and both missed a third, so it is now a gate rather than a periodic review.
       //
       // PR #102 took the four eval steps back out, and the reason matters. A hosted runner has none
       // of the seven pinned evaluation repos and no release engine binary, and the battery does not
@@ -57,7 +62,7 @@ describe("release hygiene", () => {
       // there. Listing them did not execute them; it produced a gate that named an oracle it never
       // consulted. They now live in `verify:evals`, which is a LOCAL gate, and `verify:full` is the
       // union that any "verified" claim has to cite.
-      "pnpm verify && pnpm test:harness && pnpm format:engine:check && pnpm lint:engine && pnpm check:boundaries && node scripts/validate-engine-release-matrix.mjs --allow-unverified && pnpm validate:claims && pnpm beta:proof && git diff --check",
+      "pnpm verify && pnpm test:harness && pnpm format:engine:check && pnpm lint:engine && pnpm check:boundaries && pnpm check:storage-lifecycle && node scripts/validate-engine-release-matrix.mjs --allow-unverified && pnpm validate:claims && pnpm beta:proof && git diff --check",
     );
     expect(manifest.scripts["verify:evals"]).toBe(
       "pnpm eval:external && pnpm eval:evasion && pnpm eval:bench && pnpm eval:determinism"


### PR DESCRIPTION
A table gets a migration, a storage method, a schema and a test — and no production caller. **Nothing fails.** The table stays empty forever while readers merge an always-empty array into agent output.

`ParserGapV2` is the worked example: `upsertParserGapV2` has only test callers, and four agent surfaces (`prepare`, `repo map`, two MCP tools) do `[...parserGaps, ...parserGapV2]` against nothing.

Two independent architecture audits each found a **different subset** of this class. That is the argument for a rule rather than a third audit. This check finds all nine — one of which (`upsertSymbolIdentities`) neither audit had.

## What it found

Cross-checked against a real dub scan, which is what separates the two severities:

**`writer_orphan`** — the table is never populated, so every read is empty:

| method | table | rows on dub |
|---|---|---:|
| `upsertParserGapV2` | `parser_gaps` | 639 (all V1) |
| `upsertSecurityBoundaryProofs` | `security_boundary_proofs` | **0** |
| `upsertSymbolIdentities` | `symbol_identities` | **0** |

**`reader_orphan`** — the table *is* populated and nothing in production reads it:

| method | rows on dub |
|---|---:|
| `listSymbolOccurrences` | 41,905 written, never queried |
| `listModuleDependents` | 15,311 written, never queried |
| `listCheckRuns`, `listFrameworkAdapters`, `listGraphCompleteness`, `getScanManifest` | — |

So roughly **57,000 rows per scan** are written by production and read by nothing.

The severity split is the point. A missing writer produces a false signal — a surface reporting on an empty table. A missing reader is only dead API and storage cost. Conflating them would bury the severe case.

## How it gates

Ratcheted in **both directions**, following the shape of `scripts/evasion-baseline.json` — a baseline that records honest current truth and never hides a gap:

- a **NEW** orphan fails, so the class cannot grow silently
- a **baselined orphan that now has a caller** fails, so fixing one forces removing its entry rather than leaving a stale claim behind

Both directions are exercised by tests, because a ratchet that can only pass is indistinguishable from no gate.

## Design notes

**Deliberately static.** "No production caller" is decidable from source; running the product and counting rows would be a stronger signal but slower and flakier. Row counts were used once, when writing the baseline, to classify severity.

**Performance mattered more than expected.** A first draft grepped the repo once per method — 64 full scans, **105 seconds**. Long enough to become the slowest step in `verify:ci` and get skipped locally. It now reads production source once and runs in **0.06s**, with identical output.

**This does not fix the nine.** It stops the tenth, and makes each existing one a documented decision rather than an accident.

## Verification

- `pnpm verify:ci` exits 0, reaches the final `beta:proof` JSON, with the new gate running inside it
- The release-hygiene test that pins the exact `verify:ci` string is updated, with a note on why the gate grew — that pin exists so the gate cannot be weakened silently, and it did its job here

## Known

`Drift check (self)` has been red on main since #108 (`empty_contract` on drift's own repo, which infers 0 candidates). Not introduced here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)