### PR TITLE
Fix W4 CLI/MCP parity regression and re-pin verify:ci

### DIFF
--- a/packages/cli/src/domain/scan-status.ts
+++ b/packages/cli/src/domain/scan-status.ts
@@ -1,6 +1,6 @@
 import { type AuditChainVerification,type ConventionCandidate,DRIFT_RESOLVER_VERSION,DRIFT_RULE_ENGINE_VERSION,DRIFT_SCANNER_VERSION,DRIFT_TYPESCRIPT_ADAPTER_VERSION,type FileSnapshot,type ParserGap,type ParserGapConfidenceImpact,type ParserGapKind,type ParserGapV2,type RepoRecord,type ScanCapabilityReport,type ScanFileChange,type ScanManifest } from "@drift/core";
 import { buildFactGraphArtifactFromParts,type FactGraphArtifact,type GraphDiagnostic } from "@drift/factgraph";
-import { buildParserGapQuality,buildParserGapSummary,buildSecurityPhase8ReadModel,buildStoredScanReadiness,type DriftReadinessSurface } from "@drift/query";
+import { buildParserGapQuality,buildParserGapSummary,buildSecurityPhase8ReadModel,buildStoredScanReadiness,type DriftReadinessSurface,buildParserGapSection} from "@drift/query";
 import type { SqliteDriftStorage } from "@drift/storage";
 import { existsSync,mkdtempSync,readdirSync,rmSync,statSync,writeFileSync } from "node:fs";
 import { readFileSync } from "node:fs";
@@ -700,7 +700,7 @@ export function scanStatusPayload(storage: SqliteDriftStorage, repoId: string) {
       stale: true,
       invalidation_reasons: ["scan_missing"],
       changes: { added: [], modified: [], deleted: [] },
-      parser_gaps: parserGapSummary([]),
+      parser_gaps: buildParserGapSection([]),
       parser_gap_quality: buildParserGapQuality({
         repo_id: repoId,
         scan_id: null,
@@ -807,7 +807,7 @@ export function scanStatusPayload(storage: SqliteDriftStorage, repoId: string) {
     stale,
     invalidation_reasons: invalidationReasons,
     changes,
-    parser_gaps: parserGapSummary(allParserGaps),
+    parser_gaps: buildParserGapSection(allParserGaps),
     parser_gap_quality: buildParserGapQuality({
       repo_id: repoId,
       scan_id: latestScan.id,
@@ -928,29 +928,6 @@ export function parserGapsFromDiagnostics(input: {
     .filter((gap): gap is ParserGap => Boolean(gap));
 }
 
-export function parserGapSummary(gaps: Array<ParserGap | ParserGapV2>): {
-  total_count: number;
-  by_kind: Record<string, number>;
-  confidence_impact: Record<ParserGapConfidenceImpact, number>;
-  by_capability: Record<string, number>;
-  by_contract_kind: Record<string, number>;
-  records: Array<ParserGap | ParserGapV2>;
-} {
-  const summary = buildParserGapSummary(gaps);
-  return {
-    total_count: summary.total_count,
-    by_kind: summary.by_kind,
-    confidence_impact: summary.confidence_impact as Record<ParserGapConfidenceImpact, number>,
-    by_capability: summary.by_capability,
-    by_contract_kind: summary.by_contract_kind,
-    // D-A5: the itemized records, so `guidance.parser_gaps.full_list_command` points at data that
-    // exists. It named `drift doctor --repo <id> --json`, which accepts neither `--repo` nor `--db`
-    // - the flag was silently swallowed and the wrong directory evaluated - and returned no
-    // parser_gaps key even when invoked correctly. No surface returned the itemized list at all, so
-    // the field was an unchecked string template handed to agents as a pointer to data.
-    records: gaps
-  };
-}
 
 function scanCapabilityReportForScan(input: {
   repoId: string;

--- a/packages/mcp/src/index.ts
+++ b/packages/mcp/src/index.ts
@@ -88,8 +88,7 @@ import {
   rankRelevantFiles,
   relevantFilesForTask,
   repoMapFileForPayload,
-  walkIndexableFiles
-} from "@drift/query";
+  walkIndexableFiles,buildParserGapSection} from "@drift/query";
 import { MIGRATIONS, openDriftStorage } from "@drift/storage";
 import { execFileSync } from "node:child_process";
 import { createHash } from "node:crypto";
@@ -1329,7 +1328,7 @@ function scanStatusPayload(
     stale,
     invalidation_reasons: invalidationReasons,
     changes,
-    parser_gaps: parserGapSummary(allParserGaps),
+    parser_gaps: buildParserGapSection(allParserGaps),
     parser_gap_quality: buildParserGapQuality({
       repo_id: repoId,
       scan_id: latestScan?.id ?? null,
@@ -1395,22 +1394,6 @@ function readinessForStoredScan(
   });
 }
 
-function parserGapSummary(gaps: Array<ParserGap | ParserGapV2>): {
-  total_count: number;
-  by_kind: Record<ParserGapKind, number>;
-  confidence_impact: Record<ParserGapConfidenceImpact, number>;
-  by_capability: Record<string, number>;
-  by_contract_kind: Record<string, number>;
-} {
-  const summary = buildParserGapSummary(gaps);
-  return {
-    total_count: summary.total_count,
-    by_kind: summary.by_kind as Record<ParserGapKind, number>,
-    confidence_impact: summary.confidence_impact as Record<ParserGapConfidenceImpact, number>,
-    by_capability: summary.by_capability,
-    by_contract_kind: summary.by_contract_kind
-  };
-}
 
 function scanStatusSummary(options: {
   latestScanId: string | null;

--- a/packages/query/src/index.ts
+++ b/packages/query/src/index.ts
@@ -29,7 +29,7 @@ export { classifyAgentTask } from "./task-intent.js";
 export { evaluateRoleEdge } from "./role-ontology.js";
 export { scoreHelperSimilarity } from "./helper-similarity.js";
 export { buildRepoTopology } from "./repo-topology.js";
-export { buildParserGapSummary, buildReadiness, buildStoredScanReadiness } from "./readiness.js";
+export { buildParserGapSection, buildParserGapSummary, buildReadiness, buildStoredScanReadiness } from "./readiness.js";
 export { buildParserGapQuality } from "./parser-gap-quality.js";
 export { buildSemanticCoverage, buildSemanticCoverageFromCapabilityReport } from "./semantic-coverage.js";
 export { buildCanonicalRouteReadModel } from "./canonical-routes.js";

--- a/packages/query/src/readiness.ts
+++ b/packages/query/src/readiness.ts
@@ -136,6 +136,25 @@ export function buildParserGapSummary(gaps: ParserGapLike[]): ParserGapSummary {
   };
 }
 
+/**
+ * The parser-gap section as both agent surfaces report it, including the itemized records.
+ *
+ * One implementation, because there were two and they diverged the moment one changed. The CLI and
+ * MCP each wrapped `buildParserGapSummary` above with a private, hand-written, near-identical
+ * function; adding `records` to the CLI's copy - so that the summary's own `full_list_command`
+ * finally pointed at data that exists (D-A5) - left MCP emitting `undefined` and turned
+ * `beta:proof`'s CLI/MCP parity check red.
+ *
+ * Both copies were module-private, which is exactly why no duplicate index caught them: the
+ * architecture census indexed only symbols carrying a top-level `export`, and recorded that as a
+ * known blind spot. This is an instance of it.
+ */
+export function buildParserGapSection(gaps: ParserGapLike[]): ParserGapSummary & {
+  records: ParserGapLike[];
+} {
+  return { ...buildParserGapSummary(gaps), records: gaps };
+}
+
 function readinessDecision(input: {
   graphAvailable: boolean;
   graphComplete: boolean;

--- a/test/e2e/release-hygiene.test.ts
+++ b/test/e2e/release-hygiene.test.ts
@@ -62,8 +62,15 @@ describe("release hygiene", () => {
       // there. Listing them did not execute them; it produced a gate that named an oracle it never
       // consulted. They now live in `verify:evals`, which is a LOCAL gate, and `verify:full` is the
       // union that any "verified" claim has to cite.
-      "pnpm verify && pnpm test:harness && pnpm format:engine:check && pnpm lint:engine && pnpm check:boundaries && pnpm check:storage-lifecycle && node scripts/validate-engine-release-matrix.mjs --allow-unverified && pnpm validate:claims && pnpm beta:proof && git diff --check",
+      // W1 added `pnpm check:storage-invariants`; W3 added `pnpm check:error-contract`. This
+      // assertion pins the whole string on purpose - a gate silently dropped from verify:ci is
+      // indistinguishable from one that never existed - so adding a gate has to land here too.
+      // Both workstreams forgot, and this stayed red on main until a later one noticed: the
+      // package suites and the harness were run before merge, `test:e2e` was not.
+      "pnpm verify && pnpm test:harness && pnpm format:engine:check && pnpm lint:engine && pnpm check:boundaries && pnpm check:storage-lifecycle && pnpm check:storage-invariants && pnpm check:error-contract && node scripts/validate-engine-release-matrix.mjs --allow-unverified && pnpm validate:claims && pnpm beta:proof && git diff --check",
     );
+    expect(manifest.scripts["check:storage-invariants"]).toBe("node scripts/storage-invariants.mjs");
+    expect(manifest.scripts["check:error-contract"]).toBe("node scripts/error-contract.mjs");
     expect(manifest.scripts["verify:evals"]).toBe(
       "pnpm eval:external && pnpm eval:evasion && pnpm eval:bench && pnpm eval:determinism"
     );


### PR DESCRIPTION
Two breaks that PR #113 put on `main`, both surfaced by a later workstream rather than caught before
merge.

## CLI/MCP parity — `beta:proof` red

W4 added `records` to the parser-gap section so its own `full_list_command` finally pointed at data
that exists (D-A5). The CLI and MCP each wrapped the shared `buildParserGapSummary` with a private,
hand-written, near-identical function, so only the CLI's grew the field:

```
Error: CLI/MCP parity mismatch: scan_status, repo_map, preflight, findings, allowed_context
  parser_gaps.records: cli=[] mcp=undefined
```

This is a new instance of exactly the class W6 exists to remove. Both copies were **module-private**,
which is why no duplicate index caught them — the architecture census indexed only symbols carrying a
top-level `export`, and recorded that as a known blind spot.

Fixed by deleting both wrappers and making `buildParserGapSection` in `@drift/query` the one
implementation. Adding the field to MCP's copy instead would have left the divergence one edit away
from returning.

## `verify:ci` pin — `test:e2e` red

`test/e2e/release-hygiene.test.ts` pins the entire `verify:ci` string on purpose: a gate silently
dropped from it is indistinguishable from one that never existed. W1 added
`check:storage-invariants` and W3 added `check:error-contract` without updating it, so it has been
red since W1. Both new gates now also get their own script assertions.

## Why these reached main

Before merging #113 I ran the package suites and `test:harness`, but not `test:e2e`. Both failures
were caught by checks that already existed and were simply not run — the gap was in my verification,
not in the gates.

## Verification

`beta:proof` exit 0 · e2e **83/83** (was 82/83) · cli 633 · core 206 · storage 60 · mcp 66 ·
query 62 · harness 121.

🤖 Generated with [Claude Code](https://claude.com/claude-code)