### PR TITLE
fix(query,cli,mcp): one implementation of task file selection

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
     "validate:claims": "node scripts/validate-product-claims.mjs",
     "beta:proof": "node scripts/run-beta-proof.mjs",
     "release:proof": "node scripts/generate-release-proof.mjs",
-    "verify:ci": "pnpm verify && pnpm test:harness && pnpm format:engine:check && pnpm lint:engine && pnpm check:boundaries && node scripts/validate-engine-release-matrix.mjs --allow-unverified && pnpm validate:claims && pnpm beta:proof && git diff --check",
+    "verify:ci": "pnpm verify && pnpm test:harness && pnpm format:engine:check && pnpm lint:engine && pnpm check:boundaries && pnpm check:storage-lifecycle && node scripts/validate-engine-release-matrix.mjs --allow-unverified && pnpm validate:claims && pnpm beta:proof && git diff --check",
     "verify:evals": "pnpm eval:external && pnpm eval:evasion && pnpm eval:bench && pnpm eval:determinism",
     "verify:full": "pnpm verify:ci && pnpm verify:evals",
     "eval:external": "node scripts/external-eval.mjs",
@@ -33,10 +33,11 @@
     "eval:bench:update": "node scripts/beta-bench.mjs --update",
     "eval:determinism": "node scripts/determinism.mjs",
     "run:log": "node scripts/run-log.mjs",
-    "test:harness": "vitest run scripts/external-eval.test.mjs scripts/evasion-matrix.test.mjs scripts/validate-engine-release-matrix.test.mjs scripts/worktree-contamination.test.mjs scripts/beta-bench-ratchet.test.mjs scripts/validate-product-claims.test.mjs scripts/engine-handshake.test.mjs scripts/external-eval-start.test.mjs",
+    "test:harness": "vitest run scripts/external-eval.test.mjs scripts/evasion-matrix.test.mjs scripts/validate-engine-release-matrix.test.mjs scripts/worktree-contamination.test.mjs scripts/beta-bench-ratchet.test.mjs scripts/validate-product-claims.test.mjs scripts/engine-handshake.test.mjs scripts/external-eval-start.test.mjs scripts/storage-lifecycle.test.mjs",
     "eval:prepare": "node scripts/prepare-quality-eval.mjs",
     "eval:presence": "node scripts/presence-precision-recall.mjs",
-    "eval:presence:update": "node scripts/presence-precision-recall.mjs --update"
+    "eval:presence:update": "node scripts/presence-precision-recall.mjs --update",
+    "check:storage-lifecycle": "node scripts/storage-lifecycle.mjs"
   },
   "devDependencies": {
     "@types/node": "^22.15.0",

--- a/packages/cli/src/domain/preflight.ts
+++ b/packages/cli/src/domain/preflight.ts
@@ -255,98 +255,15 @@ export function preflightSummary(input: PreflightSummaryInput): {
   };
 }
 
-export function relevantFilesForTask(input: {
-  repoRoot: string;
-  task: string;
-  contract: RepoContract;
-  targetPath?: string;
-}): RelevantFile[] {
-  if (!existsSync(input.repoRoot)) {
-    return input.targetPath
-      ? [relevantFileForPath(input.targetPath, tokenizeTask(input.task), input.contract, "requested path")].filter(
-          (file): file is RelevantFile => Boolean(file)
-        )
-      : [];
-  }
-
-  const tokens = tokenizeTask(input.task);
-  const deniedGlobs = input.contract.context_egress.denied_globs;
-  const files = walkIndexableFiles(input.repoRoot)
-    .filter((filePath) => !deniedGlobs.some((glob) => matchesGlob(filePath, glob)))
-    .map((filePath) => relevantFileForPath(filePath, tokens, input.contract))
-    .filter((file): file is RelevantFile => Boolean(file));
-  if (
-    input.targetPath &&
-    !deniedGlobs.some((glob) => matchesGlob(input.targetPath!, glob)) &&
-    !files.some((file) => file.path === input.targetPath)
-  ) {
-    const targetFile = relevantFileForPath(input.targetPath, tokens, input.contract, "requested path");
-    if (targetFile) {
-      files.unshift(targetFile);
-    }
-  } else if (input.targetPath) {
-    const existing = files.find((file) => file.path === input.targetPath);
-    if (existing && !existing.reasons.includes("requested path")) {
-      existing.reasons = uniqueSorted([...existing.reasons, "requested path"]);
-    }
-  }
-
-  // Rank before truncating.
-  //
-  // This previously returned `files.slice(0, 25)` in filesystem-walk order, so the cap was
-  // exhausted by whichever files happened to sort first - and "in scope for this convention"
-  // matches every API route in the repository, so it always had thousands of candidates.
-  //
-  // Measured on dub with "add an endpoint that lists workspace invites": 24 of the 25 returned
-  // files were arbitrary routes matched only by convention scope, none matched "invite", and
-  // apps/web/app/api/workspaces/[idOrSlug]/invites/route.ts - the one file someone doing that
-  // task must see - never appeared, because the walk reached app/(ee)/api/admin/* first. The
-  // context claim rests on this function, so ordering it by relevance is the whole point.
-  return rankRelevantFiles(files);
-}
-
-
-export function relevantFileForPath(
-  filePath: string,
-  tokens: Set<string>,
-  contract: RepoContract,
-  forcedReason?: string
-): RelevantFile | undefined {
-  const reasons = new Set<string>();
-  const roles = new Set<string>();
-  if (forcedReason) {
-    reasons.add(forcedReason);
-  }
-  if (isApiRoutePath(filePath)) {
-    roles.add("api_route");
-  }
-
-  for (const token of tokens) {
-    if (filePath.toLowerCase().includes(token)) {
-      reasons.add(`task token: ${token}`);
-    }
-  }
-
-  for (const convention of contract.conventions) {
-    const inScope = apiCompatibleGlobs(convention.scope.path_globs).some((glob) => matchesGlob(filePath, glob));
-    if (inScope) {
-      reasons.add(`in scope for ${convention.id}`);
-      for (const role of convention.scope.file_roles ?? []) {
-        roles.add(role);
-      }
-    }
-  }
-
-  if (reasons.size === 0) {
-    return undefined;
-  }
-
-  return {
-    path: filePath,
-    roles: [...roles].sort(),
-    reasons: [...reasons].sort()
-  };
-}
+/**
+ * Re-exported from `@drift/query`, which owns the one implementation.
+ *
+ * The CLI and MCP each had their own, and they diverged three ways: the in-scope predicate (the
+ * CLI tested globs while `check` enforces with `conventionScopeFiles`), `.gitignore` handling, and
+ * declaration files. Kept as a named export here so the CLI's own call sites are unaffected.
+ */
+export { relevantFileForPath, relevantFilesForTask, tokenizeTask } from "@drift/query";
+import { tokenizeTask } from "@drift/query";
 
 export function riskyAreasForFiles(
   contract: RepoContract,
@@ -452,16 +369,6 @@ export function rolesForPath(filePath: string): string[] {
 
 function apiCompatibleGlobs(globs: string[]): string[] {
   return expandApiRouteScopeGlobs(globs);
-}
-
-export function tokenizeTask(task: string): Set<string> {
-  return new Set(
-    task
-      .toLowerCase()
-      .split(/[^a-z0-9_/-]+/)
-      .map((token) => token.trim())
-      .filter((token) => token.length >= 3)
-  );
 }
 
 export function countDeniedFiles(repoRoot: string, deniedGlobs: string[]): number {

--- a/packages/cli/src/engine/ts-fallback-scanner.ts
+++ b/packages/cli/src/engine/ts-fallback-scanner.ts
@@ -1,107 +1,19 @@
-import { existsSync, readdirSync, readFileSync } from "node:fs";
-import { join,relative } from "node:path";
-
-export function walkIndexableFiles(repoRoot: string): string[] {
-  const files: string[] = [];
-  const ignorePatterns = readGitignorePatterns(repoRoot);
-  const visit = (dir: string) => {
-    for (const entry of readdirSync(dir, { withFileTypes: true })) {
-      const absolutePath = join(dir, entry.name);
-      const relativePath = relative(repoRoot, absolutePath).replaceAll("\\", "/");
-      if (shouldSkipPath(entry.name) || isIgnoredPath(relativePath, ignorePatterns)) {
-        continue;
-      }
-
-      if (entry.isDirectory()) {
-        visit(absolutePath);
-      } else if (entry.isFile() && isIndexableFilePath(entry.name)) {
-        files.push(relativePath);
-      }
-    }
-  };
-  visit(repoRoot);
-  return files.sort();
-}
-
-export function shouldSkipPath(name: string): boolean {
-  return [
-    ".git",
-    "node_modules",
-    "dist",
-    "build",
-    "coverage",
-    ".next",
-    "target",
-    "vendor"
-  ].includes(name);
-}
-
-export function isTypescriptPath(filePath: string): boolean {
-  return /\.[cm]?[jt]sx?$/.test(filePath);
-}
-
 /**
- * Files that DECLARE structure rather than implement it. Mirrors `is_declaration_path` in
- * crates/drift-engine/src/main.rs - the engine is authoritative, this keeps the CLI-side walker
- * from disagreeing with it about which files exist.
+ * Re-exported from `@drift/query`, which owns the one walk.
  *
- * These are snapshotted for their path and content hash and are NOT parsed, so they carry no
- * facts. Anything deciding whether a rule can be evaluated must read `snapshot.indexed` rather
- * than test the extension: presence in this list means Drift knows the file is there, not that it
- * knows what is in it.
+ * This file used to hold the implementation, and because the MCP server cannot import from the CLI
+ * - the boundary check enforces that - a second copy grew there. The two then drifted three ways:
+ * the copy never learned about `.gitignore`, never learned about declaration files when the scan
+ * gained them, and by then `prepare` and `get_task_preflight` disagreed about whether
+ * `prisma/schema.prisma` was worth mentioning for a task about the Prisma schema.
+ *
+ * Kept as a module so the CLI's five call sites (doctor, start, check/diff, preflight,
+ * scan-status) are unaffected by where the implementation lives.
  */
-export function isDeclarationPath(filePath: string): boolean {
-  return /\.prisma$/.test(filePath);
-}
-
-/** Every file the scan records, parsed or not. */
-export function isIndexableFilePath(filePath: string): boolean {
-  return isTypescriptPath(filePath) || isDeclarationPath(filePath);
-}
-
-function readGitignorePatterns(repoRoot: string): string[] {
-  const gitignorePath = join(repoRoot, ".gitignore");
-  if (!existsSync(gitignorePath)) {
-    return [];
-  }
-  return readFileSync(gitignorePath, "utf8")
-    .split(/\r?\n/)
-    .map((line) => line.trim())
-    .filter((line) => line.length > 0 && !line.startsWith("#") && !line.startsWith("!"))
-    .map((line) => line.replace(/^\/+/, ""));
-}
-
-function isIgnoredPath(filePath: string, patterns: string[]): boolean {
-  const fileName = filePath.split("/").at(-1) ?? filePath;
-  return patterns.some((pattern) => gitignorePatternMatches(pattern, filePath, fileName));
-}
-
-function gitignorePatternMatches(pattern: string, filePath: string, fileName: string): boolean {
-  if (pattern.endsWith("/**")) {
-    const prefix = pattern.slice(0, -3).replace(/\/+$/, "");
-    return filePath === prefix || filePath.startsWith(`${prefix}/`);
-  }
-  if (pattern.endsWith("/")) {
-    const prefix = pattern.replace(/\/+$/, "");
-    return filePath === prefix || filePath.startsWith(`${prefix}/`);
-  }
-  if (pattern.startsWith("**/")) {
-    const rest = pattern.slice(3);
-    return wildcardMatches(rest, fileName) || wildcardMatches(rest, filePath) || wildcardMatches(pattern, filePath);
-  }
-  if (pattern.includes("*")) {
-    if (pattern.includes("/")) {
-      return wildcardMatches(pattern, filePath);
-    }
-    return filePath.split("/").some((component) => wildcardMatches(pattern, component));
-  }
-  if (pattern.includes("/")) {
-    return filePath === pattern || filePath.startsWith(`${pattern}/`);
-  }
-  return filePath.split("/").includes(pattern);
-}
-
-function wildcardMatches(pattern: string, value: string): boolean {
-  const escaped = pattern.replace(/[.+^${}()|[\]\\]/g, "\\$&").replace(/\*/g, ".*");
-  return new RegExp(`^${escaped}$`).test(value);
-}
+export {
+  isDeclarationPath,
+  isIndexableFilePath,
+  isTypescriptPath,
+  shouldSkipPath,
+  walkIndexableFiles
+} from "@drift/query";

--- a/packages/mcp/src/index.ts
+++ b/packages/mcp/src/index.ts
@@ -84,8 +84,11 @@ import {
   selectRelevantTests,
   type ChangeImpactRouteFlow,
   type DriftReadinessSurface,
-  type RepoMapFile,rankRelevantFiles,
-  repoMapFileForPayload
+  type RepoMapFile,
+  rankRelevantFiles,
+  relevantFilesForTask,
+  repoMapFileForPayload,
+  walkIndexableFiles
 } from "@drift/query";
 import { MIGRATIONS, openDriftStorage } from "@drift/storage";
 import { execFileSync } from "node:child_process";
@@ -2044,38 +2047,7 @@ function isResolverInputPath(filePath: string): boolean {
     /^tsconfig(?:\.[^.]+)?\.json$/.test(fileName);
 }
 
-function walkIndexableFiles(repoRoot: string): string[] {
-  const files: string[] = [];
-  const visit = (dir: string) => {
-    for (const entry of readdirSync(dir, { withFileTypes: true })) {
-      if (shouldSkipPath(entry.name)) {
-        continue;
-      }
 
-      const absolutePath = join(dir, entry.name);
-      if (entry.isDirectory()) {
-        visit(absolutePath);
-      } else if (entry.isFile() && isTypescriptPath(entry.name)) {
-        files.push(relative(repoRoot, absolutePath).replaceAll("\\", "/"));
-      }
-    }
-  };
-  visit(repoRoot);
-  return files.sort();
-}
-
-function shouldSkipPath(name: string): boolean {
-  return [
-    ".git",
-    "node_modules",
-    "dist",
-    "build",
-    "coverage",
-    ".next",
-    "target",
-    "vendor"
-  ].includes(name);
-}
 
 function isTypescriptPath(filePath: string): boolean {
   return /\.[cm]?[jt]sx?$/.test(filePath);
@@ -2116,98 +2088,7 @@ function baselineSummary(storage: ReturnType<typeof openDriftStorage>, repoId: s
   };
 }
 
-function relevantFilesForTask(input: {
-  repoRoot: string;
-  task: string;
-  contract: RepoContract;
-  targetPath?: string;
-}): RelevantFile[] {
-  const tokens = tokenizeTask(input.task);
-  const deniedGlobs = input.contract.context_egress.denied_globs;
-  if (!existsSync(input.repoRoot)) {
-    return input.targetPath
-      ? [relevantFileForPath(input.targetPath, tokens, input.contract, "requested path")].filter(
-          (file): file is RelevantFile => Boolean(file)
-        )
-      : [];
-  }
-  const files = walkIndexableFiles(input.repoRoot)
-    .filter((filePath) => !deniedGlobs.some((glob) => matchesPolicyGlob(filePath, glob)))
-    .map((filePath) => relevantFileForPath(filePath, tokens, input.contract))
-    .filter((file): file is RelevantFile => Boolean(file));
-  // Deliberately NOT truncated here. This surface used to cut to 25 during the walk, so the cap
-  // was spent on whichever files sorted first and ranking downstream could not recover the ones
-  // already discarded. rankRelevantFiles below scores the full candidate set, then truncates.
-  if (
-    input.targetPath &&
-    !deniedGlobs.some((glob) => matchesPolicyGlob(input.targetPath!, glob)) &&
-    !files.some((file) => file.path === input.targetPath)
-  ) {
-    const targetFile = relevantFileForPath(input.targetPath, tokens, input.contract, "requested path");
-    if (targetFile) {
-      files.unshift(targetFile);
-    }
-  } else if (input.targetPath) {
-    const existing = files.find((file) => file.path === input.targetPath);
-    if (existing && !existing.reasons.includes("requested path")) {
-      existing.reasons = uniqueSorted([...existing.reasons, "requested path"]);
-    }
-  }
-  // Shared with `drift prepare`. This surface previously had its own `files.slice(0, 25)` in
-  // filesystem-walk order, so when T46 added relevance ranking to the CLI, the MCP tool that
-  // agents actually call kept returning arbitrary files. Same divergence class as B3/T12.
-  return rankRelevantFiles(files);
-}
 
-function relevantFileForPath(
-  filePath: string,
-  tokens: Set<string>,
-  contract: RepoContract,
-  forcedReason?: string
-): RelevantFile | undefined {
-  const reasons = new Set<string>();
-  const roles = new Set<string>();
-  if (forcedReason) {
-    reasons.add(forcedReason);
-  }
-  if (isApiRoutePath(filePath)) {
-    roles.add("api_route");
-  }
-
-  for (const token of tokens) {
-    if (filePath.toLowerCase().includes(token)) {
-      reasons.add(`task token: ${token}`);
-    }
-  }
-
-  for (const convention of contract.conventions) {
-    // BB-11: the shared predicate, not a local glob decision.
-    //
-    // This was the last scope decision in the product still deciding for itself, and the differential
-    // in packages/mcp/test/scope-predicate-bb11.test.ts showed it disagreeing with core on exactly one
-    // input: it applied `path_globs` only and never consulted `exclude_path_globs`, so a file an author
-    // had explicitly excluded was still reported "in scope for <convention_id>" on this agent-facing
-    // surface, and inherited that convention's roles. Adjudicated as a bug rather than a policy,
-    // because `scopeMatchesFile` two hundred lines below already honours exclusions - one file
-    // disagreeing with itself.
-    const inScope = conventionScopeFiles([filePath], convention).length > 0;
-    if (inScope) {
-      reasons.add(`in scope for ${convention.id}`);
-      for (const role of convention.scope.file_roles ?? []) {
-        roles.add(role);
-      }
-    }
-  }
-
-  if (reasons.size === 0) {
-    return undefined;
-  }
-  return {
-    path: filePath,
-    roles: [...roles].sort(),
-    reasons: [...reasons].sort()
-  };
-}
 
 function riskyAreasForFiles(
   contract: RepoContract,
@@ -2708,15 +2589,6 @@ function instructionForConvention(convention: AcceptedConvention): string {
   return `${convention.statement} Follow its scope, matcher, and exceptions.`;
 }
 
-function tokenizeTask(task: string): Set<string> {
-  return new Set(
-    task
-      .toLowerCase()
-      .split(/[^a-z0-9_/-]+/)
-      .map((token) => token.trim())
-      .filter((token) => token.length >= 3)
-  );
-}
 
 function countDeniedFiles(repoRoot: string, deniedGlobs: string[]): number {
   if (deniedGlobs.length === 0 || !existsSync(repoRoot)) {

--- a/packages/query/src/index.ts
+++ b/packages/query/src/index.ts
@@ -1518,4 +1518,5 @@ function sorted(values: Iterable<string>): string[] {
 function unique(values: string[]): string[] {
   return sorted(new Set(values));
 }
-export { MAX_RELEVANT_FILES, rankRelevantFiles, relevanceScore, type RankableFile } from "./relevance.js";
+export { MAX_RELEVANT_FILES, rankRelevantFiles, relevanceScore, relevantFileForPath, relevantFilesForTask, tokenizeTask, type RankableFile } from "./relevance.js";
+export { isDeclarationPath, isIndexableFilePath, isTypescriptPath, shouldSkipPath, walkIndexableFiles } from "./repo-files.js";

--- a/packages/query/src/relevance.ts
+++ b/packages/query/src/relevance.ts
@@ -12,6 +12,10 @@
  * thing the rule applies to, which is true of every route in the repository.
  */
 
+import { existsSync } from "node:fs";
+import { conventionScopeFiles, isNextApiRoutePath, matchesGlob, type RepoContract } from "@drift/core";
+import { walkIndexableFiles } from "./repo-files.js";
+
 export interface RankableFile {
   path: string;
   roles: string[];
@@ -53,4 +57,129 @@ export function rankRelevantFiles<T extends RankableFile>(files: T[]): T[] {
     .sort((a, b) => b.score - a.score || a.file.path.localeCompare(b.file.path))
     .slice(0, MAX_RELEVANT_FILES)
     .map((entry) => entry.file);
+}
+
+/**
+ * Files worth showing an agent for a task, ranked and capped.
+ *
+ * This is the SELECTION half of what T51 half-fixed. T51 moved ranking here after the CLI and MCP
+ * copies of it diverged; selection stayed duplicated and diverged three ways of its own:
+ *
+ *  - the in-scope predicate. The CLI tested `path_globs` alone while the enforcement path uses
+ *    `conventionScopeFiles`, so `prepare` told an agent a file was "in scope for convention_X"
+ *    using a rule `check` does not use to enforce convention_X. BB-11 already adjudicated
+ *    glob-only as a bug rather than a policy - and fixed only the MCP copy. Measured on dub's real
+ *    file list, the two answer differently by 623 vs 171 files for a contract with exclusions, and
+ *    0 vs 4,091 for one with empty globs.
+ *  - `.gitignore`. The CLI honoured it; the MCP copy never did.
+ *  - declaration files. When the scan learned to record `.prisma`, only the CLI walker learned it,
+ *    so `prepare` surfaced `prisma/schema.prisma` for a task about the Prisma schema and
+ *    `get_task_preflight` did not.
+ *
+ * The canonical predicate wins on scope and the gitignore-aware walk wins on discovery, because
+ * each was the side that had already been adjudicated correct.
+ */
+export function relevantFilesForTask(input: {
+  repoRoot: string;
+  task: string;
+  contract: RepoContract;
+  targetPath?: string;
+}): RankableFile[] {
+  const tokens = tokenizeTask(input.task);
+  if (!existsSync(input.repoRoot)) {
+    // No tree to walk: a requested path is still worth returning, because the caller named it.
+    return input.targetPath
+      ? [relevantFileForPath(input.targetPath, tokens, input.contract, "requested path")].filter(
+          (file): file is RankableFile => Boolean(file)
+        )
+      : [];
+  }
+
+  const deniedGlobs = input.contract.context_egress.denied_globs;
+  const files = walkIndexableFiles(input.repoRoot)
+    .filter((filePath) => !deniedGlobs.some((glob) => matchesGlob(filePath, glob)))
+    .map((filePath) => relevantFileForPath(filePath, tokens, input.contract))
+    .filter((file): file is RankableFile => Boolean(file));
+
+  if (
+    input.targetPath &&
+    !deniedGlobs.some((glob) => matchesGlob(input.targetPath!, glob)) &&
+    !files.some((file) => file.path === input.targetPath)
+  ) {
+    const targetFile = relevantFileForPath(input.targetPath, tokens, input.contract, "requested path");
+    if (targetFile) {
+      files.unshift(targetFile);
+    }
+  } else if (input.targetPath) {
+    const existing = files.find((file) => file.path === input.targetPath);
+    if (existing && !existing.reasons.includes("requested path")) {
+      existing.reasons = [...new Set([...existing.reasons, "requested path"])].sort();
+    }
+  }
+
+  // Rank before truncating: the cap is 25 and "in scope for this convention" matches every route
+  // in the repository, so an unranked slice returns whatever the walk reached first.
+  return rankRelevantFiles(files);
+}
+
+export function relevantFileForPath(
+  filePath: string,
+  tokens: Set<string>,
+  contract: RepoContract,
+  forcedReason?: string
+): RankableFile | undefined {
+  const reasons = new Set<string>();
+  const roles = new Set<string>();
+  if (forcedReason) {
+    reasons.add(forcedReason);
+  }
+  if (isNextApiRoutePath(filePath)) {
+    roles.add("api_route");
+  }
+
+  for (const token of tokens) {
+    if (filePath.toLowerCase().includes(token)) {
+      reasons.add(`task token: ${token}`);
+    }
+  }
+
+  for (const convention of contract.conventions) {
+    // The canonical predicate, not a glob test. It additionally honours `exclude_path_globs`,
+    // treats route detection as authoritative for api-route conventions, applies route-flavour
+    // narrowing, and reads empty `path_globs` as "no narrowing" rather than "matches nothing" -
+    // four behaviours a glob test silently gets wrong, in both directions.
+    if (conventionScopeFiles([filePath], convention).length > 0) {
+      reasons.add(`in scope for ${convention.id}`);
+      for (const role of convention.scope.file_roles ?? []) {
+        roles.add(role);
+      }
+    }
+  }
+
+  if (reasons.size === 0) {
+    return undefined;
+  }
+  return {
+    path: filePath,
+    roles: [...roles].sort(),
+    reasons: [...reasons].sort()
+  };
+}
+
+/**
+ * The tokens a path is matched against.
+ *
+ * Copied verbatim from the two byte-identical implementations this replaces, deliberately: `_`,
+ * `/` and `-` survive the split because paths contain them, and the floor is three characters, not
+ * four. Both details are load-bearing - they decide which files earn a `task token:` reason, and a
+ * reason is what puts a file in front of an agent at all.
+ */
+export function tokenizeTask(task: string): Set<string> {
+  return new Set(
+    task
+      .toLowerCase()
+      .split(/[^a-z0-9_/-]+/)
+      .map((token) => token.trim())
+      .filter((token) => token.length >= 3)
+  );
 }

--- a/packages/query/src/repo-files.ts
+++ b/packages/query/src/repo-files.ts
@@ -1,0 +1,120 @@
+/**
+ * Which files a repository scan sees, and how it walks them.
+ *
+ * Lives here rather than in the CLI because the MCP server cannot import from the CLI - the
+ * boundary check enforces that - so a copy of this walk was made there, and the two drifted. Three
+ * ways, measured: the copy never learned about `.gitignore`, never learned about declaration files
+ * when the scan gained them, and by then `prepare` and `get_task_preflight` disagreed about whether
+ * `prisma/schema.prisma` was a file worth mentioning for a task about the Prisma schema.
+ *
+ * `@drift/query` is the designated home for logic both surfaces need - the same move T51 made for
+ * preflight ranking, after the two copies of THAT silently diverged. This is the other half.
+ */
+
+import { existsSync, readdirSync, readFileSync } from "node:fs";
+import { join,relative } from "node:path";
+
+export function walkIndexableFiles(repoRoot: string): string[] {
+  const files: string[] = [];
+  const ignorePatterns = readGitignorePatterns(repoRoot);
+  const visit = (dir: string) => {
+    for (const entry of readdirSync(dir, { withFileTypes: true })) {
+      const absolutePath = join(dir, entry.name);
+      const relativePath = relative(repoRoot, absolutePath).replaceAll("\\", "/");
+      if (shouldSkipPath(entry.name) || isIgnoredPath(relativePath, ignorePatterns)) {
+        continue;
+      }
+
+      if (entry.isDirectory()) {
+        visit(absolutePath);
+      } else if (entry.isFile() && isIndexableFilePath(entry.name)) {
+        files.push(relativePath);
+      }
+    }
+  };
+  visit(repoRoot);
+  return files.sort();
+}
+
+export function shouldSkipPath(name: string): boolean {
+  return [
+    ".git",
+    "node_modules",
+    "dist",
+    "build",
+    "coverage",
+    ".next",
+    "target",
+    "vendor"
+  ].includes(name);
+}
+
+export function isTypescriptPath(filePath: string): boolean {
+  return /\.[cm]?[jt]sx?$/.test(filePath);
+}
+
+/**
+ * Files that DECLARE structure rather than implement it. Mirrors `is_declaration_path` in
+ * crates/drift-engine/src/main.rs - the engine is authoritative, this keeps the CLI-side walker
+ * from disagreeing with it about which files exist.
+ *
+ * These are snapshotted for their path and content hash and are NOT parsed, so they carry no
+ * facts. Anything deciding whether a rule can be evaluated must read `snapshot.indexed` rather
+ * than test the extension: presence in this list means Drift knows the file is there, not that it
+ * knows what is in it.
+ */
+export function isDeclarationPath(filePath: string): boolean {
+  return /\.prisma$/.test(filePath);
+}
+
+/** Every file the scan records, parsed or not. */
+export function isIndexableFilePath(filePath: string): boolean {
+  return isTypescriptPath(filePath) || isDeclarationPath(filePath);
+}
+
+function readGitignorePatterns(repoRoot: string): string[] {
+  const gitignorePath = join(repoRoot, ".gitignore");
+  if (!existsSync(gitignorePath)) {
+    return [];
+  }
+  return readFileSync(gitignorePath, "utf8")
+    .split(/\r?\n/)
+    .map((line) => line.trim())
+    .filter((line) => line.length > 0 && !line.startsWith("#") && !line.startsWith("!"))
+    .map((line) => line.replace(/^\/+/, ""));
+}
+
+function isIgnoredPath(filePath: string, patterns: string[]): boolean {
+  const fileName = filePath.split("/").at(-1) ?? filePath;
+  return patterns.some((pattern) => gitignorePatternMatches(pattern, filePath, fileName));
+}
+
+function gitignorePatternMatches(pattern: string, filePath: string, fileName: string): boolean {
+  if (pattern.endsWith("/**")) {
+    const prefix = pattern.slice(0, -3).replace(/\/+$/, "");
+    return filePath === prefix || filePath.startsWith(`${prefix}/`);
+  }
+  if (pattern.endsWith("/")) {
+    const prefix = pattern.replace(/\/+$/, "");
+    return filePath === prefix || filePath.startsWith(`${prefix}/`);
+  }
+  if (pattern.startsWith("**/")) {
+    const rest = pattern.slice(3);
+    return wildcardMatches(rest, fileName) || wildcardMatches(rest, filePath) || wildcardMatches(pattern, filePath);
+  }
+  if (pattern.includes("*")) {
+    if (pattern.includes("/")) {
+      return wildcardMatches(pattern, filePath);
+    }
+    return filePath.split("/").some((component) => wildcardMatches(pattern, component));
+  }
+  if (pattern.includes("/")) {
+    return filePath === pattern || filePath.startsWith(`${pattern}/`);
+  }
+  return filePath.split("/").includes(pattern);
+}
+
+function wildcardMatches(pattern: string, value: string): boolean {
+  const escaped = pattern.replace(/[.+^${}()|[\]\\]/g, "\\$&").replace(/\*/g, ".*");
+  return new RegExp(`^${escaped}$`).test(value);
+}

--- a/packages/query/test/relevant-files-parity.test.ts
+++ b/packages/query/test/relevant-files-parity.test.ts
@@ -1,0 +1,123 @@
+import { mkdtemp, mkdir, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { describe, expect, it } from "vitest";
+import type { RepoContract } from "@drift/core";
+import { relevantFileForPath, relevantFilesForTask, tokenizeTask } from "../src/relevance.js";
+
+/**
+ * One implementation, and the behaviours that were adjudicated correct before it.
+ *
+ * The CLI and MCP each had their own copy of file selection. They diverged three ways, all
+ * measured: the in-scope predicate (the CLI tested `path_globs` while `check` enforces with
+ * `conventionScopeFiles`), `.gitignore` handling, and declaration files. These pin the winning
+ * side of each, so collapsing to one implementation cannot quietly adopt the losing one.
+ */
+
+function contractWith(convention: Partial<RepoContract["conventions"][number]>): RepoContract {
+  return {
+    id: "contract_test",
+    repo_id: "repo_test",
+    contract_schema_version: 1,
+    repo_fingerprint: "fp",
+    conventions: [
+      {
+        id: "convention_test",
+        contract_id: "contract_test",
+        kind: "api_route_no_direct_data_access",
+        statement: "s",
+        scope: { path_globs: [], file_roles: [] },
+        matcher: {},
+        severity: "error",
+        enforcement_mode: "warn",
+        enforcement_capability: "deterministic_check",
+        exceptions: [],
+        evidence_refs: [],
+        counterexample_refs: [],
+        accepted_by: "test",
+        accepted_at: "2026-01-01T00:00:00.000Z",
+        updated_at: "2026-01-01T00:00:00.000Z",
+        ...convention
+      } as RepoContract["conventions"][number]
+    ],
+    agent_contracts: [],
+    agent_permissions: [],
+    waivers: [],
+    required_checks: [],
+    safe_commands: [],
+    risky_areas: [],
+    rejected_inferences: [],
+    context_egress: { denied_globs: [] }
+  } as unknown as RepoContract;
+}
+
+describe("relevant file selection", () => {
+  it("tokenises the way both surfaces did, not the way a rewrite might assume", () => {
+    // `_ / -` survive the split, so `app/api` is ONE token rather than two - a path fragment in a
+    // task matches a path. The floor is three characters, so `in` is dropped. Both details decide
+    // which files earn a `task token:` reason, which is what puts a file in front of an agent.
+    expect([...tokenizeTask("update user_id in app/api")].sort()).toEqual([
+      "app/api",
+      "update",
+      "user_id"
+    ]);
+    // Two characters is below the floor.
+    expect([...tokenizeTask("fix db")].sort()).toEqual(["fix"]);
+  });
+
+  it("uses the canonical scope predicate, not a glob test", () => {
+    // BB-11 adjudicated glob-only as a bug. `exclude_path_globs` is one of four things it gets
+    // wrong; a glob test would report this file in scope.
+    const contract = contractWith({
+      scope: {
+        path_globs: ["apps/web/app/api/**"],
+        exclude_path_globs: ["apps/web/app/api/internal/**"],
+        file_roles: []
+      }
+    });
+    const excluded = relevantFileForPath(
+      "apps/web/app/api/internal/route.ts",
+      new Set<string>(),
+      contract
+    );
+    expect(excluded?.reasons ?? []).not.toContain("in scope for convention_test");
+
+    const included = relevantFileForPath("apps/web/app/api/public/route.ts", new Set<string>(), contract);
+    expect(included?.reasons ?? []).toContain("in scope for convention_test");
+  });
+
+  it("walks with gitignore applied and includes declaration files", async () => {
+    // The MCP copy had neither: it never read .gitignore, and never learned about `.prisma` when
+    // the scan gained it - so `prepare` and `get_task_preflight` disagreed about whether the
+    // schema file was worth mentioning for a task about the schema.
+    const dir = await mkdtemp(join(tmpdir(), "drift-relevance-"));
+    await mkdir(join(dir, "prisma"), { recursive: true });
+    await mkdir(join(dir, "generated"), { recursive: true });
+    await writeFile(join(dir, ".gitignore"), "generated/\n");
+    await writeFile(join(dir, "prisma/schema.prisma"), "model Thing {\n  id String @id\n}\n");
+    await writeFile(join(dir, "widget.ts"), "export const widget = 1;\n");
+    await writeFile(join(dir, "generated/widget.ts"), "export const generated = 1;\n");
+
+    const files = relevantFilesForTask({
+      repoRoot: dir,
+      task: "update the widget schema",
+      contract: contractWith({})
+    });
+    const paths = files.map((file) => file.path);
+
+    expect(paths).toContain("prisma/schema.prisma");
+    expect(paths).toContain("widget.ts");
+    expect(paths).not.toContain("generated/widget.ts");
+  });
+
+  it("ranks before capping", () => {
+    // An unranked slice returns whatever the walk reached first, and convention scope matches every
+    // route in a repository - so the cap was previously exhausted by arbitrary files.
+    const contract = contractWith({});
+    const tokens = tokenizeTask("invites");
+    const scored = relevantFileForPath("apps/web/app/api/invites/route.ts", tokens, contract);
+    const unscored = relevantFileForPath("apps/web/app/api/other/route.ts", tokens, contract);
+    expect(scored?.reasons).toContain("task token: invites");
+    expect(unscored?.reasons ?? []).not.toContain("task token: invites");
+  });
+});

--- a/scripts/storage-lifecycle-baseline.json
+++ b/scripts/storage-lifecycle-baseline.json
@@ -1,0 +1,73 @@
+{
+  "what_this_is": "Storage methods that reach a migration-backed table and have no production caller. Honest current truth, not an allowlist of things that are fine. Each entry is a known gap, recorded so the class cannot grow silently and so fixing one forces removing its entry. Enforced by scripts/storage-lifecycle.mjs.",
+  "severity": {
+    "writer_orphan": "The table is never populated in production. Every read of it is empty, and any surface reporting on it is reporting on nothing.",
+    "reader_orphan": "The table IS populated and nothing in production reads it. Dead read API and storage cost, not a false signal."
+  },
+  "measured_at": {
+    "commit": "f058c310",
+    "repo": "dub",
+    "note": "Row counts below came from a real onboarding scan of ~/drift-falsification/repos/dub, which is what distinguishes a writer orphan (table empty) from a reader orphan (table populated, unread)."
+  },
+  "known_orphans": [
+    {
+      "method": "upsertParserGapV2",
+      "table": "parser_gaps",
+      "kind": "writer_orphan",
+      "rows_on_dub": 639,
+      "reason": "The V2 arm has only test callers, so no V2 row is ever written; the 639 rows are all V1. Four agent surfaces (prepare, repo map, and two MCP tools) do `[...parserGaps, ...parserGapV2]` against a permanently empty array. Either give V2 a real writer or delete the arm - the merge currently advertises a capability that produces nothing."
+    },
+    {
+      "method": "upsertSecurityBoundaryProofs",
+      "table": "security_boundary_proofs",
+      "kind": "writer_orphan",
+      "rows_on_dub": 0,
+      "reason": "Measured 0 rows after a full dub onboarding. Note the sibling `upsertSecurityBoundaryProofRuns` IS called in production (run-check.ts), so the runs path is live while this one is not; the two are easy to confuse when reading the security read-model code."
+    },
+    {
+      "method": "upsertSymbolIdentities",
+      "table": "symbol_identities",
+      "kind": "writer_orphan",
+      "rows_on_dub": 0,
+      "reason": "Measured 0 rows on dub. Found by this check rather than by either architecture audit, both of which missed it - which is the argument for the check existing."
+    },
+    {
+      "method": "getScanManifest",
+      "table": "scan_manifests",
+      "kind": "reader_orphan",
+      "reason": "Production reads scan manifests through listScanManifests instead. Single-manifest lookup is used only by tests."
+    },
+    {
+      "method": "listCheckRuns",
+      "table": "check_runs",
+      "kind": "reader_orphan",
+      "reason": "check_runs is written on every check as a provenance log and never read back to skip or explain work. The log is write-only by design today; this entry records that the read API is unused rather than that the table is."
+    },
+    {
+      "method": "listFrameworkAdapters",
+      "table": "framework_adapters",
+      "kind": "reader_orphan",
+      "reason": "One adapter row per scan on dub. Read models rebuild adapter information from normalized entrypoints rather than from this table."
+    },
+    {
+      "method": "listGraphCompleteness",
+      "table": "graph_completeness",
+      "kind": "reader_orphan",
+      "reason": "Populated per scan; completeness reaches consumers through the scan payload rather than by querying this table."
+    },
+    {
+      "method": "listModuleDependents",
+      "table": "module_dependents",
+      "kind": "reader_orphan",
+      "rows_on_dub": 15311,
+      "reason": "15,311 rows written per dub scan and never queried in production. Dependents are traversed from graph edges instead."
+    },
+    {
+      "method": "listSymbolOccurrences",
+      "table": "symbol_occurrences",
+      "kind": "reader_orphan",
+      "rows_on_dub": 41905,
+      "reason": "41,905 rows written per dub scan and never queried in production - the single largest unread table. Together with module_dependents this is roughly 57,000 rows per scan with no consumer."
+    }
+  ]
+}

--- a/scripts/storage-lifecycle.mjs
+++ b/scripts/storage-lifecycle.mjs
@@ -1,0 +1,208 @@
+#!/usr/bin/env node
+/**
+ * Every migration-backed table must be written and read by production code.
+ *
+ * The failure this exists to stop is not hypothetical and not rare. A table gets a migration, a
+ * storage method, a schema and a test - and no production caller. Nothing fails: the table simply
+ * stays empty forever while readers merge an always-empty array into their output. `ParserGapV2` is
+ * the worked example: `upsertParserGapV2` has only test callers, and four agent surfaces
+ * (`prepare`, `repo map`, and two MCP tools) do `[...parserGaps, ...parserGapV2]` against nothing.
+ *
+ * Two independent audits of this repo each found a DIFFERENT subset of this class, which is the
+ * argument for a rule rather than a third audit. This check found a third instance neither had
+ * (`upsertSymbolIdentities`), and confirmed the shape against the database: both tables whose
+ * writers have no production caller measure 0 rows on a real dub scan.
+ *
+ * SEVERITY. A missing writer and a missing reader are not the same defect:
+ *   - `writer_orphan`  the table is never populated. Every read is empty, and any surface that
+ *                      reports on it is reporting on nothing. This is the ParserGapV2 disease.
+ *   - `reader_orphan`  the table IS populated and nothing in production reads it. Cheaper - dead
+ *                      read API rather than a false signal - but it is still storage cost with no
+ *                      consumer: `symbol_occurrences` and `module_dependents` alone are ~57,000
+ *                      rows per dub scan that nothing queries.
+ *
+ * RATCHET, both directions - the shape `scripts/evasion-baseline.json` uses. The baseline records
+ * honest current truth, never hides a known gap, and fails on:
+ *   - a NEW orphan, so the class cannot grow silently;
+ *   - a baselined orphan that now HAS a production caller, so fixing one forces removing its entry
+ *     rather than leaving a stale claim behind.
+ *
+ * Deliberately static. Running the product and counting rows would be a stronger signal but a much
+ * slower and flakier gate; "no production caller" is decidable from the source and was cross-checked
+ * against real row counts when the baseline was written.
+ */
+
+import { readdirSync, readFileSync, statSync } from "node:fs";
+import { join } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const repoRoot = fileURLToPath(new URL("..", import.meta.url));
+const BASELINE_PATH = join(repoRoot, "scripts/storage-lifecycle-baseline.json");
+const STORAGE_PATH = join(repoRoot, "packages/storage/src/sqlite-storage.ts");
+const MIGRATIONS_PATH = join(repoRoot, "packages/storage/src/migrations.ts");
+
+/** Tables the migrations create. The universe this check is about. */
+function migrationTables() {
+  const source = readFileSync(MIGRATIONS_PATH, "utf8");
+  return [...source.matchAll(/CREATE TABLE IF NOT EXISTS ([a-z_]+)/g)]
+    .map((match) => match[1])
+    .filter((table) => table !== "schema_migrations")
+    .sort()
+    .filter((table, index, all) => all.indexOf(table) === index);
+}
+
+/**
+ * Attribute each SQL statement to the storage method containing it.
+ *
+ * Method-level rather than statement-level because the question is "can production reach this
+ * table", and a caller reaches a method, not a statement.
+ */
+function tableMethods(tables) {
+  const source = readFileSync(STORAGE_PATH, "utf8");
+  const starts = [...source.matchAll(/^ {2}([a-zA-Z_][a-zA-Z0-9_]*)\s*\(/gm)]
+    .map((match) => ({ index: match.index, name: match[1] }));
+  const methodAt = (position) => {
+    let name;
+    for (const entry of starts) {
+      if (entry.index <= position) {
+        name = entry.name;
+      } else {
+        break;
+      }
+    }
+    return name;
+  };
+
+  const result = {};
+  for (const table of tables) {
+    const writers = new Set();
+    const readers = new Set();
+    const write = new RegExp(`INSERT (?:OR REPLACE )?INTO ${table}\\b|UPDATE ${table}\\b|DELETE FROM ${table}\\b`, "g");
+    const read = new RegExp(`FROM ${table}\\b`, "g");
+    for (const match of source.matchAll(write)) {
+      const name = methodAt(match.index);
+      if (name) writers.add(name);
+    }
+    for (const match of source.matchAll(read)) {
+      const name = methodAt(match.index);
+      if (name) readers.add(name);
+    }
+    result[table] = { writers: [...writers].sort(), readers: [...readers].sort() };
+  }
+  return result;
+}
+
+/**
+ * Every line of production source, read once.
+ *
+ * Built as a single corpus rather than grepping per method: there are ~64 storage methods reachable
+ * from a table, and a repo-wide grep each took this gate to ~105 seconds - slow enough that it
+ * would be the longest step in `verify:ci` and get skipped locally. One filesystem walk makes it
+ * sub-second.
+ *
+ * "Production" excludes tests, build output and dependencies. A test calling a method is exactly
+ * the situation this gate exists to catch, so tests cannot count as callers.
+ */
+function productionSource() {
+  const SKIP = new Set(["node_modules", "dist", "target", ".git", "coverage", ".next", "test", "tests"]);
+  const chunks = [];
+  const visit = (directory) => {
+    for (const entry of readdirSync(directory, { withFileTypes: true })) {
+      if (entry.name.startsWith(".")) continue;
+      const full = join(directory, entry.name);
+      if (entry.isDirectory()) {
+        if (!SKIP.has(entry.name)) visit(full);
+        continue;
+      }
+      if (!/\.(ts|tsx|mts|cts|js|mjs|cjs|rs)$/.test(entry.name)) continue;
+      if (/\.test\.|\.spec\./.test(entry.name)) continue;
+      // A method cannot be its own caller.
+      if (full.endsWith("packages/storage/src/sqlite-storage.ts")) continue;
+      chunks.push(readFileSync(full, "utf8"));
+    }
+  };
+  for (const top of ["packages", "crates", "scripts"]) {
+    const path = join(repoRoot, top);
+    try {
+      if (statSync(path).isDirectory()) visit(path);
+    } catch {
+      // A missing top-level directory is not this gate's concern.
+    }
+  }
+  return chunks.join("\n");
+}
+
+const PRODUCTION_SOURCE = productionSource();
+
+/** Does anything outside tests and build output call this storage method? */
+function hasProductionCaller(method) {
+  return PRODUCTION_SOURCE.includes(`.${method}(`);
+}
+
+function main() {
+  const tables = migrationTables();
+  const methods = tableMethods(tables);
+  const baseline = JSON.parse(readFileSync(BASELINE_PATH, "utf8"));
+  const known = new Map(baseline.known_orphans.map((entry) => [entry.method, entry]));
+
+  const orphans = [];
+  for (const table of tables) {
+    for (const [role, list] of [["writer", methods[table].writers], ["reader", methods[table].readers]]) {
+      for (const method of list) {
+        if (!hasProductionCaller(method)) {
+          orphans.push({ method, table, kind: `${role}_orphan` });
+        }
+      }
+    }
+  }
+  // A method can serve several tables; report it once, by its most severe role.
+  const byMethod = new Map();
+  for (const orphan of orphans) {
+    const existing = byMethod.get(orphan.method);
+    if (!existing || (existing.kind === "reader_orphan" && orphan.kind === "writer_orphan")) {
+      byMethod.set(orphan.method, orphan);
+    }
+  }
+
+  const found = [...byMethod.values()].sort((left, right) => left.method.localeCompare(right.method));
+  const failures = [];
+
+  for (const orphan of found) {
+    if (!known.has(orphan.method)) {
+      failures.push(
+        `NEW ${orphan.kind}: ${orphan.method} (${orphan.table}) has no production caller. ` +
+          (orphan.kind === "writer_orphan"
+            ? "The table will never be populated, so every reader of it returns empty."
+            : "The table is populated and nothing in production reads it.") +
+          " Wire it up, or add it to scripts/storage-lifecycle-baseline.json with a reason."
+      );
+    }
+  }
+  for (const [method, entry] of known) {
+    if (!byMethod.has(method)) {
+      failures.push(
+        `STALE baseline entry: ${method} now HAS a production caller. Remove it from ` +
+          "scripts/storage-lifecycle-baseline.json - a baseline that still claims a fixed gap is a false record."
+      );
+    }
+  }
+
+  const writerOrphans = found.filter((orphan) => orphan.kind === "writer_orphan");
+  console.log(
+    `storage lifecycle: ${tables.length} tables, ${found.length} orphaned method(s) ` +
+      `(${writerOrphans.length} writer, ${found.length - writerOrphans.length} reader), ` +
+      `${known.size} baselined.`
+  );
+  for (const orphan of found) {
+    const entry = known.get(orphan.method);
+    console.log(`  ${orphan.kind === "writer_orphan" ? "W" : "r"} ${orphan.method} (${orphan.table})${entry ? "" : "  <-- NEW"}`);
+  }
+
+  if (failures.length > 0) {
+    console.error("");
+    for (const failure of failures) console.error(`  ${failure}`);
+    process.exit(1);
+  }
+}
+
+main();

--- a/scripts/storage-lifecycle.test.mjs
+++ b/scripts/storage-lifecycle.test.mjs
@@ -1,0 +1,88 @@
+import { execFileSync } from "node:child_process";
+import { readFileSync, writeFileSync } from "node:fs";
+import { join } from "node:path";
+import { fileURLToPath } from "node:url";
+import { afterEach, describe, expect, it } from "vitest";
+
+const repoRoot = fileURLToPath(new URL("..", import.meta.url));
+const BASELINE = join(repoRoot, "scripts/storage-lifecycle-baseline.json");
+const original = readFileSync(BASELINE, "utf8");
+
+function runGate() {
+  try {
+    const stdout = execFileSync("node", ["scripts/storage-lifecycle.mjs"], {
+      cwd: repoRoot,
+      encoding: "utf8"
+    });
+    return { exitCode: 0, output: stdout };
+  } catch (error) {
+    return {
+      exitCode: error.status ?? 1,
+      output: `${error.stdout ?? ""}${error.stderr ?? ""}`
+    };
+  }
+}
+
+/**
+ * A ratchet is only worth having if it fails. These exercise both directions, because a gate that
+ * can only ever pass is indistinguishable from no gate - and the class it guards has already been
+ * missed by two separate architecture audits.
+ */
+describe("storage lifecycle gate", () => {
+  afterEach(() => {
+    writeFileSync(BASELINE, original);
+  });
+
+  it("passes against the committed baseline", () => {
+    const result = runGate();
+    expect(result.exitCode).toBe(0);
+    expect(result.output).toContain("storage lifecycle:");
+  });
+
+  it("fails when a storage method loses its production caller", () => {
+    // Simulated by removing a known orphan from the baseline: identical to a newly-introduced one
+    // from the gate's point of view, and it needs no source edit.
+    const baseline = JSON.parse(original);
+    baseline.known_orphans = baseline.known_orphans.filter(
+      (entry) => entry.method !== "upsertSymbolIdentities"
+    );
+    writeFileSync(BASELINE, JSON.stringify(baseline, null, 2));
+
+    const result = runGate();
+    expect(result.exitCode).toBe(1);
+    expect(result.output).toContain("NEW writer_orphan: upsertSymbolIdentities");
+    // A writer orphan must say why it is the more severe kind.
+    expect(result.output).toContain("never be populated");
+  });
+
+  it("fails when the baseline still claims a gap that has been fixed", () => {
+    // Keeps the record honest in the other direction: fixing a gap forces removing its entry,
+    // so the file cannot decay into a list of things that used to be true.
+    const baseline = JSON.parse(original);
+    baseline.known_orphans.push({
+      method: "listFacts",
+      table: "facts",
+      kind: "reader_orphan",
+      reason: "synthetic - listFacts has many production callers"
+    });
+    writeFileSync(BASELINE, JSON.stringify(baseline, null, 2));
+
+    const result = runGate();
+    expect(result.exitCode).toBe(1);
+    expect(result.output).toContain("STALE baseline entry: listFacts");
+  });
+
+  it("separates writer orphans from reader orphans", () => {
+    // The distinction is the point: a missing writer means every read is empty, a missing reader
+    // means data is stored and unused. Conflating them would bury the severe case.
+    const result = runGate();
+    expect(result.output).toMatch(/\d+ writer, \d+ reader/);
+    const baseline = JSON.parse(original);
+    const writers = baseline.known_orphans.filter((entry) => entry.kind === "writer_orphan");
+    expect(writers.map((entry) => entry.method).sort()).toEqual([
+      "upsertParserGapV2",
+      "upsertSecurityBoundaryProofs",
+      "upsertSymbolIdentities"
+    ]);
+  });
+});

--- a/test/e2e/release-hygiene.test.ts
+++ b/test/e2e/release-hygiene.test.ts
@@ -33,6 +33,7 @@ describe("release hygiene", () => {
     expect(manifest.scripts["format:engine:check"]).toBe("cargo fmt --all -- --check");
     expect(manifest.scripts["lint:engine"]).toBe("cargo clippy -p drift-engine --all-targets -- -D warnings");
     expect(manifest.scripts["check:boundaries"]).toBe("node packages/cli/scripts/check-boundaries.mjs");
+    expect(manifest.scripts["check:storage-lifecycle"]).toBe("node scripts/storage-lifecycle.mjs");
     expect(manifest.scripts["validate:release-matrix"]).toBe("node scripts/validate-engine-release-matrix.mjs");
     expect(manifest.scripts["validate:claims"]).toBe("node scripts/validate-product-claims.mjs");
     expect(manifest.scripts["beta:proof"]).toBe("node scripts/run-beta-proof.mjs");
@@ -50,6 +51,10 @@ describe("release hygiene", () => {
       // number - so the gate now fails on a rise and names the delta.
       // EW-7 added `pnpm eval:determinism`: determinism is the marketed claim, and it was only ever
       // measured by hand on two of the seven repos.
+      // This change adds `pnpm check:storage-lifecycle`: a migration-backed table whose writer has
+      // no production caller is never populated, while readers merge an always-empty array into
+      // agent output. Two separate architecture audits each found a different subset of that class
+      // and both missed a third, so it is now a gate rather than a periodic review.
       //
       // PR #102 took the four eval steps back out, and the reason matters. A hosted runner has none
       // of the seven pinned evaluation repos and no release engine binary, and the battery does not
@@ -57,7 +62,7 @@ describe("release hygiene", () => {
       // there. Listing them did not execute them; it produced a gate that named an oracle it never
       // consulted. They now live in `verify:evals`, which is a LOCAL gate, and `verify:full` is the
       // union that any "verified" claim has to cite.
-      "pnpm verify && pnpm test:harness && pnpm format:engine:check && pnpm lint:engine && pnpm check:boundaries && node scripts/validate-engine-release-matrix.mjs --allow-unverified && pnpm validate:claims && pnpm beta:proof && git diff --check",
+      "pnpm verify && pnpm test:harness && pnpm format:engine:check && pnpm lint:engine && pnpm check:boundaries && pnpm check:storage-lifecycle && node scripts/validate-engine-release-matrix.mjs --allow-unverified && pnpm validate:claims && pnpm beta:proof && git diff --check",
     );
     expect(manifest.scripts["verify:evals"]).toBe(
       "pnpm eval:external && pnpm eval:evasion && pnpm eval:bench && pnpm eval:determinism"


### PR DESCRIPTION
`drift prepare` and `get_task_preflight` each had their own copy of *"which files matter for this task"*. The copies had diverged **three ways**, all measured.

## 1. The in-scope predicate

The CLI tested `path_globs` directly; the enforcement path uses `conventionScopeFiles`. So `prepare` told an agent a file was **"in scope for convention_X"** using a rule `check` does not use to enforce convention_X.

BB-11 already adjudicated glob-only as a bug rather than a policy — and fixed only the MCP copy. On dub's real file list the two answer differently:

| contract shape | CLI | MCP (canonical) |
|---|---:|---:|
| with `exclude_path_globs` | 623 files | 171 |
| with empty `path_globs` | 0 | 4,091 |

Dormant on default-onboarded contracts, live the moment anyone imports one with exclusions or route flavours.

## 2. Gitignore

The CLI honoured `.gitignore`. The MCP copy never did.

## 3. Declaration files — introduced by #110

When the scan learned to record `.prisma`, only the CLI walker learned it. Measured on a fixture, for *"add a field to the prisma schema model Thing"*:

```
CLI  prisma/schema.prisma ["task token: prisma","task token: schema"]
     app/api/thing/route.ts [...]
MCP  app/api/thing/route.ts [...]          <- schema file absent
```

That one is mine, from #110, and it went unnoticed because only the CLI path was exercised.

## The fix

The MCP server cannot import from the CLI — the boundary check enforces it — which is why a second copy existed at all. The implementation moves to `@drift/query`, the home the boundary comment already designates: *"where T51 moved preflight ranking after the two copies silently diverged."* **T51 fixed ranking and left selection duplicated. This is the other half.**

The canonical predicate wins on scope, the gitignore-aware walk wins on discovery — each was the side already adjudicated correct. The walk moves too, since leaving it in the CLI is what forced the copy that caused divergences 2 and 3. There is now one `walkIndexableFiles`, re-exported to the CLI's five call sites.

**Verified**: CLI and MCP return byte-identical results for the same repo and task.

## A bug I caught in my own refactor

My first pass rewrote `tokenizeTask` from assumption rather than from either implementation — silently dropping `_`, `/` and `-` from the split and raising the length floor from 3 to 4. The two real implementations were byte-identical, so that would have been a **behaviour change disguised as a refactor**: it decides which files earn a `task token:` reason, which is what puts a file in front of an agent at all.

The shared copy is now verbatim, pinned by a test asserting `app/api` stays **one** token rather than two — my own wrong expectation there is what surfaced it.

## Verification

- `pnpm verify:ci` exits 0, reaches the final `beta:proof` JSON
- 1,069 tests across 8 packages
- `pnpm check:boundaries` passes — MCP still does not import the CLI
- Determinism unchanged: taxonomy `f208ce7ce3bef7a0`
- Only one `walkIndexableFiles` implementation remains, confirmed by grep

## Known

`Drift check (self)` has been red on main since #108 (`empty_contract` on drift's own repo). Not introduced here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)