### PR TITLE
Remediation: eval ratchet, shared derivation, W4 remainder, payload invariants

### DIFF
--- a/crates/drift-engine/src/candidate_command.rs
+++ b/crates/drift-engine/src/candidate_command.rs
@@ -138,8 +138,19 @@ pub fn infer_candidates(request: CandidateRequest) -> CandidateResult {
             .collect::<BTreeSet<_>>();
         let direction =
             baseline_coverage_direction(&violating_files, &scope_files, &diff_changed_files);
+        // D-H1: the count is the DEDUPED evidence, not the two source lists summed.
+        //
+        // `combined_evidence_refs` dedupes by (file_path, start_line, end_line, symbol,
+        // import_source), because a fact and a graph import routinely describe the same import
+        // statement. Summing the inputs counts that statement twice. On a fixture with one import
+        // in one file it reported `supporting_examples_count: 2` beside an `evidence_refs` of
+        // length 1 - and `commands/start.ts:368` renders the score directly, so a human accepting
+        // the convention read "Evidence: 2 matching import(s)" for one import.
+        //
+        // `build_candidate` at the bottom of this file already passes `evidence_refs.len()`;
+        // this makes the two agree.
         let mut data_access_scoring = scoring(
-            data_imports.len() + graph_data_imports.len(),
+            evidence_refs.len(),
             0,
             scope_file_count,
             unique_evidence_file_count(&data_imports, &graph_data_imports),
@@ -244,9 +255,14 @@ pub fn infer_candidates(request: CandidateRequest) -> CandidateResult {
             suggested_enforcement_mode: "warn".to_string(),
             enforcement_capability: "heuristic_check".to_string(),
             confidence_label: if service_imports.is_empty() { "low" } else { "medium" }.to_string(),
+            // D-H1, second instance and not in the audit: same undeduped sum, one field over.
+            // `counterexample_refs` here is `combined_evidence_refs(data_imports,
+            // graph_data_imports)` - deduped - while `counterexamples_count` summed the same two
+            // inputs raw. `supporting` is `service_imports.len()` and stays: plain `evidence_refs`
+            // maps one ref per fact with no dedup, so that count already equals its list.
             scoring: scoring(
                 service_imports.len(),
-                data_imports.len() + graph_data_imports.len(),
+                counterexample_refs.len(),
                 scope_file_count,
                 unique_fact_file_count(&service_imports),
                 "engine-service-delegation-v1",

--- a/crates/drift-engine/tests/candidate_inference.rs
+++ b/crates/drift-engine/tests/candidate_inference.rs
@@ -718,6 +718,20 @@ fn infer_candidates_merges_duplicate_raw_and_graph_evidence_fact_ids() {
             "graph_fact_db"
         ])
     );
+
+    // D-H1: the SCORE has to agree with the list it summarises.
+    //
+    // This fixture is one import statement in one file described twice - once as a raw fact and
+    // once as a graph import - which is exactly what `combined_evidence_refs` dedupes and exactly
+    // what `data_imports.len() + graph_data_imports.len()` did not. The test asserted the deduped
+    // list and never the count, so `supporting_examples_count: 2` sat beside one ref for as long
+    // as it existed. `commands/start.ts:368` prints this number as "Evidence: N matching
+    // import(s)" on the screen a human uses to accept the convention.
+    assert_eq!(
+        direct["scoring"]["supporting_examples_count"],
+        json!(refs.len()),
+        "{direct:#?}"
+    );
 }
 
 /// T26: `withWorkspace` is NOT recognised as an auth helper, and that is the correct behaviour.

--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
     "validate:claims": "node scripts/validate-product-claims.mjs",
     "beta:proof": "node scripts/run-beta-proof.mjs",
     "release:proof": "node scripts/generate-release-proof.mjs",
-    "verify:ci": "pnpm verify && pnpm test:harness && pnpm format:engine:check && pnpm lint:engine && pnpm check:boundaries && pnpm check:storage-lifecycle && pnpm check:storage-invariants && pnpm check:error-contract && pnpm check:vocabulary && node scripts/validate-engine-release-matrix.mjs --allow-unverified && pnpm validate:claims && pnpm beta:proof && git diff --check",
+    "verify:ci": "pnpm verify && pnpm test:harness && pnpm format:engine:check && pnpm lint:engine && pnpm check:boundaries && pnpm check:storage-lifecycle && pnpm check:storage-invariants && pnpm check:error-contract && pnpm check:vocabulary && pnpm check:surface-parity && node scripts/validate-engine-release-matrix.mjs --allow-unverified && pnpm validate:claims && pnpm beta:proof && git diff --check",
     "verify:evals": "pnpm eval:external && pnpm eval:breadth && pnpm eval:evasion && pnpm eval:bench && pnpm eval:determinism",
     "verify:full": "pnpm verify:ci && pnpm verify:evals",
     "eval:external": "node scripts/external-eval.mjs",
@@ -35,7 +35,7 @@
     "eval:bench:update": "node scripts/beta-bench.mjs --update",
     "eval:determinism": "node scripts/determinism.mjs",
     "run:log": "node scripts/run-log.mjs",
-    "test:harness": "vitest run scripts/detection-breadth.test.mjs scripts/external-eval.test.mjs scripts/evasion-matrix.test.mjs scripts/validate-engine-release-matrix.test.mjs scripts/worktree-contamination.test.mjs scripts/beta-bench-ratchet.test.mjs scripts/validate-product-claims.test.mjs scripts/engine-handshake.test.mjs scripts/external-eval-start.test.mjs scripts/storage-lifecycle.test.mjs scripts/storage-invariants.test.mjs scripts/error-contract.test.mjs scripts/vocabulary-parity.test.mjs",
+    "test:harness": "vitest run scripts/detection-breadth.test.mjs scripts/external-eval.test.mjs scripts/evasion-matrix.test.mjs scripts/validate-engine-release-matrix.test.mjs scripts/worktree-contamination.test.mjs scripts/beta-bench-ratchet.test.mjs scripts/validate-product-claims.test.mjs scripts/engine-handshake.test.mjs scripts/external-eval-start.test.mjs scripts/storage-lifecycle.test.mjs scripts/storage-invariants.test.mjs scripts/error-contract.test.mjs scripts/vocabulary-parity.test.mjs scripts/surface-parity.test.mjs",
     "eval:prepare": "node scripts/prepare-quality-eval.mjs",
     "eval:presence": "node scripts/presence-precision-recall.mjs",
     "eval:presence:update": "node scripts/presence-precision-recall.mjs --update",
@@ -43,6 +43,7 @@
     "check:storage-invariants": "node scripts/storage-invariants.mjs",
     "check:error-contract": "node scripts/error-contract.mjs",
     "check:vocabulary": "node scripts/vocabulary-parity.mjs",
+    "check:surface-parity": "node scripts/surface-parity.mjs",
     "vocabulary:generate": "node vocabulary/generate.mjs"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
     "validate:claims": "node scripts/validate-product-claims.mjs",
     "beta:proof": "node scripts/run-beta-proof.mjs",
     "release:proof": "node scripts/generate-release-proof.mjs",
-    "verify:ci": "pnpm verify && pnpm test:harness && pnpm format:engine:check && pnpm lint:engine && pnpm check:boundaries && pnpm check:storage-lifecycle && pnpm check:storage-invariants && pnpm check:error-contract && pnpm check:vocabulary && pnpm check:surface-parity && node scripts/validate-engine-release-matrix.mjs --allow-unverified && pnpm validate:claims && pnpm beta:proof && git diff --check",
+    "verify:ci": "pnpm verify && pnpm test:harness && pnpm format:engine:check && pnpm lint:engine && pnpm check:boundaries && pnpm check:storage-lifecycle && pnpm check:storage-invariants && pnpm check:error-contract && pnpm check:vocabulary && pnpm check:surface-parity && pnpm check:payload-invariants && node scripts/validate-engine-release-matrix.mjs --allow-unverified && pnpm validate:claims && pnpm beta:proof && git diff --check",
     "verify:evals": "pnpm eval:external && pnpm eval:breadth && pnpm eval:evasion && pnpm eval:bench && pnpm eval:determinism",
     "verify:full": "pnpm verify:ci && pnpm verify:evals",
     "eval:external": "node scripts/external-eval.mjs",
@@ -35,7 +35,7 @@
     "eval:bench:update": "node scripts/beta-bench.mjs --update",
     "eval:determinism": "node scripts/determinism.mjs",
     "run:log": "node scripts/run-log.mjs",
-    "test:harness": "vitest run scripts/detection-breadth.test.mjs scripts/external-eval.test.mjs scripts/evasion-matrix.test.mjs scripts/validate-engine-release-matrix.test.mjs scripts/worktree-contamination.test.mjs scripts/beta-bench-ratchet.test.mjs scripts/validate-product-claims.test.mjs scripts/engine-handshake.test.mjs scripts/external-eval-start.test.mjs scripts/storage-lifecycle.test.mjs scripts/storage-invariants.test.mjs scripts/error-contract.test.mjs scripts/vocabulary-parity.test.mjs scripts/surface-parity.test.mjs",
+    "test:harness": "vitest run scripts/detection-breadth.test.mjs scripts/external-eval.test.mjs scripts/evasion-matrix.test.mjs scripts/validate-engine-release-matrix.test.mjs scripts/worktree-contamination.test.mjs scripts/beta-bench-ratchet.test.mjs scripts/validate-product-claims.test.mjs scripts/engine-handshake.test.mjs scripts/external-eval-start.test.mjs scripts/storage-lifecycle.test.mjs scripts/storage-invariants.test.mjs scripts/error-contract.test.mjs scripts/vocabulary-parity.test.mjs scripts/surface-parity.test.mjs scripts/payload-invariants.test.mjs",
     "eval:prepare": "node scripts/prepare-quality-eval.mjs",
     "eval:presence": "node scripts/presence-precision-recall.mjs",
     "eval:presence:update": "node scripts/presence-precision-recall.mjs --update",
@@ -44,6 +44,7 @@
     "check:error-contract": "node scripts/error-contract.mjs",
     "check:vocabulary": "node scripts/vocabulary-parity.mjs",
     "check:surface-parity": "node scripts/surface-parity.mjs",
+    "check:payload-invariants": "node scripts/payload-invariants.mjs",
     "vocabulary:generate": "node vocabulary/generate.mjs"
   },
   "devDependencies": {

--- a/packages/cli/src/app/router.ts
+++ b/packages/cli/src/app/router.ts
@@ -9,6 +9,7 @@ import { listChecks } from "../commands/checks.js";
 import { runRequiredCheck } from "../commands/checks-run.js";
 import { addContractWaiver,exportContract,importContractDryRun,listContractWaivers,removeContractWaiver,showContract,showContractWaiver,validateContract } from "../commands/contract.js";
 import { acceptCandidate,addConventionException,editCandidate,listAcceptedConventions,listConventionCandidates,rejectCandidate,showConventionCandidate } from "../commands/conventions.js";
+import { formatConventionMutationText } from "../formatters/convention-mutations.js";
 import { listFindings,markFindingFixed,resolveFindingWithReason,showFinding } from "../commands/findings.js";
 import { initRepo } from "../commands/init.js";
 import { checkPolicyContext,grantAgentPermission,revokeAgentPermission,setEgressPolicy,showPolicy } from "../commands/policy.js";
@@ -115,24 +116,31 @@ export async function runCommand(storage: SqliteDriftStorage, parsed: ParsedArgs
     return showConventionCandidate(storage, parsed, id);
   }
 
+  // D-CL2: the four convention mutations are wrapped here rather than at each of their several
+  // return points, so the text branch cannot be added to three of them and forgotten on the
+  // fourth - which is the shape of the defect being fixed.
   if (group === "conventions" && command === "accept") {
     const id = requiredValue(maybeId, "candidate id");
-    return acceptCandidate(storage, parsed, id);
+    return conventionMutationResult(parsed, "accepted", acceptCandidate(storage, parsed, id));
   }
 
   if (group === "conventions" && command === "reject") {
     const id = requiredValue(maybeId, "candidate id");
-    return rejectCandidate(storage, parsed, id);
+    return conventionMutationResult(parsed, "rejected", rejectCandidate(storage, parsed, id));
   }
 
   if (group === "conventions" && command === "edit") {
     const id = requiredValue(maybeId, "candidate id");
-    return editCandidate(storage, parsed, id);
+    return conventionMutationResult(parsed, "edited", editCandidate(storage, parsed, id));
   }
 
   if (group === "conventions" && command === "exception" && maybeId === "add") {
     const conventionId = requiredValue(parsed.positional[3], "convention id");
-    return addConventionException(storage, parsed, conventionId);
+    return conventionMutationResult(
+      parsed,
+      "exception added",
+      addConventionException(storage, parsed, conventionId)
+    );
   }
 
   if (group === "contract" && command === "show") {
@@ -238,4 +246,22 @@ export async function runCommand(storage: SqliteDriftStorage, parsed: ParsedArgs
   }
 
   throw new Error(`Unknown command: ${parsed.positional.join(" ")}. Run drift --help.`);
+}
+
+/**
+ * D-CL2: give a convention mutation its human rendering.
+ *
+ * These four commands each have several return points (dry run, already-in-that-state, and the
+ * confirmed write), so branching inside them would mean twelve places to remember instead of one.
+ */
+function conventionMutationResult(
+  parsed: ParsedArgs,
+  action: "accepted" | "rejected" | "edited" | "exception added",
+  result: unknown
+): CommandPayload {
+  return {
+    payload: parsed.flags.has("json")
+      ? result
+      : formatConventionMutationText(action, result as Parameters<typeof formatConventionMutationText>[1])
+  };
 }

--- a/packages/cli/src/commands/ask.ts
+++ b/packages/cli/src/commands/ask.ts
@@ -43,15 +43,7 @@ export function askRepo(storage: SqliteDriftStorage, parsed: ParsedArgs): Comman
   const conventions = conventionsForFiles(activeConventions, relevantFiles).map((convention) =>
     // Explicit lambda: a bare reference passes Array#map's index as the context argument,
     // which the compiler caught when BB-5 gave preparedConvention a second parameter.
-    preparedConvention(convention, {
-      scopeFiles: askExemplarContext.scopeFilesFor(convention),
-      // CV-5: any accepted convention, not just this one - see violatingFilesAnyConvention.
-      violatingFiles: askExemplarContext.violatingFilesAnyConvention(),
-      roleByFile: askExemplarContext.roleByFile,
-      baselineActiveCount: askExemplarContext.baselineActiveCountFor(convention.id),
-      targetPath: targetPath ?? undefined,
-      importsByFile: askExemplarContext.importsByFile
-    })
+    preparedConvention(convention, askExemplarContext, { targetPath: targetPath ?? undefined })
   );
   const findings = findingsForTopic(storage.listFindings(repoId), topic, relevantFiles)
     .map((finding) => ({

--- a/packages/cli/src/commands/checks-run.ts
+++ b/packages/cli/src/commands/checks-run.ts
@@ -9,6 +9,7 @@ import { actorFlag,optionalPositiveIntegerFlag,requiredNonEmptyFlag,stringFlag }
 import { resolveRepoId } from "../args/repo-flags.js";
 import { auditEvent,preflightGovernance } from "../domain/governance.js";
 import { contractFingerprint,hashStable } from "../domain/identifiers.js";
+import { formatChecksRunText } from "../formatters/checks-run.js";
 import { allRequiredChecks } from "../domain/preflight.js";
 import { requiredRepoContract } from "../domain/repo-paths.js";
 import { gitOutput } from "../io/git.js";
@@ -133,7 +134,8 @@ export async function runRequiredCheck(storage: SqliteDriftStorage, parsed: Pars
 
   return {
     exitCode: status === "passed" ? 0 : 1,
-    payload
+    // D-CL2: the exit code is the contract; the text is what a human reads beside it.
+    payload: parsed.flags.has("json") ? payload : formatChecksRunText(payload)
   };
 }
 

--- a/packages/cli/src/commands/prepare.ts
+++ b/packages/cli/src/commands/prepare.ts
@@ -115,7 +115,8 @@ export function prepareTask(storage: SqliteDriftStorage, parsed: ParsedArgs): Co
     test_files: testFiles
   });
   const testSelection = selectRelevantTests({
-    changed_file: relevantFiles[0]?.path ?? targetPath ?? "",
+    // D-A3(a): every relevant file, not just the head of the ranked list.
+    changed_files: relevantFiles.map((file) => file.path),
     route_flow: changeImpactRouteFlows[0],
     test_files: testFiles
   });
@@ -283,11 +284,12 @@ export function prepareTask(storage: SqliteDriftStorage, parsed: ParsedArgs): Co
     task_preflight_packet: taskPreflightPacket,
     change_impact: changeImpact,
     test_intelligence: testSelection.test_intelligence,
-    // BB-6 (EW-3 shape): a bare `[]` cannot say whether test selection ran and found nothing or was
-    // never implemented for this repo, and the two call for opposite responses from a reader.
-    test_intelligence_reason: testSelection.test_intelligence.length === 0
-      ? "not_implemented_for_repo"
-      : null,
+    // BB-6 (EW-3 shape): a bare `[]` cannot say whether test selection ran and found nothing or
+    // was never implemented for this repo, and the two call for opposite responses from a reader.
+    // D-A3(c): derived by selectRelevantTests, which is where the inputs that tell "no tests
+    // exist" from "the matcher missed them" actually live. This was an inline ternary here and a
+    // byte-identical one in MCP, and both answered "not_implemented_for_repo" to both questions.
+    test_intelligence_reason: testSelection.test_intelligence_reason,
     agent_contract_packet: agentContractPacket,
     baseline,
     findings,

--- a/packages/cli/src/commands/prepare.ts
+++ b/packages/cli/src/commands/prepare.ts
@@ -53,15 +53,8 @@ export function prepareTask(storage: SqliteDriftStorage, parsed: ParsedArgs): Co
   // about - an exemplar it cannot vouch for is the thing this item exists to stop.
   const exemplarContext = conformingExemplarContext(storage, repoId);
   const conventions = activeConventions.map((convention) =>
-    preparedConvention(convention, {
-      scopeFiles: exemplarContext.scopeFilesFor(convention),
-      // CV-5: any accepted convention, not just this one - see violatingFilesAnyConvention.
-      violatingFiles: exemplarContext.violatingFilesAnyConvention(),
-      roleByFile: exemplarContext.roleByFile,
-      baselineActiveCount: exemplarContext.baselineActiveCountFor(convention.id),
-      targetPath: targetPath ?? undefined,
-      importsByFile: exemplarContext.importsByFile
-    })
+    // Explicit lambda: a bare reference passes Array#map's index as the second argument.
+    preparedConvention(convention, exemplarContext, { targetPath: targetPath ?? undefined })
   );
   const findings = storage
     .listFindings(repoId)

--- a/packages/cli/src/commands/scan.ts
+++ b/packages/cli/src/commands/scan.ts
@@ -5,18 +5,21 @@ import { requiredDatabasePath,resolveRepoRoot } from "../args/repo-flags.js";
 import { auditEvent } from "../domain/governance.js";
 import { hashStable,repoIdForRoot,sanitizeAuditId } from "../domain/identifiers.js";
 import { runScanRepo,scanStatusPayload } from "../domain/scan-status.js";
+import { formatScanText } from "../formatters/scan.js";
 import { formatScanStatusText } from "../formatters/scan-status.js";
 
-export async function scanRepo(storage: SqliteDriftStorage, parsed: ParsedArgs) {
+export async function scanRepo(storage: SqliteDriftStorage, parsed: ParsedArgs): Promise<CommandPayload> {
   if (stringFlag(parsed, "repo")) {
     throw new Error("--repo is not supported for drift scan; use --repo-root with --state-root, or run scan status for an existing repo id.");
   }
-  return runScanRepo(storage, {
+  const payload = await runScanRepo(storage, {
     now: stringFlag(parsed, "now") ?? new Date().toISOString(),
     repoRoot: resolveRepoRoot(parsed),
     actor: actorFlag(parsed),
     databasePath: requiredDatabasePath(parsed)
   });
+  // D-CL2: without this branch, `drift scan` printed compact single-line JSON to a terminal.
+  return { payload: parsed.flags.has("json") ? payload : formatScanText(payload) };
 }
 
 export function scanStatus(storage: SqliteDriftStorage, parsed: ParsedArgs): CommandPayload {

--- a/packages/cli/src/domain/agent-envelope.ts
+++ b/packages/cli/src/domain/agent-envelope.ts
@@ -1,26 +1,8 @@
-import { createAgentEnvelopeV2,type PolicyDecision } from "@drift/core";
-import type { scanStatusPayload } from "./scan-status.js";
-
-export function agentEnvelopeForScan(input: {
-  surface: PolicyDecision["surface"] | "cli-error";
-  policy?: Pick<PolicyDecision, "allowed" | "surface" | "reason">;
-  scanStatus?: ReturnType<typeof scanStatusPayload>;
-  requireFresh?: boolean;
-  diagnostics?: string[];
-  contextTruncated?: boolean;
-}) {
-  return createAgentEnvelopeV2({
-    surface: input.surface,
-    policy: input.policy,
-    scan: {
-      required_fresh: Boolean(input.requireFresh),
-      stale: input.scanStatus?.stale ?? false,
-      latest_scan_id: input.scanStatus?.latest_scan?.id ?? null
-    },
-    redactions: {
-      snippets_included: false,
-      context_truncated: Boolean(input.contextTruncated)
-    },
-    diagnostics: input.diagnostics
-  });
-}
+/**
+ * W6: `agentEnvelopeForScan` moved to @drift/query.
+ *
+ * MCP kept `mcpAgentEnvelope` - the same `createAgentEnvelopeV2` call with a narrower signature -
+ * and the two would have had to be edited in step forever. Re-exported from here so the CLI's
+ * existing importers keep their path; @drift/query holds the only definition.
+ */
+export { agentEnvelopeForScan } from "@drift/query";

--- a/packages/cli/src/domain/preflight.ts
+++ b/packages/cli/src/domain/preflight.ts
@@ -9,35 +9,12 @@ import { isOpenPreflightFinding } from "./findings.js";
 import { isApiRoutePath,matchesGlob } from "./repo-paths.js";
 import { scanStatusPayload } from "./scan-status.js";
 
-export interface PreparedConvention {
-  id: string;
-  kind: AcceptedConvention["kind"];
-  statement: string;
-  severity: Severity;
-  enforcement_mode: EnforcementMode;
-  enforcement_capability: AcceptedConvention["enforcement_capability"];
-  scope: AcceptedConvention["scope"];
-  matcher: AcceptedConvention["matcher"];
-  exceptions: AcceptedConvention["exceptions"];
-  agent_instruction: string;
-  /**
-   * BB-5: files in scope that obey this convention. Never a violator - see
-   * `domain/conforming-exemplars.ts` for why that invariant is the item rather than a nicety.
-   */
-  conforming_examples: Array<{ file_path: string; role: string | null }>;
-  /** BB-5: why an empty exemplar list is empty. Never a bare `[]` (the EW-3 shape). */
-  conforming_examples_reason: string | null;
-  /**
-   * BB-5: the AK-8 split. `derivation` is how Drift came to believe the repo holds this convention;
-   * `reason` is why the repo holds it, which is what a reader deciding whether to comply needs.
-   */
-  rationale: { derivation: string; reason: string | null };
-  /**
-   * BB-5: why the baselined violations around the exemplars are not precedent. Absent when there
-   * are none - boilerplate saying "0 are baselined" trains readers to skip the line.
-   */
-  migration_sentence: string | null;
-}
+// W6: `PreparedConvention`, `preparedConvention` and `instructionForConvention` moved to
+// @drift/query, because MCP maintained a second copy of all three and the copy had diverged twice
+// (D-A1, and the missing CV-5 presence branch). Re-exported here so the CLI's existing importers
+// keep their import path; @drift/query is the only definition.
+import type { PreparedConvention } from "@drift/query";
+export { instructionForConvention, preparedConvention, type PreparedConvention } from "@drift/query";
 
 export interface RelevantFile {
   path: string;
@@ -83,102 +60,6 @@ export interface PreflightSummaryInput {
   safeCommands: RepoContract["safe_commands"];
   baseline: ReturnType<typeof baselineSummary>;
   scanStatus: ReturnType<typeof scanStatusPayload>;
-}
-
-export function preparedConvention(
-  convention: AcceptedConvention,
-  // BB-5: optional so every existing caller keeps working and gets the empty-with-reason shape
-  // rather than a missing field. A packet that silently omits the exemplars is the status quo.
-  context: {
-    scopeFiles?: string[];
-    violatingFiles?: Iterable<string>;
-    roleByFile?: Map<string, string>;
-    baselineActiveCount?: number;
-    targetPath?: string;
-    /** `import_used` values by file, so an exemplar is proven rather than presumed. */
-    importsByFile?: Map<string, string[]>;
-  } = {}
-): PreparedConvention {
-  const exemplars = conformingExemplars({
-    scopeFiles: context.scopeFiles ?? [],
-    violatingFiles: context.violatingFiles ?? [],
-    roleByFile: context.roleByFile,
-    referenceFile: context.targetPath,
-    // Verified against facts, not inferred from a missing finding. prepare never runs a check, so
-    // its violator set is only whatever a previous check happened to record.
-    forbiddenImports: convention.matcher?.forbidden_imports ?? [],
-    importsByFile: context.importsByFile
-  });
-  return {
-    id: convention.id,
-    kind: convention.kind,
-    statement: convention.statement,
-    severity: convention.severity,
-    enforcement_mode: convention.enforcement_mode,
-    enforcement_capability: convention.enforcement_capability,
-    scope: convention.scope,
-    matcher: convention.matcher,
-    exceptions: convention.exceptions,
-    agent_instruction: instructionForConvention(convention),
-    conforming_examples: exemplars.conforming_examples,
-    conforming_examples_reason: exemplars.reason,
-    rationale: conventionRationale({
-      kind: convention.kind,
-      derivation: convention.rationale ?? convention.statement
-    }),
-    migration_sentence: migrationSentence(context.baselineActiveCount ?? 0)
-  };
-}
-
-export function instructionForConvention(convention: AcceptedConvention): string {
-  if (convention.kind === "api_route_no_direct_data_access") {
-    const forbidden = (convention.matcher.forbidden_imports ?? []).join(", ");
-    return [
-      "When editing API route files, do not import data-access clients directly.",
-      forbidden ? `Forbidden imports: ${forbidden}.` : "",
-      "Delegate through the repo's accepted service/data-access layer and run drift check before finishing."
-    ].filter(Boolean).join(" ");
-  }
-
-  if (convention.kind === "api_route_requires_service_delegation") {
-    const delegates = (convention.matcher.allowed_delegate_imports ?? []).join(", ");
-    return [
-      "When editing API route files, keep route modules thin and delegate business/data-access work to the service layer.",
-      delegates ? `Observed delegate imports: ${delegates}.` : "",
-      "Treat this as briefing guidance unless the repo later upgrades it to a deterministic check."
-    ].filter(Boolean).join(" ");
-  }
-
-  // CV-5: the presence kinds. Without this they fell through to the generic sentence below, which
-  // restates the convention and tells an agent nothing it can act on - and, worse, says nothing about
-  // what the check does NOT verify. The instruction is the one place the packet can be explicit that
-  // calling the helper is all that is checked, so an agent does not read a passing check as proof the
-  // route is protected.
-  if (convention.matcher.enforcement_semantics === "presence") {
-    const members = (convention.matcher.required_calls ?? []).join(", ");
-    const flavors = convention.matcher.applies_to_route_flavors ?? [];
-    const noun =
-      convention.kind === "api_route_requires_rate_limit"
-        ? "rate-limit helper"
-        : convention.kind === "api_route_requires_request_validation"
-          ? "request validator"
-          : "auth wrapper";
-    const scopeClause =
-      flavors.length > 0 && !flavors.includes("api_route")
-        ? ` This applies to ${flavors.join(" and ")} routes only.`
-        : flavors.length > 0
-          ? " This applies to application routes only, not cron or webhook routes."
-          : "";
-    return [
-      `When adding or editing an API route in scope, call one of the repo's accepted ${noun}s.`,
-      members ? `Accepted: ${members}.` : "",
-      scopeClause.trim(),
-      // Said plainly, because an agent that believes this proves protection will stop looking.
-      `Drift checks only that one of these is called - it does not verify that it guards the route's work.`
-    ].filter(Boolean).join(" ");
-  }
-
-  return `${convention.statement} Follow its scope, matcher, and exceptions.`;
 }
 
 export function conventionsForFiles(

--- a/packages/cli/src/domain/repo-map.ts
+++ b/packages/cli/src/domain/repo-map.ts
@@ -1,21 +1,15 @@
 import { authorizeContextExport,type FileRole,type PolicyDecision,type RepoContract } from "@drift/core";
 import {
-  buildCanonicalRouteReadModel,
-  buildFrameworkEntrypointReadModel,
-  buildParserGapQuality,
+  buildRepoMapPayload,
   buildRepoMapReadModel,
-  buildSecurityPhase8ReadModel,
   createGraphQueryService,
   fallbackFactRepoMapFiles,
   repoMapConventionIds,
   repoMapOpenFindingIds,
   repoMapRiskyAreaIds,
-  type CanonicalFactRouteInput,
-  type RepoMapFile,
-  repoMapFileForPayload
+  type RepoMapFile
 } from "@drift/query";
 import type { SqliteDriftStorage } from "@drift/storage";
-import { agentEnvelopeForScan } from "./agent-envelope.js";
 import { preflightGovernance } from "./governance.js";
 import { scanFingerprint } from "./identifiers.js";
 import { repoContractOrDefault } from "./repo-paths.js";
@@ -91,163 +85,28 @@ export function repoMapPayload(
   }
   const latestScan = latestIndexedScan(storage.listScanManifests(repoId));
   const snapshots = latestScan ? storage.listFileSnapshots(repoId, latestScan.id) : [];
-  const facts = latestScan ? storage.listFacts(latestScan.id) : [];
-  const findings = storage.listFindings(repoId);
-  const graphMap = latestScan ? createGraphQueryService(storage).repoMap({ repoId, scanId: latestScan.id }) : null;
-  const normalizedEntrypoints = latestScan
-    ? storage.listNormalizedEntrypoints(repoId, latestScan.id)
-    : [];
-  const frameworkParserGaps = latestScan
-    ? storage.listFrameworkParserGaps(repoId, latestScan.id)
-    : [];
-  const frameworkCapabilities = latestScan
-    ? storage.listFrameworkCapabilities(repoId, latestScan.id)
-    : [];
-  const frameworkEntryPoints = latestScan
-    ? buildFrameworkEntrypointReadModel({
-        repo_id: repoId,
-        scan_id: latestScan.id,
-        entrypoints: normalizedEntrypoints,
-        parser_gaps: frameworkParserGaps,
-        capabilities: frameworkCapabilities
-      })
-    : null;
-  const readModel = buildRepoMapReadModel({
-    repoId,
-    scanId: latestScan?.id ?? null,
-    graphFiles: graphMap?.files ?? [],
-    factFiles: fallbackFactRepoMapFiles(snapshots, facts),
-    contract,
-    findings,
-    filters: {
-      role: options.role,
-      path: options.path
-    },
-    limit: options.limit,
-    offset: options.offset ?? 0
-  });
-  const offset = options.offset ?? 0;
   const scanStatus = scanStatusPayload(storage, repoId);
   assertFreshScanIfRequired(repoId, scanStatus, Boolean(options.requireFresh));
   const allParserGaps = latestScan
     ? [...storage.listParserGaps(repoId, latestScan.id), ...storage.listParserGapV2(repoId, latestScan.id)]
     : [];
-  const readiness = readinessForStoredScan(storage, repoId, latestScan?.id ?? null, "repo_map", allParserGaps);
-  const proofRuns = latestScan
-    ? storage.listLatestSecurityBoundaryProofRunsForRepo({
-        repo_id: repoId,
-        file_path: options.path
-      })
-    : [];
-  const fallbackProofs = proofRuns.length === 0 && latestScan
-    ? storage.listSecurityBoundaryProofs(repoId, latestScan.id)
-        .filter((proof) => !options.path || proof.route.file_path === options.path)
-    : [];
-  const proofs = proofRuns.length > 0 ? proofRuns.map((run) => run.proof) : fallbackProofs;
-  const proofScanId = proofRuns[0]?.scan_id ?? (fallbackProofs.length > 0 ? latestScan?.id ?? null : null);
-  const canonicalRoutes = buildCanonicalRouteReadModel({
-    repo_id: repoId,
-    scan_id: latestScan?.id ?? null,
-    entrypoints: normalizedEntrypoints,
-    proofs: proofs.map((proof) => ({
-      proof_scan_id: proofScanId,
-      route_id: proof.route.route_id,
-      ...(proof.route.normalized_entrypoint_id ? { normalized_entrypoint_id: proof.route.normalized_entrypoint_id } : {}),
-      file_path: proof.route.file_path,
-      path: proof.route.endpoint?.path ?? null,
-      method: proof.route.endpoint?.method ?? proof.route.handler_symbol ?? null
-    })),
-    fallback_fact_routes: fallbackFactRoutes(readModel.all_files)
-  });
-  const canonicalKnownRoutes = canonicalRoutes.routes
-    .filter((route) => !options.path || route.file_path === options.path);
-  const phase8Security = buildSecurityPhase8ReadModel({
-    repo_id: repoId,
-    scan_id: latestScan?.id ?? null,
-    check_id: proofRuns[0]?.check_id ?? null,
-    proof_scan_id: proofScanId,
-    proofs,
-    findings: findings.map((finding) => ({
-      finding_id: finding.id,
-      title: finding.title,
-      lifecycle: finding.status
-    })),
-    accepted_conventions: contract.conventions,
-    changed_files: options.path ? [options.path] : undefined,
-    known_routes: canonicalKnownRoutes,
-    route_source_summary: canonicalRoutes.route_source_summary,
-    canonical_route_fallback: canonicalRoutes.fallback
-  });
-  return {
-    response_schema: "drift.repo.map.v1",
-    repo_id: repoId,
-    repo_root: repo.root_path,
-    generated_at: new Date().toISOString(),
-    agent_envelope: agentEnvelopeForScan({
-      surface: options.surface,
-      policy,
-      scanStatus,
-      requireFresh: Boolean(options.requireFresh),
-      // Same value the payload's `redactions` reports. The envelope builds its own redactions and
-      // defaulted this to false, so a paginated map claimed `safe_to_edit` in the envelope while
-      // `redactions.context_truncated` said true one key away.
-      contextTruncated: readModel.pagination.has_more
-    }),
+  // W6/D-A2: one derivation, shared with MCP. The CLI's copy of this assembly omitted
+  // `route_source_summary`, `canonical_route_fallback` and `proof_freshness` - all three already
+  // computed here, and all three dropped.
+  return buildRepoMapPayload({
+    storage,
+    repoId,
+    repo,
+    contract,
     policy,
-    readiness,
-    parser_gap_quality: buildParserGapQuality({
-      repo_id: repoId,
-      scan_id: latestScan?.id ?? null,
-      surface: "repo_map",
-      parser_gaps: allParserGaps,
-      readiness
-    }),
     governance: preflightGovernance(),
-    latest_scan: latestScan ?? null,
-    scan_fingerprint: latestScan ? scanFingerprint(latestScan, snapshots) : null,
-    scan_status: scanStatus,
-    filters: {
-      role: options.role ?? null,
-      path: options.path ?? null
-    },
-    summary: readModel.summary,
-    impact_summary: readModel.impact_summary,
-    topology: readModel.topology,
-    pagination: readModel.pagination,
-    routes: phase8Security.routes,
-    framework_entrypoints: frameworkEntryPoints,
-    freshness_requirement: freshnessRequirement(Boolean(options.requireFresh), scanStatus),
-    files: readModel.listed_files.map(repoMapFileForPayload),
-    redactions: {
-      denied_globs: contract.context_egress.denied_globs,
-      snippets_included: false,
-      source_content_included: false,
-      graph_context_included: Boolean(graphMap),
-      // Derived, not asserted: a paginated map is a subset, and `has_more` already says so. Claiming
-      // `false` here told the envelope to report `safe_to_edit` for a response that omits files.
-      context_truncated: readModel.pagination.has_more
-    },
-    next_commands: [
-      `drift prepare "task" --repo ${repoId} --json`,
-      `drift scan status --repo ${repoId} --json`
-    ]
-  };
+    scanStatus,
+    freshnessRequirement: freshnessRequirement(Boolean(options.requireFresh), scanStatus),
+    scanFingerprint: latestScan ? scanFingerprint(latestScan, snapshots) : null,
+    latestScan: latestScan ?? null,
+    readiness: readinessForStoredScan(storage, repoId, latestScan?.id ?? null, "repo_map", allParserGaps),
+    options
+  });
 }
 
 export type { RepoMapFile };
-
-function fallbackFactRoutes(files: RepoMapFile[]): CanonicalFactRouteInput[] {
-  return files
-    .filter((file) => file.roles.includes("api_route"))
-    .flatMap((file) => {
-      const methods = file.exported_symbols.filter((symbol) =>
-        ["GET", "POST", "PUT", "PATCH", "DELETE", "HEAD", "OPTIONS"].includes(symbol)
-      );
-      return (methods.length > 0 ? methods : ["unknown"]).map((method) => ({
-        route_id: `route:${file.path}:${method}`,
-        file_path: file.path,
-        method,
-        file_role: "api_route"
-      }));
-    });
-}

--- a/packages/cli/src/formatters/checks-run.ts
+++ b/packages/cli/src/formatters/checks-run.ts
@@ -1,0 +1,55 @@
+import type { RequiredCheckExecution } from "@drift/core";
+
+/**
+ * W4/D-CL2: `drift checks run` had no human path.
+ *
+ * Without `--json`, `formatOutput` falls through to compact single-line JSON, so the result of
+ * running a required check - the thing whose exit code gates a merge - arrived as an unreadable
+ * blob containing a full execution proof.
+ */
+export function formatChecksRunText(payload: {
+  repo_id: string;
+  execution: RequiredCheckExecution;
+  summary: {
+    command: string;
+    status: string;
+    passed: boolean;
+    exit_code: number | null;
+    timed_out: boolean;
+    worktree_dirty: boolean;
+    diff_hash: string;
+    contract_fingerprint: string;
+  };
+}): string {
+  const { summary } = payload;
+  return [
+    `Required check ${summary.passed ? "PASSED" : "FAILED"}`,
+    "",
+    `Repo: ${payload.repo_id}`,
+    `Command: ${summary.command}`,
+    `Status: ${summary.status}`,
+    // `exit_code` is null exactly when the process never exited, so printing the raw value would
+    // put the word "null" where a number belongs and say nothing about why.
+    summary.exit_code === null
+      ? "Exit code: none - the command did not exit"
+      : `Exit code: ${summary.exit_code}`,
+    // Distinguished from a plain failure: a timeout says nothing about the code under test, and a
+    // reader who cannot tell them apart will act on a verdict that was never reached.
+    ...(summary.timed_out ? ["Timed out: yes - no verdict was reached"] : []),
+    "",
+    `Execution: ${payload.execution.execution_id}`,
+    `Contract fingerprint: ${summary.contract_fingerprint}`,
+    `Diff hash: ${summary.diff_hash}`,
+    // The proof is only about the tree that was measured, so a dirty worktree is a caveat on the
+    // result rather than a detail about the environment.
+    ...(summary.worktree_dirty
+      ? ["Worktree: DIRTY - this proof describes uncommitted state"]
+      : ["Worktree: clean"]),
+    "",
+    "Next commands:",
+    `  drift checks run --repo ${payload.repo_id} --json`,
+    `  drift audit verify --repo ${payload.repo_id}`,
+    "",
+    ""
+  ].join("\n");
+}

--- a/packages/cli/src/formatters/convention-mutations.ts
+++ b/packages/cli/src/formatters/convention-mutations.ts
@@ -1,0 +1,67 @@
+import type { AcceptedConvention, ConventionCandidate } from "@drift/core";
+
+/**
+ * W4/D-CL2: the four convention-mutation commands had no human path.
+ *
+ * `conventions accept`, `reject`, `edit` and `exception add` are the governance surface - the
+ * point where a human decides what Drift will enforce - and without `--json` each emitted compact
+ * single-line JSON. One formatter rather than four because the payloads share a shape (a subject,
+ * whether anything changed, whether this was a dry run, and what to run next); four near-identical
+ * formatters is how the CLI/MCP copies started.
+ */
+export function formatConventionMutationText(
+  action: "accepted" | "rejected" | "edited" | "exception added",
+  payload: {
+    /**
+     * The subject appears under three different keys across the four commands - `accepted` (the
+     * materialized convention), `convention` (exception add), `candidate` (reject/edit) - which
+     * is itself a small instance of what D-CL2 is about: four payloads that were never rendered
+     * for a human and so were never made to agree.
+     */
+    accepted?: AcceptedConvention;
+    candidate?: ConventionCandidate;
+    convention?: AcceptedConvention;
+    changed?: boolean;
+    changed_fields?: string[];
+    dry_run?: boolean;
+    write_intent?: boolean;
+    next_commands?: string[];
+  }
+): string {
+  const acceptedConvention = payload.accepted ?? payload.convention;
+  const subject = payload.candidate ?? acceptedConvention;
+  const dryRun = payload.dry_run === true;
+  // A dry run that says "accepted" is the D-CL2 failure mode in words rather than in JSON: the
+  // headline has to carry whether anything was written.
+  const headline = dryRun
+    ? `Convention would be ${action} (dry run - nothing written)`
+    : payload.changed === false
+      ? `Convention already ${action} - no change`
+      : `Convention ${action}`;
+
+  return [
+    headline,
+    "",
+    ...(subject ? [`Id: ${subject.id}`, `Kind: ${subject.kind}`] : []),
+    ...(payload.candidate
+      ? [`Repo: ${payload.candidate.repo_id}`, `Status: ${payload.candidate.status}`]
+      : []),
+    ...(acceptedConvention
+      ? [
+          `Severity: ${acceptedConvention.severity}`,
+          `Enforcement: ${acceptedConvention.enforcement_mode} (${acceptedConvention.enforcement_capability})`,
+          `Exceptions: ${acceptedConvention.exceptions.length}`
+        ]
+      : []),
+    ...(payload.changed_fields && payload.changed_fields.length > 0
+      ? ["", `Changed fields: ${payload.changed_fields.join(", ")}`]
+      : []),
+    ...(subject ? ["", `Statement: ${subject.statement}`] : []),
+    "",
+    ...(payload.next_commands && payload.next_commands.length > 0
+      ? ["Next commands:", ...payload.next_commands.map((command) => `  ${command}`)]
+      : []),
+    "",
+    ""
+  ].join("\n");
+}

--- a/packages/cli/src/formatters/scan.ts
+++ b/packages/cli/src/formatters/scan.ts
@@ -1,0 +1,46 @@
+import type { runScanRepo } from "../domain/scan-status.js";
+
+/**
+ * W4/D-CL2: `drift scan` had no human path at all.
+ *
+ * `formatOutput` prints a string as-is, pretty JSON under `--json`, and otherwise compact
+ * single-line JSON - so a command with no text branch emitted a one-line JSON blob to a terminal.
+ * Every other command family has a `formatXText`; `scan` is the first thing a new user runs.
+ */
+export function formatScanText(payload: Awaited<ReturnType<typeof runScanRepo>>): string {
+  const { summary } = payload;
+  const changes = summary.incremental_changes;
+  return [
+    "Drift scan complete",
+    "",
+    `Repo: ${payload.repo.id}`,
+    `Root: ${payload.repo.root_path}`,
+    `Scan: ${payload.scan.id} (${payload.scan.status})`,
+    `Engine: ${summary.engine_source}`,
+    "",
+    `Files indexed: ${summary.files_indexed}`,
+    `Files skipped: ${summary.files_skipped}`,
+    `Facts: ${summary.facts_count}`,
+    // Named rather than summed into "issues": a diagnostic is something the scan could not read,
+    // and a reader who cannot see the count cannot know the scan was partial.
+    `Diagnostics: ${summary.diagnostics_count}`,
+    `Candidates: ${summary.candidates_count}`,
+    "",
+    `Changes since last scan: ${changes.added} added, ${changes.modified} modified, ${changes.deleted} deleted`,
+    `Mode: ${summary.incremental_plan.execution_mode}` +
+      (summary.incremental_plan.reuse_applied
+        ? ` (reused ${summary.incremental_plan.reusable_file_count}, reparsed ${summary.incremental_plan.changed_file_count})`
+        : ""),
+    // Why a full rescan happened, when one did. A silent "full_scan" reads as a choice rather
+    // than as reuse being blocked, and the reasons are the actionable half.
+    ...(summary.incremental_plan.blocked_reasons.length > 0
+      ? [`Reuse blocked: ${summary.incremental_plan.blocked_reasons.join(", ")}`]
+      : []),
+    "",
+    "Next commands:",
+    `  drift conventions list --repo ${payload.repo.id}`,
+    `  drift scan status --repo ${payload.repo.id}`,
+    "",
+    ""
+  ].join("\n");
+}

--- a/packages/cli/test/cli.test.ts
+++ b/packages/cli/test/cli.test.ts
@@ -10923,6 +10923,31 @@ schema_version: MIGRATIONS.length,
     expect(unsafe.stderr).toContain("--path must be repo-relative.");
   });
 
+  it("repo map carries the route-trust fields alongside the routes", async () => {
+    // W6/D-A2. `routes` says what the routes are; these three say how much to trust that list -
+    // where each route came from, whether the canonical list fell back, and whether the proofs
+    // behind it are from this scan. All three were computed inside the CLI's copy of this
+    // payload, off the same phase-8 read model it takes `routes` from, and then dropped, while
+    // MCP emitted them under the same `response_schema`. So two documents both claiming
+    // drift.repo.map.v1 disagreed about which keys that schema has.
+    const { databasePath, repoId } = await seedStartedDoctorState("drift-repo-map-trust-fields-");
+
+    const mapped = await runCli(["--db", databasePath, "repo", "map", "--repo", repoId, "--json"]);
+    const payload = JSON.parse(mapped.stdout);
+
+    expect(mapped.exitCode).toBe(0);
+    // Presence, not value: absence is the defect, and a null here would still be an answer.
+    expect(Object.keys(payload)).toEqual(
+      expect.arrayContaining(["route_source_summary", "canonical_route_fallback", "proof_freshness"])
+    );
+    expect(payload.route_source_summary).toMatchObject({
+      normalized_entrypoint: expect.any(Number),
+      security_proof: expect.any(Number),
+      legacy_fact_fallback: expect.any(Number)
+    });
+    expect(payload.canonical_route_fallback).toMatchObject({ used: expect.any(Boolean) });
+  });
+
   it("fails repo map when fresh scan context is required but the graph is stale", async () => {
     const { databasePath } = await seedAcceptedDatabase();
 

--- a/packages/cli/test/cli.test.ts
+++ b/packages/cli/test/cli.test.ts
@@ -13433,6 +13433,59 @@ schema_version: MIGRATIONS.length,
     expect(result.stderr).toContain("Unknown repo repo_missing");
   });
 
+  it("renders every mutating command for a human without --json", async () => {
+    // W4/D-CL2. `formatOutput` prints a string as-is, pretty JSON under `--json`, and otherwise
+    // COMPACT SINGLE-LINE JSON - so a command with no text branch emitted a one-line blob to a
+    // terminal. Six commands had no branch: scan, checks run, and the four convention mutations.
+    //
+    // No existing test caught it because every existing test for these six passes `--json`. The
+    // human path was untested precisely because it did not exist.
+    const databasePath = await seedDatabase();
+
+    const accepted = await runCli([
+      "--db", databasePath,
+      "conventions", "accept",
+      "candidate_no_direct_db",
+      "--confirm",
+      "--severity", "warning",
+      "--mode", "warn",
+      "--actor", "geoff",
+      "--now", "2026-05-10T00:00:10.000Z"
+    ]);
+
+    expect(accepted.exitCode).toBe(0);
+    // The load-bearing assertion is the negative one: not JSON. A human-readable rendering is
+    // allowed to change wording, but it may never go back to being a serialized object.
+    expect(accepted.stdout.trimStart().startsWith("{")).toBe(false);
+    expect(accepted.stdout).toContain("Convention accepted");
+    expect(accepted.stdout).toContain("convention_no_direct_db");
+    // The mode a human just chose has to be visible in what they are shown.
+    expect(accepted.stdout).toContain("warn");
+  });
+
+  it("says nothing was written when a mutation is a dry run", async () => {
+    // D-CL2's sharpest case: without --confirm these commands write nothing, and a headline
+    // reading "Convention accepted" over an unwritten change is worse than the JSON blob was.
+    const databasePath = await seedDatabase();
+
+    const dryRun = await runCli([
+      "--db", databasePath,
+      "conventions", "accept",
+      "candidate_no_direct_db",
+      "--dry-run",
+      "--severity", "warning",
+      "--mode", "warn",
+      "--now", "2026-05-10T00:00:10.000Z"
+    ]);
+
+    expect(dryRun.exitCode).toBe(0);
+    expect(dryRun.stdout.trimStart().startsWith("{")).toBe(false);
+    expect(dryRun.stdout).toContain("dry run");
+    expect(dryRun.stdout).toContain("nothing written");
+    // And it must NOT read as though the write happened.
+    expect(dryRun.stdout).not.toContain("Convention accepted\n");
+  });
+
   it("accepts a candidate, materializes a repo contract, and audits the action", async () => {
     const databasePath = await seedDatabase();
 

--- a/packages/cli/test/command-shape-parity.test.ts
+++ b/packages/cli/test/command-shape-parity.test.ts
@@ -1,0 +1,138 @@
+import { readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+import { describe, expect, it } from "vitest";
+
+import { unknownCommandError, validateCommandShape } from "../src/args/command-shape.js";
+import type { ParsedArgs } from "../src/app/command-types.js";
+
+/**
+ * W4/D-CL3: the CLI's command surface is enumerated three times and nothing compared the lists.
+ *
+ * `router.ts` decides what a command DOES. `unknownCommandError` decides whether it EXISTS.
+ * `validateCommandShape` decides how many positionals it may carry. All three are hand-written
+ * `group === "x" && command === "y"` chains, and they can disagree in two directions, both of
+ * which are silent:
+ *
+ *   - the router handles a command `unknownCommandError` rejects, so a working command is
+ *     unreachable and reports "Unknown command";
+ *   - `unknownCommandError` accepts a command the router does not handle, so it falls through
+ *     to whatever the final branch does instead of saying it does not exist.
+ *
+ * Cross-checked by reading the router's own source for the pairs it routes, rather than by
+ * restating them here - a fourth hand-maintained list would be the same defect with one more
+ * copy of it.
+ */
+
+const ROUTER_SOURCE = readFileSync(
+  fileURLToPath(new URL("../src/app/router.ts", import.meta.url)),
+  "utf8"
+);
+const SHAPE_SOURCE = readFileSync(
+  fileURLToPath(new URL("../src/args/command-shape.ts", import.meta.url)),
+  "utf8"
+);
+/**
+ * The FOURTH enumeration, which the audit named three of. `doctor`, `capabilities` and `restore`
+ * are dispatched in run-cli.ts BEFORE the router is reached, on `parsed.positional[0]`, so the
+ * router legitimately never branches on them. Found by this test failing on all three.
+ */
+const RUN_CLI_SOURCE = readFileSync(
+  fileURLToPath(new URL("../src/app/run-cli.ts", import.meta.url)),
+  "utf8"
+);
+
+function parsedFor(positional: string[]): ParsedArgs {
+  return { positional, flags: new Map() };
+}
+
+/**
+ * Every command the router branches on, as the positionals that reach it.
+ *
+ * Four of them are three-level (`policy agent grant`, `conventions exception add`,
+ * `contract waiver show`, `contract waivers list`), and their branch tests `maybeId` in the same
+ * condition. Probing those with two positionals reports a disagreement that is not one - the
+ * first version of this test did exactly that and named all four - so the third level is read
+ * out of the branch rather than assumed absent.
+ */
+function routedCommands(): Array<{ label: string; positional: string[] }> {
+  const commands = new Map<string, { label: string; positional: string[] }>();
+  const pattern =
+    /group === "([a-z-]+)"\s*&&\s*command === "([a-z-]+)"(?:[^\n]*?maybeId === "([a-z-]+)")?/g;
+  for (const [, group, command, maybeId] of ROUTER_SOURCE.matchAll(pattern)) {
+    const positional = maybeId ? [group, command, maybeId] : [group, command];
+    const label = positional.join(" ");
+    // A pair reached by several branches keeps the most specific one seen.
+    if (!commands.has(label)) {
+      commands.set(label, { label, positional });
+    }
+  }
+  return [...commands.values()];
+}
+
+/** Every group dispatched anywhere: the router's branches plus run-cli.ts's pre-router ones. */
+function routedGroups(): string[] {
+  return [
+    ...new Set([
+      ...[...ROUTER_SOURCE.matchAll(/group === "([a-z-]+)"/g)].map((match) => match[1]),
+      ...[...RUN_CLI_SOURCE.matchAll(/parsed\.positional\[0\] === "([a-z-]+)"/g)].map((match) => match[1])
+    ])
+  ];
+}
+
+describe("command surface parity", () => {
+  it("reads the router's own branches rather than a restated list", () => {
+    // Liveness, the BB-8 shape: if the regex stops matching - because the router is rewritten
+    // into a table, say - every assertion below passes vacuously and this gate reports success
+    // forever. Fail instead, so the gate is rewritten with the thing it reads.
+    expect(routedGroups().length).toBeGreaterThan(8);
+    expect(
+      [...RUN_CLI_SOURCE.matchAll(/parsed\.positional\[0\] === "([a-z-]+)"/g)].length,
+      "run-cli.ts pre-router dispatch no longer parses"
+    ).toBeGreaterThan(2);
+    expect(routedCommands().length).toBeGreaterThan(15);
+  });
+
+  it("recognizes every command the router routes", () => {
+    // Direction one: a command that works but reports "Unknown command".
+    const unrecognized = routedCommands().filter(
+      ({ positional }) => unknownCommandError(parsedFor(positional)) !== null
+    );
+    expect(
+      unrecognized.map(({ label }) => label),
+      "router routes these, unknownCommandError rejects them"
+    ).toEqual([]);
+  });
+
+  it("accepts the positional arity of every command the router routes", () => {
+    // Direction two: `validateCommandShape` rejecting the exact shape the router is built to
+    // receive. An arity rule stricter than the router's branch makes a routed command
+    // unreachable, and the error names an argument rather than the disagreement.
+    const rejected: string[] = [];
+    for (const { label, positional } of routedCommands()) {
+      try {
+        validateCommandShape(parsedFor(positional));
+      } catch (error) {
+        rejected.push(`${label}: ${(error as Error).message}`);
+      }
+    }
+    expect(rejected, "router routes these, validateCommandShape rejects their base shape").toEqual([]);
+  });
+
+  it("routes every group command-shape.ts claims to recognize", () => {
+    // The reverse direction: a group `unknownCommandError` accepts but the router never branches
+    // on falls through to the final branch instead of reporting that it does not exist.
+    //
+    // Read from command-shape.ts, NOT from the router. The first version of this test took both
+    // sides from ROUTER_SOURCE and so compared the file to itself - it passed for the same reason
+    // it could never fail.
+    const routed = new Set(routedGroups());
+    const claimed = [
+      ...new Set([...SHAPE_SOURCE.matchAll(/group === "([a-z-]+)"/g)].map((match) => match[1]))
+    ];
+    expect(claimed.length, "command-shape.ts source no longer parses").toBeGreaterThan(8);
+    expect(
+      claimed.filter((group) => !routed.has(group)),
+      "command-shape.ts recognizes these groups, the router never routes them"
+    ).toEqual([]);
+  });
+});

--- a/packages/core/src/failure-classification.ts
+++ b/packages/core/src/failure-classification.ts
@@ -214,3 +214,36 @@ function extractRecoveryCommands(message: string, fallback: string[]): string[] 
   const match = message.match(/Run (drift [^;]+);/);
   return match?.[1] ? [match[1]] : fallback;
 }
+
+/**
+ * An error that states its own classification, without needing a shared class identity.
+ *
+ * W4/D-E7. `isSelfClassifiedError` above is deliberately structural so that "no package has to
+ * share a class identity across build boundaries" - but only the CLI ever had a constructor for
+ * the shape, so MCP kept throwing plain `Error`s and relied on `classifyFailureMessage` matching
+ * their prose. Two of its throw sites land on codes the CLI migrated away from prose-matching in
+ * W3: `Scan is stale for ...` -> `stale_scan` and `No repo contract exists for ...` ->
+ * `missing_contract`.
+ *
+ * Those matched, so nothing was broken. What was true is that MCP's classification depended on
+ * the first four words of two sentences, and since W3 the exit code follows the failure code - so
+ * rewording either sentence would have silently demoted a refusal to the catch-all. The CLI has
+ * not been able to do that since W3; this is the same protection for the other surface.
+ *
+ * Returns a real `Error` (so stacks and `instanceof Error` still work) with the classification
+ * attached, which is exactly what `isSelfClassifiedError` looks for.
+ */
+export function selfClassifiedError(input: {
+  message: string;
+  code: string;
+  userAction: string;
+  recoveryCommands?: string[];
+  safeToRetry?: boolean;
+}): Error {
+  return Object.assign(new Error(input.message), {
+    code: input.code,
+    userAction: input.userAction,
+    recoveryCommands: input.recoveryCommands ?? [],
+    safeToRetry: input.safeToRetry ?? true
+  });
+}

--- a/packages/mcp/src/index.ts
+++ b/packages/mcp/src/index.ts
@@ -88,7 +88,12 @@ import {
   rankRelevantFiles,
   relevantFilesForTask,
   repoMapFileForPayload,
-  walkIndexableFiles,buildParserGapSection,withParserGapRecordsOmitted} from "@drift/query";
+  walkIndexableFiles,buildParserGapSection,withParserGapRecordsOmitted,
+  // W6: derivations shared with the CLI rather than copied. MCP's private `preparedConvention`
+  // carried D-A1 and had never received CV-5's presence branch, and its `repoMapPayload` was the
+  // only one emitting the three route-trust fields - see query/src/prepared-convention.ts and
+  // query/src/repo-map-payload.ts.
+  agentEnvelopeForScan,buildRepoMapPayload,instructionForConvention,preparedConvention} from "@drift/query";
 import { MIGRATIONS, openDriftStorage } from "@drift/storage";
 import { execFileSync } from "node:child_process";
 import { createHash } from "node:crypto";
@@ -349,7 +354,10 @@ export function createReadOnlyMcpHandlers(options: DriftMcpOptions): DriftMcpHan
         }, new Map<string, string[]>())
       });
       const preflightConventions = activeConventions.map((convention) =>
-        preflightConvention(convention, preflightExemplars)
+        // W6/D-A1: `requestedPath` is passed, which the private copy never did. It is the same
+        // `path` this handler already uses to rank relevant files and reports as `target_path`;
+        // without it, a task naming a conforming file got that file back as an example of itself.
+        preparedConvention(convention, preflightExemplars, { targetPath: requestedPath ?? undefined })
       );
       const guidance = buildGuidanceView({
         repoId: requestedRepoId,
@@ -396,7 +404,7 @@ export function createReadOnlyMcpHandlers(options: DriftMcpOptions): DriftMcpHan
         task: requestedTask,
         target_path: requestedPath ?? null,
         generated_at: generatedAt,
-        agent_envelope: mcpAgentEnvelope({
+        agent_envelope: agentEnvelopeForScan({
           surface: "cli-preflight",
           policy,
           scanStatus,
@@ -532,7 +540,7 @@ export function createReadOnlyMcpHandlers(options: DriftMcpOptions): DriftMcpHan
       return {
         response_schema: "drift.findings.list.v1",
         repo_id: requestedRepoId,
-        agent_envelope: mcpAgentEnvelope({
+        agent_envelope: agentEnvelopeForScan({
           surface: "cli-check",
           policy,
           scanStatus,
@@ -1632,162 +1640,30 @@ function repoMapPayload(
   const { contract, policy } = authorizedMcpContractOrDefault(storage, repoId, options.surface);
   const latestScan = latestIndexedScan(storage.listScanManifests(repoId));
   const snapshots = latestScan ? storage.listFileSnapshots(repoId, latestScan.id) : [];
-  const facts = latestScan ? storage.listFacts(latestScan.id) : [];
-  const findings = storage.listFindings(repoId);
-  const graphMap = latestScan ? createGraphQueryService(storage).repoMap({ repoId, scanId: latestScan.id }) : null;
-  const normalizedEntrypoints = latestScan
-    ? storage.listNormalizedEntrypoints(repoId, latestScan.id)
-    : [];
-  const frameworkParserGaps = latestScan
-    ? storage.listFrameworkParserGaps(repoId, latestScan.id)
-    : [];
-  const frameworkCapabilities = latestScan
-    ? storage.listFrameworkCapabilities(repoId, latestScan.id)
-    : [];
-  const frameworkEntryPoints = latestScan
-    ? buildFrameworkEntrypointReadModel({
-        repo_id: repoId,
-        scan_id: latestScan.id,
-        entrypoints: normalizedEntrypoints,
-        parser_gaps: frameworkParserGaps,
-        capabilities: frameworkCapabilities
-      })
-    : null;
-  const offset = options.offset ?? 0;
-  const readModel = buildRepoMapReadModel({
-    repoId,
-    scanId: latestScan?.id ?? null,
-    graphFiles: graphMap?.files ?? [],
-    factFiles: fallbackFactRepoMapFiles(snapshots, facts),
-    contract,
-    findings,
-    filters: {
-      role: options.role,
-      path: options.path
-    },
-    limit: options.limit,
-    offset
-  });
   const scanStatus = scanStatusPayload(storage, repoId);
   assertFreshScanIfRequired(repoId, scanStatus, Boolean(options.requireFresh));
   const allParserGaps = latestScan
     ? [...storage.listParserGaps(repoId, latestScan.id), ...storage.listParserGapV2(repoId, latestScan.id)]
     : [];
-  const readiness = readinessForStoredScan(storage, repoId, latestScan?.id ?? null, "repo_map", allParserGaps);
-  const proofRuns = latestScan
-    ? storage.listLatestSecurityBoundaryProofRunsForRepo({
-        repo_id: repoId,
-        file_path: options.path
-      })
-    : [];
-  const fallbackProofs = proofRuns.length === 0 && latestScan
-    ? storage.listSecurityBoundaryProofs(repoId, latestScan.id)
-        .filter((proof) => !options.path || proof.route.file_path === options.path)
-    : [];
-  const proofs = proofRuns.length > 0 ? proofRuns.map((run) => run.proof) : fallbackProofs;
-  const proofScanId = proofRuns[0]?.scan_id ?? (fallbackProofs.length > 0 ? latestScan?.id ?? null : null);
-  const canonicalRoutes = buildCanonicalRouteReadModel({
-    repo_id: repoId,
-    scan_id: latestScan?.id ?? null,
-    entrypoints: normalizedEntrypoints,
-    proofs: proofs.map((proof) => ({
-      proof_scan_id: proofScanId,
-      route_id: proof.route.route_id,
-      ...(proof.route.normalized_entrypoint_id ? { normalized_entrypoint_id: proof.route.normalized_entrypoint_id } : {}),
-      file_path: proof.route.file_path,
-      path: proof.route.endpoint?.path ?? null,
-      method: proof.route.endpoint?.method ?? proof.route.handler_symbol ?? null
-    })),
-    fallback_fact_routes: fallbackFactRoutes(readModel.all_files)
-  });
-  const phase8Security = buildSecurityPhase8ReadModel({
-    repo_id: repoId,
-    scan_id: latestScan?.id ?? null,
-    check_id: proofRuns[0]?.check_id ?? null,
-    proof_scan_id: proofScanId,
-    proofs,
-    findings: findings.map((finding) => ({
-      finding_id: finding.id,
-      title: finding.title,
-      lifecycle: finding.status
-    })),
-    accepted_conventions: contract.conventions,
-    changed_files: options.path ? [options.path] : undefined,
-    known_routes: canonicalRoutes.routes.filter((route) => !options.path || route.file_path === options.path),
-    route_source_summary: canonicalRoutes.route_source_summary,
-    canonical_route_fallback: canonicalRoutes.fallback
-  });
-  return {
-    response_schema: "drift.repo.map.v1",
-    repo_id: repoId,
-    repo_root: repo.root_path,
-    generated_at: new Date().toISOString(),
-    agent_envelope: mcpAgentEnvelope({
-      surface: options.surface,
-      policy,
-      scanStatus,
-      requireFresh: Boolean(options.requireFresh),
-      // Same value the payload's `redactions` reports - see the CLI repo-map payload.
-      contextTruncated: readModel.pagination.has_more
-    }),
+  // W6/D-A2: one derivation, shared with the CLI. This surface was the one emitting the three
+  // trust fields; the CLI computed and discarded them. See query/src/repo-map-payload.ts.
+  return buildRepoMapPayload({
+    storage,
+    repoId,
+    repo,
+    contract,
     policy,
-    readiness,
-    parser_gap_quality: buildParserGapQuality({
-      repo_id: repoId,
-      scan_id: latestScan?.id ?? null,
-      surface: "repo_map",
-      parser_gaps: allParserGaps,
-      readiness
-    }),
     governance: preflightGovernance(),
-    latest_scan: latestScan ?? null,
-    scan_fingerprint: latestScan ? scanFingerprint(latestScan, snapshots) : null,
-    scan_status: scanStatus,
-    filters: {
-      role: options.role ?? null,
-      path: options.path ?? null
-    },
-    summary: readModel.summary,
-    impact_summary: readModel.impact_summary,
-    topology: readModel.topology,
-    pagination: readModel.pagination,
-    routes: phase8Security.routes,
-    route_source_summary: phase8Security.route_source_summary,
-    canonical_route_fallback: phase8Security.canonical_route_fallback,
-    proof_freshness: phase8Security.proof_freshness,
-    framework_entrypoints: frameworkEntryPoints,
-    freshness_requirement: freshnessRequirement(Boolean(options.requireFresh), scanStatus),
-    files: readModel.listed_files.map(repoMapFileForPayload),
-    redactions: {
-      denied_globs: contract.context_egress.denied_globs,
-      snippets_included: false,
-      source_content_included: false,
-      graph_context_included: Boolean(graphMap),
-      // Derived, not asserted - see the CLI repo-map payload for the same reasoning.
-      context_truncated: readModel.pagination.has_more
-    },
-    next_commands: [
-      `drift prepare "task" --repo ${repoId} --json`,
-      `drift scan status --repo ${repoId} --json`
-    ]
-  };
+    scanStatus,
+    freshnessRequirement: freshnessRequirement(Boolean(options.requireFresh), scanStatus),
+    scanFingerprint: latestScan ? scanFingerprint(latestScan, snapshots) : null,
+    latestScan: latestScan ?? null,
+    readiness: readinessForStoredScan(storage, repoId, latestScan?.id ?? null, "repo_map", allParserGaps),
+    options
+  });
 }
 
-function fallbackFactRoutes(files: RepoMapFile[]): CanonicalFactRouteInput[] {
-  return files
-    .filter((file) => file.roles.includes("api_route"))
-    .flatMap((file) => {
-      const methods = file.exported_symbols.filter((symbol) =>
-        ["GET", "POST", "PUT", "PATCH", "DELETE", "HEAD", "OPTIONS"].includes(symbol)
-      );
-      return (methods.length > 0 ? methods : ["unknown"]).map((method) => ({
-        route_id: `route:${file.path}:${method}`,
-        file_path: file.path,
-        method,
-        file_role: "api_route"
-      }));
-    });
-}
+
 
 function orderAcceptedConventionsForReview(conventions: AcceptedConvention[]): AcceptedConvention[] {
   return [...conventions].sort((left, right) =>
@@ -2038,9 +1914,7 @@ function isResolverInputPath(filePath: string): boolean {
 
 
 
-function isTypescriptPath(filePath: string): boolean {
-  return /\.[cm]?[jt]sx?$/.test(filePath);
-}
+
 
 function fileContentHash(absolutePath: string): string {
   return createHash("sha256").update(readFileSync(absolutePath)).digest("hex");
@@ -2502,81 +2376,7 @@ function prepareFinding(finding: Finding): {
   };
 }
 
-function preflightConvention(
-  convention: AcceptedConvention,
-  // BB-5/BB-6: same optional context, same shared derivation, as the CLI's preparedConvention. The
-  // parity gate compares these entries across surfaces, so a field present on one and absent on the
-  // other is a failure rather than a cosmetic difference.
-  context?: ExemplarContext
-): {
-  id: string;
-  kind: AcceptedConvention["kind"];
-  statement: string;
-  severity: Severity;
-  enforcement_mode: AcceptedConvention["enforcement_mode"];
-  enforcement_capability: AcceptedConvention["enforcement_capability"];
-  scope: AcceptedConvention["scope"];
-  matcher: AcceptedConvention["matcher"];
-  exceptions: AcceptedConvention["exceptions"];
-  agent_instruction: string;
-  conforming_examples: Array<{ file_path: string; role: string | null }>;
-  conforming_examples_reason: string | null;
-  rationale: { derivation: string; reason: string | null };
-  migration_sentence: string | null;
-} {
-  const exemplars = conformingExemplars({
-    scopeFiles: context?.scopeFilesFor(convention) ?? [],
-    // CV-5: any accepted convention, not just this one. The MCP packet and the CLI packet must not
-    // disagree about what conforms, which is the EW-6 parity shape.
-    violatingFiles: context?.violatingFilesAnyConvention() ?? [],
-    roleByFile: context?.roleByFile,
-    // Proven, not presumed - and this surface needs it most: get_task_preflight never runs a check,
-    // so an absent finding here means only that nothing has ever looked.
-    forbiddenImports: convention.matcher?.forbidden_imports ?? [],
-    importsByFile: context?.importsByFile
-  });
-  return {
-    id: convention.id,
-    kind: convention.kind,
-    statement: convention.statement,
-    severity: convention.severity,
-    enforcement_mode: convention.enforcement_mode,
-    enforcement_capability: convention.enforcement_capability,
-    scope: convention.scope,
-    matcher: convention.matcher,
-    exceptions: convention.exceptions,
-    agent_instruction: instructionForConvention(convention),
-    conforming_examples: exemplars.conforming_examples,
-    conforming_examples_reason: exemplars.reason,
-    rationale: conventionRationale({
-      kind: convention.kind,
-      derivation: convention.rationale ?? convention.statement
-    }),
-    migration_sentence: migrationSentence(context?.baselineActiveCountFor(convention.id) ?? 0)
-  };
-}
 
-function instructionForConvention(convention: AcceptedConvention): string {
-  if (convention.kind === "api_route_no_direct_data_access") {
-    const forbidden = (convention.matcher.forbidden_imports ?? []).join(", ");
-    return [
-      "When editing API route files, do not import data-access clients directly.",
-      forbidden ? `Forbidden imports: ${forbidden}.` : "",
-      "Delegate through the repo's accepted service/data-access layer and run drift check before finishing."
-    ].filter(Boolean).join(" ");
-  }
-
-  if (convention.kind === "api_route_requires_service_delegation") {
-    const delegates = (convention.matcher.allowed_delegate_imports ?? []).join(", ");
-    return [
-      "When editing API route files, keep route modules thin and delegate business/data-access work to the service layer.",
-      delegates ? `Observed delegate imports: ${delegates}.` : "",
-      "Treat this as briefing guidance unless the repo later upgrades it to a deterministic check."
-    ].filter(Boolean).join(" ");
-  }
-
-  return `${convention.statement} Follow its scope, matcher, and exceptions.`;
-}
 
 
 function countDeniedFiles(repoRoot: string, deniedGlobs: string[]): number {
@@ -2588,29 +2388,6 @@ function countDeniedFiles(repoRoot: string, deniedGlobs: string[]): number {
   ).length;
 }
 
-function mcpAgentEnvelope(input: {
-  surface: PolicyDecision["surface"];
-  policy: Pick<PolicyDecision, "allowed" | "surface" | "reason">;
-  scanStatus: ReturnType<typeof scanStatusPayload>;
-  requireFresh: boolean;
-  diagnostics?: string[];
-  contextTruncated?: boolean;
-}) {
-  return createAgentEnvelopeV2({
-    surface: input.surface,
-    policy: input.policy,
-    scan: {
-      required_fresh: input.requireFresh,
-      stale: input.scanStatus.stale,
-      latest_scan_id: input.scanStatus.latest_scan?.id ?? null
-    },
-    redactions: {
-      snippets_included: false,
-      context_truncated: Boolean(input.contextTruncated)
-    },
-    diagnostics: input.diagnostics
-  });
-}
 
 function isApiRoutePath(filePath: string): boolean {
   return isNextApiRoutePath(filePath);

--- a/packages/mcp/src/index.ts
+++ b/packages/mcp/src/index.ts
@@ -33,6 +33,7 @@ import {
   migrationSentence,
   canonicalScanStateJson,
   classifyFailure,
+  selfClassifiedError,
   createAgentEnvelopeV2,
   createAgentPreflightPacket,
   createContextPolicyMatrix,
@@ -265,7 +266,8 @@ export function createReadOnlyMcpHandlers(options: DriftMcpOptions): DriftMcpHan
         test_files: testFiles
       });
       const testSelection = selectRelevantTests({
-        changed_file: relevantFiles[0]?.path ?? requestedPath ?? "",
+        // D-A3(a): every relevant file, not just the head of the ranked list.
+        changed_files: relevantFiles.map((file) => file.path),
         route_flow: changeImpactRouteFlows[0],
         test_files: testFiles
       });
@@ -448,9 +450,9 @@ export function createReadOnlyMcpHandlers(options: DriftMcpOptions): DriftMcpHan
         task_preflight_packet: taskPreflightPacket,
         change_impact: changeImpact,
         test_intelligence: testSelection.test_intelligence,
-        test_intelligence_reason: testSelection.test_intelligence.length === 0
-          ? "not_implemented_for_repo"
-          : null,
+        // D-A3(c): derived once, in selectRelevantTests. See the CLI's prepare for the two
+        // questions the old inline ternary gave the same answer to.
+        test_intelligence_reason: testSelection.test_intelligence_reason,
         agent_contract_packet: agentContractPacket,
         baseline,
         findings,
@@ -1093,7 +1095,17 @@ function validateMcpToolArguments(name: keyof DriftMcpHandlers, args: Record<str
 
 function requiredContract(contract: RepoContract | undefined, repoId: string): RepoContract {
   if (!contract) {
-    throw new Error(`No repo contract exists for ${repoId}.`);
+    // D-E7: see assertFreshScanIfRequired. Same code the CLI reports for this scenario.
+    throw selfClassifiedError({
+      message: `No repo contract exists for ${repoId}.`,
+      code: "missing_contract",
+      userAction:
+        "Accept or import a repo contract before running contract-backed enforcement.",
+      recoveryCommands: [
+        "drift conventions list --status candidate --json",
+        "drift contract import <contract.json> --dry-run --json"
+      ]
+    });
   }
   return contract;
 }
@@ -1525,9 +1537,16 @@ function assertFreshScanIfRequired(
   if (!required || !scanStatus.stale) {
     return;
   }
-  throw new Error(
-    `Scan is stale for ${repoId}. Run ${scanStatus.next_command}; omit require_fresh to inspect stale context.`
-  );
+  // D-E7: self-classified, so the refusal survives a reword. The code, action and recovery
+  // command are the ones classifyFailureMessage derived from this sentence's prose - this states
+  // them instead of spelling them.
+  throw selfClassifiedError({
+    message: `Scan is stale for ${repoId}. Run ${scanStatus.next_command}; omit require_fresh to inspect stale context.`,
+    code: "stale_scan",
+    userAction:
+      "Refresh the scan or rerun without --require-fresh for read-only stale context.",
+    recoveryCommands: [scanStatus.next_command]
+  });
 }
 
 function policyContextSummary(input: {

--- a/packages/mcp/test/error-classification.test.ts
+++ b/packages/mcp/test/error-classification.test.ts
@@ -3,6 +3,7 @@ import Database from "better-sqlite3";
 import { join } from "node:path";
 import { tmpdir } from "node:os";
 import { afterEach, describe, expect, it } from "vitest";
+import { classifyFailure, selfClassifiedError } from "@drift/core";
 import { openDriftStorage } from "@drift/storage";
 import { handleMcpJsonRpcRequest } from "../src/index.js";
 
@@ -130,5 +131,37 @@ describe("MCP errors arrive classified, not as raw SQLite strings", () => {
     expect(data.code).toBeTruthy();
     expect(data.user_action).toBeTruthy();
     expect(typeof data.safe_to_retry).toBe("boolean");
+  });
+
+  it("classifies MCP's own refusals from the error, not from its prose", () => {
+    // W4/D-E7. These two throw sites carried no classification, so `classifyFailureMessage`
+    // recognised them by the first four words of their sentences - "Scan is stale" and "No repo
+    // contract exists". That matched, so nothing was broken; what was true is that since W3 the
+    // exit code follows the failure code, so rewording either sentence would have silently
+    // demoted a refusal to the catch-all. The CLI stopped being able to do that in W3.
+    //
+    // Asserted against a REWORDED message, which is the property under test: a classifier reading
+    // the code gets it right, and one reading the prose cannot.
+    const stale = selfClassifiedError({
+      message: "the scan for repo_abc is out of date",
+      code: "stale_scan",
+      userAction: "Refresh the scan or rerun without --require-fresh for read-only stale context.",
+      recoveryCommands: ["drift scan --repo-root ."]
+    });
+    const missingContract = selfClassifiedError({
+      message: "repo_abc has not accepted anything yet",
+      code: "missing_contract",
+      userAction: "Accept or import a repo contract before running contract-backed enforcement.",
+      recoveryCommands: []
+    });
+
+    expect(classifyFailure(stale, stale.message).code).toBe("stale_scan");
+    expect(classifyFailure(missingContract, missingContract.message).code).toBe("missing_contract");
+
+    // The control: the same reworded prose, thrown as a plain Error, is NOT recognised. This is
+    // what the two sites were one edit away from.
+    expect(classifyFailure(new Error(stale.message), stale.message).code).not.toBe("stale_scan");
+    expect(classifyFailure(new Error("repo_abc has not accepted anything yet"), "repo_abc has not accepted anything yet").code)
+      .not.toBe("missing_contract");
   });
 });

--- a/packages/query/src/agent-envelope.ts
+++ b/packages/query/src/agent-envelope.ts
@@ -1,0 +1,42 @@
+/**
+ * The agent envelope, built once for both surfaces.
+ *
+ * W6. The CLI's `agentEnvelopeForScan` and MCP's `mcpAgentEnvelope` were the same call to
+ * `createAgentEnvelopeV2` written twice; the CLI's signature was a strict superset (optional
+ * `policy`/`scanStatus`, and the `cli-error` surface), so it is the one that survives.
+ *
+ * `scanStatus` is typed structurally rather than as `ReturnType<typeof scanStatusPayload>`,
+ * because that helper is itself duplicated across the boundary and importing either copy here
+ * would make this module pick a side.
+ */
+
+import { createAgentEnvelopeV2, type PolicyDecision } from "@drift/core";
+
+export interface AgentEnvelopeScanStatus {
+  stale: boolean;
+  latest_scan?: { id: string } | null;
+}
+
+export function agentEnvelopeForScan(input: {
+  surface: PolicyDecision["surface"] | "cli-error";
+  policy?: Pick<PolicyDecision, "allowed" | "surface" | "reason">;
+  scanStatus?: AgentEnvelopeScanStatus;
+  requireFresh?: boolean;
+  diagnostics?: string[];
+  contextTruncated?: boolean;
+}) {
+  return createAgentEnvelopeV2({
+    surface: input.surface,
+    policy: input.policy,
+    scan: {
+      required_fresh: Boolean(input.requireFresh),
+      stale: input.scanStatus?.stale ?? false,
+      latest_scan_id: input.scanStatus?.latest_scan?.id ?? null
+    },
+    redactions: {
+      snippets_included: false,
+      context_truncated: Boolean(input.contextTruncated)
+    },
+    diagnostics: input.diagnostics
+  });
+}

--- a/packages/query/src/index.ts
+++ b/packages/query/src/index.ts
@@ -1520,3 +1520,10 @@ function unique(values: string[]): string[] {
 }
 export { MAX_RELEVANT_FILES, rankRelevantFiles, relevanceScore, relevantFileForPath, relevantFilesForTask, tokenizeTask, type RankableFile } from "./relevance.js";
 export { isDeclarationPath, isIndexableFilePath, isTypescriptPath, shouldSkipPath, walkIndexableFiles } from "./repo-files.js";
+// W6: one derivation for the convention entry both preflight surfaces emit - see
+// ./prepared-convention.ts for the two divergences the second copy was carrying.
+export { instructionForConvention, preparedConvention, type PreparedConvention } from "./prepared-convention.js";
+// W6: one agent envelope, and one repo-map document. See ./repo-map-payload.ts for D-A2 - the
+// three trust fields the CLI's copy computed and then dropped.
+export { agentEnvelopeForScan, type AgentEnvelopeScanStatus } from "./agent-envelope.js";
+export { buildRepoMapPayload, type RepoMapPayloadInput } from "./repo-map-payload.js";

--- a/packages/query/src/prepared-convention.ts
+++ b/packages/query/src/prepared-convention.ts
@@ -1,0 +1,167 @@
+/**
+ * The convention entry both preflight surfaces emit, derived once.
+ *
+ * W6. `prepare`/`ask` (CLI) and `get_task_preflight` (MCP) each built this entry from the same
+ * inputs through their own copy - `preparedConvention` in packages/cli/src/domain/preflight.ts and
+ * `preflightConvention` in packages/mcp/src/index.ts. The two return objects were field-for-field
+ * identical, which is why the divergence took a measurement to see rather than a diff:
+ *
+ *   D-A1  the CLI passed the task's `--path` to `conformingExemplars` as `referenceFile`; MCP
+ *         passed nothing. `referenceFile` does two things there - it excludes the target from being
+ *         offered as an example of itself (conforming-exemplars.ts:119) and it sorts the remainder
+ *         by path distance (:135). So on a task naming a conforming file, `prepare` offered three
+ *         neighbours and `get_task_preflight` offered the file the agent was already editing.
+ *
+ *   The second one had not been named at all, and is worse than a disagreement. MCP's private copy
+ *   of `instructionForConvention` never received CV-5's `presence` branch, so every presence-kind
+ *   convention - `api_route_requires_auth`, `api_route_requires_rate_limit`,
+ *   `api_route_requires_request_validation` - fell through to the generic sentence. The branch
+ *   exists to say one thing plainly: Drift checks only that an accepted helper is CALLED, not that
+ *   it guards the route's work. An agent reading the MCP packet was never told that, and an agent
+ *   that believes a passing check proves the route is protected stops looking. `beta:proof` diffs
+ *   the two payloads and could not see it: its fixture repo accepts no presence-kind convention.
+ *
+ * Lives in @drift/query because MCP cannot import @drift/cli (drift.lock forbids it, blocking) and
+ * this needs @drift/core's exemplar machinery. Both callers already built an `ExemplarContext` and
+ * then hand-unpacked it into a bag of primitives, so taking the context directly removes a third
+ * copy - the unpacking - rather than adding a parameter.
+ */
+
+import {
+  conformingExemplars,
+  conventionRationale,
+  migrationSentence,
+  type AcceptedConvention,
+  type EnforcementMode,
+  type ExemplarContext,
+  type Severity
+} from "@drift/core";
+
+export interface PreparedConvention {
+  id: string;
+  kind: AcceptedConvention["kind"];
+  statement: string;
+  severity: Severity;
+  enforcement_mode: EnforcementMode;
+  enforcement_capability: AcceptedConvention["enforcement_capability"];
+  scope: AcceptedConvention["scope"];
+  matcher: AcceptedConvention["matcher"];
+  exceptions: AcceptedConvention["exceptions"];
+  agent_instruction: string;
+  /**
+   * BB-5: files in scope that obey this convention. Never a violator - see
+   * `core/src/conforming-exemplars.ts` for why that invariant is the item rather than a nicety.
+   */
+  conforming_examples: Array<{ file_path: string; role: string | null }>;
+  /** BB-5: why an empty exemplar list is empty. Never a bare `[]` (the EW-3 shape). */
+  conforming_examples_reason: string | null;
+  /**
+   * BB-5: the AK-8 split. `derivation` is how Drift came to believe the repo holds this convention;
+   * `reason` is why the repo holds it, which is what a reader deciding whether to comply needs.
+   */
+  rationale: { derivation: string; reason: string | null };
+  /**
+   * BB-5: why the baselined violations around the exemplars are not precedent. Absent when there
+   * are none - boilerplate saying "0 are baselined" trains readers to skip the line.
+   */
+  migration_sentence: string | null;
+}
+
+export function preparedConvention(
+  convention: AcceptedConvention,
+  // BB-5: optional so a caller with no scan state still gets the empty-with-reason shape rather
+  // than a missing field. A packet that silently omits the exemplars is the status quo.
+  context?: ExemplarContext,
+  options: {
+    /**
+     * The file the task targets, when it named one. D-A1: this is what the CLI passed and MCP did
+     * not. It is not a display preference - it decides whether the target can be cited as an
+     * example of itself.
+     */
+    targetPath?: string;
+  } = {}
+): PreparedConvention {
+  const exemplars = conformingExemplars({
+    scopeFiles: context?.scopeFilesFor(convention) ?? [],
+    // CV-5: any accepted convention, not just this one. A file conforming to the data-access rule
+    // can violate the auth family, and offering it as an example sends an agent to open a file
+    // that breaks another accepted rule - the trial-B1 defection trigger.
+    violatingFiles: context?.violatingFilesAnyConvention() ?? [],
+    roleByFile: context?.roleByFile,
+    referenceFile: options.targetPath,
+    // Verified against facts, not inferred from a missing finding. Neither surface runs a check,
+    // so its violator set is only whatever a previous check happened to record.
+    forbiddenImports: convention.matcher?.forbidden_imports ?? [],
+    importsByFile: context?.importsByFile
+  });
+  return {
+    id: convention.id,
+    kind: convention.kind,
+    statement: convention.statement,
+    severity: convention.severity,
+    enforcement_mode: convention.enforcement_mode,
+    enforcement_capability: convention.enforcement_capability,
+    scope: convention.scope,
+    matcher: convention.matcher,
+    exceptions: convention.exceptions,
+    agent_instruction: instructionForConvention(convention),
+    conforming_examples: exemplars.conforming_examples,
+    conforming_examples_reason: exemplars.reason,
+    rationale: conventionRationale({
+      kind: convention.kind,
+      derivation: convention.rationale ?? convention.statement
+    }),
+    migration_sentence: migrationSentence(context?.baselineActiveCountFor(convention.id) ?? 0)
+  };
+}
+
+export function instructionForConvention(convention: AcceptedConvention): string {
+  if (convention.kind === "api_route_no_direct_data_access") {
+    const forbidden = (convention.matcher.forbidden_imports ?? []).join(", ");
+    return [
+      "When editing API route files, do not import data-access clients directly.",
+      forbidden ? `Forbidden imports: ${forbidden}.` : "",
+      "Delegate through the repo's accepted service/data-access layer and run drift check before finishing."
+    ].filter(Boolean).join(" ");
+  }
+
+  if (convention.kind === "api_route_requires_service_delegation") {
+    const delegates = (convention.matcher.allowed_delegate_imports ?? []).join(", ");
+    return [
+      "When editing API route files, keep route modules thin and delegate business/data-access work to the service layer.",
+      delegates ? `Observed delegate imports: ${delegates}.` : "",
+      "Treat this as briefing guidance unless the repo later upgrades it to a deterministic check."
+    ].filter(Boolean).join(" ");
+  }
+
+  // CV-5: the presence kinds. Without this they fell through to the generic sentence below, which
+  // restates the convention and tells an agent nothing it can act on - and, worse, says nothing about
+  // what the check does NOT verify. The instruction is the one place the packet can be explicit that
+  // calling the helper is all that is checked, so an agent does not read a passing check as proof the
+  // route is protected.
+  if (convention.matcher.enforcement_semantics === "presence") {
+    const members = (convention.matcher.required_calls ?? []).join(", ");
+    const flavors = convention.matcher.applies_to_route_flavors ?? [];
+    const noun =
+      convention.kind === "api_route_requires_rate_limit"
+        ? "rate-limit helper"
+        : convention.kind === "api_route_requires_request_validation"
+          ? "request validator"
+          : "auth wrapper";
+    const scopeClause =
+      flavors.length > 0 && !flavors.includes("api_route")
+        ? ` This applies to ${flavors.join(" and ")} routes only.`
+        : flavors.length > 0
+          ? " This applies to application routes only, not cron or webhook routes."
+          : "";
+    return [
+      `When adding or editing an API route in scope, call one of the repo's accepted ${noun}s.`,
+      members ? `Accepted: ${members}.` : "",
+      scopeClause.trim(),
+      // Said plainly, because an agent that believes this proves protection will stop looking.
+      `Drift checks only that one of these is called - it does not verify that it guards the route's work.`
+    ].filter(Boolean).join(" ");
+  }
+
+  return `${convention.statement} Follow its scope, matcher, and exceptions.`;
+}

--- a/packages/query/src/repo-map-payload.ts
+++ b/packages/query/src/repo-map-payload.ts
@@ -1,0 +1,230 @@
+/**
+ * The `drift.repo.map.v1` document, assembled once for both surfaces.
+ *
+ * W6 / D-A2. `repoMapPayload` existed twice - packages/cli/src/domain/repo-map.ts and
+ * packages/mcp/src/index.ts - as 120-line near-copies. Every overlapping key was
+ * byte-identical, and `mcp keys - cli keys` was exactly three:
+ *
+ *   route_source_summary     how many routes came from proofs vs the fact fallback
+ *   canonical_route_fallback whether the canonical route list fell back at all
+ *   proof_freshness          whether the proofs backing those routes are from this scan
+ *
+ * All three are computed INSIDE the CLI's copy already - `buildSecurityPhase8ReadModel` returns
+ * them on the same `phase8Security` object the CLI reads `routes` off - and then dropped on the
+ * floor. So `drift repo map --json` answered "here are the routes" while withholding the three
+ * fields that say how much to trust them, and the same schema version over MCP answered with
+ * them. A consumer keying on `response_schema` got different documents from the same contract.
+ *
+ * The surface-specific parts are parameters rather than branches: each surface resolves its own
+ * contract and policy (their refusal messages differ, and MCP's carries a `ready` flag the CLI
+ * has no use for) and passes the result in. Everything downstream of that is one derivation.
+ */
+
+import {
+  type FileRole,
+  type PolicyDecision,
+  type RepoContract
+} from "@drift/core";
+import type { SqliteDriftStorage } from "@drift/storage";
+import { agentEnvelopeForScan } from "./agent-envelope.js";
+import { buildCanonicalRouteReadModel, type CanonicalFactRouteInput } from "./canonical-routes.js";
+import { buildFrameworkEntrypointReadModel } from "./framework-entrypoints.js";
+import { buildParserGapQuality } from "./parser-gap-quality.js";
+import { buildSecurityPhase8ReadModel } from "./security-boundary-proof.js";
+import {
+  buildRepoMapReadModel,
+  createGraphQueryService,
+  fallbackFactRepoMapFiles,
+  repoMapFileForPayload,
+  type RepoMapFile
+} from "./index.js";
+
+export interface RepoMapPayloadInput {
+  storage: SqliteDriftStorage;
+  repoId: string;
+  /** The repo record, already required by the caller so its "unknown repo" wording is its own. */
+  repo: { root_path: string };
+  /** Resolved and authorized by the caller - see the module comment. */
+  contract: RepoContract;
+  policy: PolicyDecision;
+  /** Governance block, which each surface words for its own audience. */
+  governance: unknown;
+  /** The scan-status document, and the freshness helpers that read it. */
+  scanStatus: { stale: boolean; latest_scan?: { id: string } | null };
+  freshnessRequirement: unknown;
+  scanFingerprint: string | null;
+  latestScan: { id: string } | null;
+  readiness: unknown;
+  options: {
+    surface: PolicyDecision["surface"];
+    role?: FileRole;
+    path?: string;
+    requireFresh?: boolean;
+    limit?: number;
+    offset?: number;
+  };
+}
+
+export function buildRepoMapPayload(input: RepoMapPayloadInput) {
+  const { storage, repoId, contract, options } = input;
+  const latestScan = input.latestScan;
+  const snapshots = latestScan ? storage.listFileSnapshots(repoId, latestScan.id) : [];
+  const facts = latestScan ? storage.listFacts(latestScan.id) : [];
+  const findings = storage.listFindings(repoId);
+  const graphMap = latestScan
+    ? createGraphQueryService(storage).repoMap({ repoId, scanId: latestScan.id })
+    : null;
+  const normalizedEntrypoints = latestScan
+    ? storage.listNormalizedEntrypoints(repoId, latestScan.id)
+    : [];
+  const frameworkEntryPoints = latestScan
+    ? buildFrameworkEntrypointReadModel({
+        repo_id: repoId,
+        scan_id: latestScan.id,
+        entrypoints: normalizedEntrypoints,
+        parser_gaps: storage.listFrameworkParserGaps(repoId, latestScan.id),
+        capabilities: storage.listFrameworkCapabilities(repoId, latestScan.id)
+      })
+    : null;
+  const readModel = buildRepoMapReadModel({
+    repoId,
+    scanId: latestScan?.id ?? null,
+    graphFiles: graphMap?.files ?? [],
+    factFiles: fallbackFactRepoMapFiles(snapshots, facts),
+    contract,
+    findings,
+    filters: { role: options.role, path: options.path },
+    limit: options.limit,
+    offset: options.offset ?? 0
+  });
+  const allParserGaps = latestScan
+    ? [...storage.listParserGaps(repoId, latestScan.id), ...storage.listParserGapV2(repoId, latestScan.id)]
+    : [];
+  const proofRuns = latestScan
+    ? storage.listLatestSecurityBoundaryProofRunsForRepo({ repo_id: repoId, file_path: options.path })
+    : [];
+  const fallbackProofs =
+    proofRuns.length === 0 && latestScan
+      ? storage
+          .listSecurityBoundaryProofs(repoId, latestScan.id)
+          .filter((proof) => !options.path || proof.route.file_path === options.path)
+      : [];
+  const proofs = proofRuns.length > 0 ? proofRuns.map((run) => run.proof) : fallbackProofs;
+  const proofScanId = proofRuns[0]?.scan_id ?? (fallbackProofs.length > 0 ? latestScan?.id ?? null : null);
+  const canonicalRoutes = buildCanonicalRouteReadModel({
+    repo_id: repoId,
+    scan_id: latestScan?.id ?? null,
+    entrypoints: normalizedEntrypoints,
+    proofs: proofs.map((proof) => ({
+      proof_scan_id: proofScanId,
+      route_id: proof.route.route_id,
+      ...(proof.route.normalized_entrypoint_id
+        ? { normalized_entrypoint_id: proof.route.normalized_entrypoint_id }
+        : {}),
+      file_path: proof.route.file_path,
+      path: proof.route.endpoint?.path ?? null,
+      method: proof.route.endpoint?.method ?? proof.route.handler_symbol ?? null
+    })),
+    fallback_fact_routes: fallbackFactRoutes(readModel.all_files)
+  });
+  const phase8Security = buildSecurityPhase8ReadModel({
+    repo_id: repoId,
+    scan_id: latestScan?.id ?? null,
+    check_id: proofRuns[0]?.check_id ?? null,
+    proof_scan_id: proofScanId,
+    proofs,
+    findings: findings.map((finding) => ({
+      finding_id: finding.id,
+      title: finding.title,
+      lifecycle: finding.status
+    })),
+    accepted_conventions: contract.conventions,
+    changed_files: options.path ? [options.path] : undefined,
+    known_routes: canonicalRoutes.routes.filter((route) => !options.path || route.file_path === options.path),
+    route_source_summary: canonicalRoutes.route_source_summary,
+    canonical_route_fallback: canonicalRoutes.fallback
+  });
+  return {
+    response_schema: "drift.repo.map.v1",
+    repo_id: repoId,
+    repo_root: input.repo.root_path,
+    generated_at: new Date().toISOString(),
+    agent_envelope: agentEnvelopeForScan({
+      surface: options.surface,
+      policy: input.policy,
+      scanStatus: input.scanStatus,
+      requireFresh: Boolean(options.requireFresh),
+      // Same value the payload's `redactions` reports. The envelope builds its own redactions and
+      // defaulted this to false, so a paginated map claimed `safe_to_edit` in the envelope while
+      // `redactions.context_truncated` said true one key away.
+      contextTruncated: readModel.pagination.has_more
+    }),
+    policy: input.policy,
+    readiness: input.readiness,
+    parser_gap_quality: buildParserGapQuality({
+      repo_id: repoId,
+      scan_id: latestScan?.id ?? null,
+      surface: "repo_map",
+      parser_gaps: allParserGaps,
+      readiness: input.readiness as never
+    }),
+    governance: input.governance,
+    latest_scan: latestScan ?? null,
+    scan_fingerprint: input.scanFingerprint,
+    scan_status: input.scanStatus,
+    filters: {
+      role: options.role ?? null,
+      path: options.path ?? null
+    },
+    summary: readModel.summary,
+    impact_summary: readModel.impact_summary,
+    topology: readModel.topology,
+    pagination: readModel.pagination,
+    routes: phase8Security.routes,
+    // D-A2: the three fields the CLI computed and discarded. They are the trust half of the
+    // routes above - where each route came from, whether the list fell back, and whether the
+    // proofs behind it are from the current scan.
+    route_source_summary: phase8Security.route_source_summary,
+    canonical_route_fallback: phase8Security.canonical_route_fallback,
+    proof_freshness: phase8Security.proof_freshness,
+    framework_entrypoints: frameworkEntryPoints,
+    freshness_requirement: input.freshnessRequirement,
+    files: readModel.listed_files.map(repoMapFileForPayload),
+    redactions: {
+      denied_globs: contract.context_egress.denied_globs,
+      snippets_included: false,
+      source_content_included: false,
+      graph_context_included: Boolean(graphMap),
+      // Derived, not asserted: a paginated map is a subset, and `has_more` already says so.
+      // Claiming `false` here told the envelope to report `safe_to_edit` for a response that
+      // omits files.
+      context_truncated: readModel.pagination.has_more
+    },
+    next_commands: [
+      `drift prepare "task" --repo ${repoId} --json`,
+      `drift scan status --repo ${repoId} --json`
+    ]
+  };
+}
+
+/**
+ * Routes recovered from facts when no proof names them.
+ *
+ * Module-private in BOTH copies, byte-identical, and therefore invisible to the architecture
+ * census, which indexed only symbols carrying a top-level `export`.
+ */
+function fallbackFactRoutes(files: RepoMapFile[]): CanonicalFactRouteInput[] {
+  return files
+    .filter((file) => file.roles.includes("api_route"))
+    .flatMap((file) => {
+      const methods = file.exported_symbols.filter((symbol) =>
+        ["GET", "POST", "PUT", "PATCH", "DELETE", "HEAD", "OPTIONS"].includes(symbol)
+      );
+      return (methods.length > 0 ? methods : ["unknown"]).map((method) => ({
+        route_id: `route:${file.path}:${method}`,
+        file_path: file.path,
+        method,
+        file_role: "api_route"
+      }));
+    });
+}

--- a/packages/query/src/test-intelligence.ts
+++ b/packages/query/src/test-intelligence.ts
@@ -1,7 +1,41 @@
+/**
+ * Which existing tests cover a change, and - when none do - why not.
+ *
+ * W4/D-A3. Three defects, all of which made the answer look the same as a correct one:
+ *
+ *   (a) selection saw ONE file. Both surfaces called this with
+ *       `changed_file: relevantFiles[0]?.path`, and `relevantFiles` is ranked and then
+ *       truncated, so on midday's "update the onboarding email template" the directly relevant
+ *       test sat behind a file at index 0 that had none, and was never considered. The input is
+ *       `changed_files` now: the whole set both surfaces had already computed and were
+ *       discarding all but the head of.
+ *
+ *   (b) the matcher was a raw basename-slug `.includes()`, so `lib/utils/formatCurrency.ts`
+ *       against `lib/utils/__tests__/format-currency.test.ts` returned []. camelCase in the
+ *       source and kebab-case in the test file is an ordinary convention pair, and it defeated
+ *       the match completely. Slugs are now compared with case and separators removed.
+ *
+ *   (c) `test_intelligence_reason` was `"not_implemented_for_repo"` whenever the list was
+ *       empty, written as an inline ternary in BOTH surfaces. taxonomy (0 test files, so
+ *       legitimately nothing to find) and midday (86 test files, one directly relevant, missed
+ *       by (a)) emitted the byte-identical string, and an agent reading it cannot tell "this
+ *       repo has no tests" from "the matcher missed them" - which call for opposite responses.
+ *       The reason is computed HERE, where the inputs that distinguish the two cases exist, so
+ *       there is one of it and it cannot disagree with the list it explains. The old value was
+ *       also just false: the feature is implemented for every repo.
+ *
+ *       It was an expression rather than a function, which is why W6's duplicate gate did not
+ *       collapse it - that gate indexes function bodies. Worth recording as a known limit of it.
+ */
+
 import type { TestIntelligence } from "@drift/core";
 
 export interface SelectRelevantTestsInput {
-  changed_file: string;
+  /**
+   * Every file the change touches, not just the first. A caller passing one file is asking
+   * "does some test mention THIS file", which is a weaker question than the one this answers.
+   */
+  changed_files: string[];
   route_flow?: {
     route?: string;
     service_file?: string;
@@ -9,33 +43,53 @@ export interface SelectRelevantTestsInput {
   test_files: string[];
 }
 
+/**
+ * Why `test_intelligence` is empty, when it is. Never a bare `[]` - the EW-3 lesson - and these
+ * two values are the distinction D-A3 collapsed into one string.
+ */
+export type TestIntelligenceReason =
+  /** The repo has no test files at all. Nothing was missed; there is nothing to find. */
+  | "no_test_files_in_repo"
+  /** The repo HAS tests and none matched this change. A reader should go looking. */
+  | "no_tests_matched_change";
+
 export interface RelevantTestsSelection {
   closest_tests: string[];
   missing_test_candidate: boolean;
   required_check_hint: string;
   test_intelligence: TestIntelligence[];
+  test_intelligence_reason: TestIntelligenceReason | null;
 }
 
 export function selectRelevantTests(input: SelectRelevantTestsInput): RelevantTestsSelection {
   const subjects = [
-    input.changed_file,
+    ...input.changed_files,
     input.route_flow?.route,
     input.route_flow?.service_file
   ].filter((value): value is string => Boolean(value));
-  const closestTests = input.test_files.filter((testFile) =>
-    subjects.some((subject) => matchesSubject(testFile, subject))
-  ).sort((left, right) => left.localeCompare(right));
+
+  // Which subject each matching test covers, so `test_subject` names the file the test is
+  // actually about rather than whichever file happened to rank first.
+  const matches = input.test_files
+    .map((testFile) => ({
+      testFile,
+      subject: subjects.find((subject) => matchesSubject(testFile, subject))
+    }))
+    .filter((entry): entry is { testFile: string; subject: string } => Boolean(entry.subject))
+    .sort((left, right) => left.testFile.localeCompare(right.testFile));
+
   const slug = subjects.map(subjectSlug).find(Boolean) ?? "changed";
 
   return {
-    closest_tests: closestTests,
-    missing_test_candidate: closestTests.length === 0,
+    closest_tests: matches.map((entry) => entry.testFile),
+    missing_test_candidate: matches.length === 0,
     required_check_hint: `npm test -- ${slug}`,
-    test_intelligence: closestTests.map((testFile) => ({
+    test_intelligence: matches.map((entry) => ({
       schema_version: "drift.test_intelligence.v1",
-      test_subject: input.changed_file,
-      test_type: testFile.includes("/api/") ? "integration" : "unit",
-      test_framework: testFile.includes(".spec.") || testFile.includes(".test.") ? "vitest" : "unknown",
+      test_subject: entry.subject,
+      test_type: entry.testFile.includes("/api/") ? "integration" : "unit",
+      test_framework:
+        entry.testFile.includes(".spec.") || entry.testFile.includes(".test.") ? "vitest" : "unknown",
       test_file_for: subjects,
       covered_symbols: [],
       covered_routes: input.route_flow?.route ? [input.route_flow.route] : [],
@@ -44,14 +98,30 @@ export function selectRelevantTests(input: SelectRelevantTestsInput): RelevantTe
       snapshot_usage: false,
       missing_test_candidate: false,
       stale_test_candidate: false
-    }))
+    })),
+    // (c): derived from the inputs that tell the two cases apart, rather than from the emptiness
+    // of the output - which is the one thing both cases have in common.
+    test_intelligence_reason:
+      matches.length > 0
+        ? null
+        : input.test_files.length === 0
+          ? "no_test_files_in_repo"
+          : "no_tests_matched_change"
   };
 }
 
 function matchesSubject(testFile: string, subject: string): boolean {
-  const testSlug = subjectSlug(testFile);
-  const targetSlug = subjectSlug(subject);
+  const testSlug = comparableSlug(subjectSlug(testFile));
+  const targetSlug = comparableSlug(subjectSlug(subject));
   return Boolean(testSlug && targetSlug && testSlug.includes(targetSlug));
+}
+
+/**
+ * (b): case and separators removed, so `formatCurrency` and `format-currency` are the same name.
+ * Not a fuzzy match - every character must still be present, in order.
+ */
+function comparableSlug(slug: string): string {
+  return slug.toLowerCase().replaceAll(/[-_.]/g, "");
 }
 
 function subjectSlug(subject: string): string {

--- a/packages/query/test/query.test.ts
+++ b/packages/query/test/query.test.ts
@@ -385,7 +385,7 @@ describe("GraphQueryService", () => {
 
   it("selects route and service tests relevant to a changed route flow", () => {
     const result = selectRelevantTests({
-      changed_file: "app/api/users/route.ts",
+      changed_files: ["app/api/users/route.ts"],
       route_flow: {
         route: "GET /api/users",
         service_file: "server/services/users.ts"
@@ -396,8 +396,80 @@ describe("GraphQueryService", () => {
     expect(result).toMatchObject({
       closest_tests: ["app/api/users/route.test.ts", "server/services/users.test.ts"],
       missing_test_candidate: false,
-      required_check_hint: "npm test -- users"
+      required_check_hint: "npm test -- users",
+      test_intelligence_reason: null
     });
+  });
+
+  it("considers every changed file, not only the first", () => {
+    // D-A3(a). Both surfaces passed `relevantFiles[0]?.path`, and relevantFiles is ranked then
+    // truncated. This is midday's shape: the directly relevant test belongs to the file at
+    // index 2, and the files ahead of it have no tests at all, so selection returned [].
+    const result = selectRelevantTests({
+      changed_files: [
+        "app/(marketing)/page.tsx",
+        "lib/constants.ts",
+        "lib/email/onboarding-template.ts"
+      ],
+      test_files: ["lib/email/__tests__/onboarding-template.test.ts"]
+    });
+
+    expect(result.closest_tests).toEqual(["lib/email/__tests__/onboarding-template.test.ts"]);
+    // The subject is the file the test is about, not whichever file ranked first.
+    expect(result.test_intelligence[0]).toMatchObject({
+      test_subject: "lib/email/onboarding-template.ts"
+    });
+  });
+
+  it("matches a camelCase source against a kebab-case test", () => {
+    // D-A3(b). The exact pair from the audit: the raw slugs are `formatCurrency` and
+    // `format-currency`, and `.includes()` on them is false.
+    const result = selectRelevantTests({
+      changed_files: ["lib/utils/formatCurrency.ts"],
+      test_files: ["lib/utils/__tests__/format-currency.test.ts"]
+    });
+
+    expect(result.closest_tests).toEqual(["lib/utils/__tests__/format-currency.test.ts"]);
+    expect(result.missing_test_candidate).toBe(false);
+  });
+
+  it("distinguishes a repo with no tests from a change nothing covers", () => {
+    // D-A3(c). These two emitted the byte-identical `"not_implemented_for_repo"`, and they call
+    // for opposite responses: one means write the first test, the other means go find the test
+    // that already exists. taxonomy is the first shape, midday the second.
+    const noTestsAnywhere = selectRelevantTests({
+      changed_files: ["app/api/users/route.ts"],
+      test_files: []
+    });
+    const testsExistButNoneMatch = selectRelevantTests({
+      changed_files: ["app/api/users/route.ts"],
+      test_files: ["lib/unrelated/billing.test.ts"]
+    });
+
+    expect(noTestsAnywhere.test_intelligence_reason).toBe("no_test_files_in_repo");
+    expect(testsExistButNoneMatch.test_intelligence_reason).toBe("no_tests_matched_change");
+    expect(noTestsAnywhere.test_intelligence_reason).not.toBe(
+      testsExistButNoneMatch.test_intelligence_reason
+    );
+  });
+
+  it("reports no reason when tests were found", () => {
+    const result = selectRelevantTests({
+      changed_files: ["server/services/users.ts"],
+      test_files: ["server/services/users.test.ts"]
+    });
+    expect(result.test_intelligence_reason).toBeNull();
+  });
+
+  it("does not match an unrelated test after separators are stripped", () => {
+    // Restraint for (b): removing separators must not turn every name into a substring of every
+    // other. A normalized match is still a substring match, not a fuzzy one.
+    const result = selectRelevantTests({
+      changed_files: ["server/services/users.ts"],
+      test_files: ["server/services/billing-reports.test.ts"]
+    });
+    expect(result.closest_tests).toEqual([]);
+    expect(result.test_intelligence_reason).toBe("no_tests_matched_change");
   });
 
   it("classifies a user endpoint filtering task", () => {

--- a/scripts/external-eval-baseline.json
+++ b/scripts/external-eval-baseline.json
@@ -1,7 +1,7 @@
 [
   {
     "repo": "taxonomy",
-    "onboard_seconds": 0.6,
+    "onboard_seconds": 0.7,
     "onboarded": true,
     "repo_id": "repo_11b231f73583e336",
     "files": 132,
@@ -31,13 +31,14 @@
     "exemplar_violators": [],
     "guidance_bytes": 3072,
     "guidance_within_budget": true,
-    "packet_bytes": 81510,
+    "packet_bytes": 81355,
     "packet_largest_sections": [
       "graph_context:21856",
-      "scan_status:7611",
+      "scan_status:7641",
       "task_preflight_packet:7419"
     ],
     "packet_within_envelope_budget": true,
+    "packet_budget_band": "under_60pct",
     "injection_diff_status": "new_in_diff",
     "injection_enforcement": "warn",
     "injection_finding_status": "new",
@@ -50,7 +51,7 @@
   },
   {
     "repo": "dub",
-    "onboard_seconds": 33.4,
+    "onboard_seconds": 34.6,
     "onboarded": true,
     "repo_id": "repo_9a75a9b284d85c79",
     "files": 4128,
@@ -82,13 +83,14 @@
     "exemplar_violators": [],
     "guidance_bytes": 5350,
     "guidance_within_budget": true,
-    "packet_bytes": 270193,
+    "packet_bytes": 270038,
     "packet_largest_sections": [
       "findings:90039",
       "graph_context:38104",
-      "semantic_coverage:19979"
+      "semantic_coverage:19820"
     ],
     "packet_within_envelope_budget": true,
+    "packet_budget_band": "under_60pct",
     "injection_diff_status": "new_in_diff",
     "injection_enforcement": "warn",
     "injection_finding_status": "new",
@@ -101,7 +103,7 @@
   },
   {
     "repo": "formbricks",
-    "onboard_seconds": 33.1,
+    "onboard_seconds": 32,
     "onboarded": true,
     "repo_id": "repo_bd38209bef6ebfe5",
     "files": 2872,
@@ -132,13 +134,14 @@
     "exemplar_violators": [],
     "guidance_bytes": 4415,
     "guidance_within_budget": true,
-    "packet_bytes": 88760,
+    "packet_bytes": 88605,
     "packet_largest_sections": [
       "graph_context:16416",
       "task_preflight_packet:10201",
-      "semantic_coverage:8939"
+      "scan_status:8837"
     ],
     "packet_within_envelope_budget": true,
+    "packet_budget_band": "under_60pct",
     "injection_diff_status": "new_in_diff",
     "injection_enforcement": "block",
     "injection_finding_status": "new",
@@ -151,7 +154,7 @@
   },
   {
     "repo": "calcom",
-    "onboard_seconds": 37.2,
+    "onboard_seconds": 36.9,
     "onboarded": true,
     "repo_id": "repo_5bd515cfd633da52",
     "files": 5066,
@@ -181,13 +184,14 @@
     "exemplar_violators": [],
     "guidance_bytes": 3833,
     "guidance_within_budget": true,
-    "packet_bytes": 133945,
+    "packet_bytes": 133790,
     "packet_largest_sections": [
-      "semantic_coverage:35090",
+      "semantic_coverage:34931",
       "graph_context:24724",
       "findings:9205"
     ],
     "packet_within_envelope_budget": true,
+    "packet_budget_band": "under_60pct",
     "injection_diff_status": "new_in_diff",
     "injection_enforcement": "block",
     "injection_finding_status": "new",
@@ -231,13 +235,14 @@
     "exemplar_violators": [],
     "guidance_bytes": 3815,
     "guidance_within_budget": true,
-    "packet_bytes": 226611,
+    "packet_bytes": 226456,
     "packet_largest_sections": [
       "findings:59575",
       "graph_context:50725",
-      "semantic_coverage:11279"
+      "semantic_coverage:11120"
     ],
     "packet_within_envelope_budget": true,
+    "packet_budget_band": "under_60pct",
     "injection_diff_status": "new_in_diff",
     "injection_enforcement": "warn",
     "injection_finding_status": "new",
@@ -253,7 +258,7 @@
     "inference_alone_found_data_layer": false,
     "discovery_named_data_layer": true,
     "discovery_reason": "no_data_access_candidate_inferred_but_data_layer_found",
-    "onboard_seconds": 16.9,
+    "onboard_seconds": 17.4,
     "onboarded": true,
     "repo_id": "repo_cc9a5c6bb0c30dc4",
     "files": 2037,
@@ -284,13 +289,14 @@
     "exemplar_violators": [],
     "guidance_bytes": 4267,
     "guidance_within_budget": true,
-    "packet_bytes": 112534,
+    "packet_bytes": 112379,
     "packet_largest_sections": [
       "graph_context:22154",
-      "semantic_coverage:15629",
+      "semantic_coverage:15470",
       "task_preflight_packet:11405"
     ],
     "packet_within_envelope_budget": true,
+    "packet_budget_band": "under_60pct",
     "injection_diff_status": "new_in_diff",
     "injection_enforcement": "block",
     "injection_finding_status": "new",
@@ -303,7 +309,7 @@
   },
   {
     "repo": "openstatus",
-    "onboard_seconds": 17.7,
+    "onboard_seconds": 22.7,
     "onboarded": true,
     "repo_id": "repo_c1e4d99fcacbd550",
     "files": 2185,
@@ -335,13 +341,14 @@
     "exemplar_violators": [],
     "guidance_bytes": 4596,
     "guidance_within_budget": true,
-    "packet_bytes": 197760,
+    "packet_bytes": 197605,
     "packet_largest_sections": [
       "graph_context:52746",
       "task_preflight_packet:24211",
-      "semantic_coverage:19739"
+      "semantic_coverage:19580"
     ],
     "packet_within_envelope_budget": true,
+    "packet_budget_band": "under_60pct",
     "injection_diff_status": "new_in_diff",
     "injection_enforcement": "block",
     "injection_finding_status": "new",

--- a/scripts/external-eval-predicate.mjs
+++ b/scripts/external-eval-predicate.mjs
@@ -6,6 +6,44 @@
  * failed, which the runner prints and records.
  */
 
+/** BB-6's envelope ceiling, in bytes. Shared so the runner and the ratchet cannot disagree. */
+export const PACKET_ENVELOPE_BUDGET = 500_000;
+
+/**
+ * W0: which coarse band of the envelope budget a repo's packet occupies.
+ *
+ * `packet_within_envelope_budget` is a cliff. It reads true at 499,999 bytes and false at
+ * 500,001, so the only regression it can see is one that has already shipped. W7 fixed the
+ * overrun that exposed this (dub 715,023 -> 269,235) and recorded `packet_bytes` so a flip
+ * could be diagnosed - but put it in VOLATILE, which is the set the baseline diff SKIPS. So
+ * the measurement exists and nothing compares it: dub could double from 270,193 to 499,999
+ * and the suite would print "no change vs baseline".
+ *
+ * A band is compared instead of the raw number for the reason `packet_bytes` was made
+ * volatile in the first place - ids and timestamps move it by tens of bytes between runs, and
+ * a pinned integer would flap. The bands are wide enough that the closest repo (dub, 54.0% of
+ * budget) sits 30k bytes clear of a boundary, and narrow enough that crossing 60% prints a
+ * line while there is still 40% of the budget left to fix it in.
+ */
+/**
+ * Band edges as fractions of the budget, exported because the anti-flap test asserts no suite
+ * repo sits near one. Hardcoding them in the test instead would let an edge be moved onto a
+ * repo with nothing failing - the gate losing its grip on the source it reads.
+ */
+export const ENVELOPE_BAND_EDGES = [0.6, 0.8, 0.95];
+
+/** Worst-to-best ordering, so "did this band get worse" is a comparison rather than a table. */
+export const ENVELOPE_BAND_ORDER = ["under_60pct", "60_to_80pct", "80_to_95pct", "over_95pct"];
+
+export function envelopeBudgetBand(packetBytes, budget = PACKET_ENVELOPE_BUDGET) {
+  if (!Number.isFinite(packetBytes) || !Number.isFinite(budget) || budget <= 0) {
+    return null;
+  }
+  const ratio = packetBytes / budget;
+  const index = ENVELOPE_BAND_EDGES.findIndex((edge) => ratio < edge);
+  return index === -1 ? ENVELOPE_BAND_ORDER.at(-1) : ENVELOPE_BAND_ORDER[index];
+}
+
 /**
  * @param {object} result the record built by evaluateRepo
  * @param {object} cfg    the REPOS entry (or ad-hoc config) that produced it
@@ -140,6 +178,16 @@ export function unsafeBaselineMoves(before, after) {
   }
   if (["fail", "refused"].includes(before.check_status) && after.check_status === "pass") {
     moves.push("check_status");
+  }
+  // W0: the envelope band may improve for free and may never silently worsen. Without this,
+  // `--update` would happily record a packet that grew from 54% to 94% of budget - still
+  // `packet_within_envelope_budget: true`, so no assertion fails, and the band delta would be
+  // the only line in the diff naming it. That is the shape of the movement W7 had to
+  // reconstruct by hand.
+  const beforeBand = ENVELOPE_BAND_ORDER.indexOf(before.packet_budget_band);
+  const afterBand = ENVELOPE_BAND_ORDER.indexOf(after.packet_budget_band);
+  if (beforeBand >= 0 && afterBand > beforeBand) {
+    moves.push("packet_budget_band");
   }
   return moves;
 }

--- a/scripts/external-eval.mjs
+++ b/scripts/external-eval.mjs
@@ -23,7 +23,7 @@ import { homedir, tmpdir } from "node:os";
 import { dirname, join, resolve } from "node:path";
 import { fileURLToPath } from "node:url";
 
-import { mergeBaselineRows, repoVerdict, unsafeBaselineMoves, updateGate } from "./external-eval-predicate.mjs";
+import { envelopeBudgetBand, mergeBaselineRows, PACKET_ENVELOPE_BUDGET, repoVerdict, unsafeBaselineMoves, updateGate } from "./external-eval-predicate.mjs";
 import { EVAL_REPOS } from "./eval-repos.mjs";
 import { importOf } from "./data-layer-import.mjs";
 import { contaminationAllowed, contaminationRefusal } from "./worktree-contamination.mjs";
@@ -459,7 +459,11 @@ function evaluateRepoAt(reposDir, cfg) {
           .sort((left, right) => right[1] - left[1])
           .slice(0, 3)
           .map(([key, bytes]) => `${key}:${bytes}`);
-        result.packet_within_envelope_budget = result.packet_bytes < 500_000;
+        result.packet_within_envelope_budget = result.packet_bytes < PACKET_ENVELOPE_BUDGET;
+        // W0: the band IS compared (it is deliberately absent from VOLATILE). The boolean above
+        // only moves once the budget is already blown; this moves at 60%, while there is still
+        // room to act. See envelopeBudgetBand for why a band rather than the raw byte count.
+        result.packet_budget_band = envelopeBudgetBand(result.packet_bytes);
       } catch (error) {
         result.guidance_within_budget = false;
         result.guidance_parse_error = String(error.message).slice(0, 200);

--- a/scripts/external-eval.test.mjs
+++ b/scripts/external-eval.test.mjs
@@ -5,7 +5,10 @@ import { join } from "node:path";
 import { afterEach, describe, expect, it } from "vitest";
 
 import {
+  ENVELOPE_BAND_EDGES,
+  envelopeBudgetBand,
   mergeBaselineRows,
+  PACKET_ENVELOPE_BUDGET,
   repoVerdict,
   unsafeBaselineMoves,
   updateGate
@@ -346,6 +349,76 @@ describe("unsafeBaselineMoves", () => {
 
   it("is silent for a brand-new repo with no baseline row", () => {
     expect(unsafeBaselineMoves(undefined, before)).toEqual([]);
+  });
+
+  it("flags an envelope band that widened toward the budget", () => {
+    const banded = { ...before, packet_budget_band: "under_60pct" };
+    expect(unsafeBaselineMoves(banded, { ...banded, packet_budget_band: "60_to_80pct" })).toEqual([
+      "packet_budget_band"
+    ]);
+  });
+
+  it("lets an envelope band shrink for free", () => {
+    const banded = { ...before, packet_budget_band: "80_to_95pct" };
+    expect(unsafeBaselineMoves(banded, { ...banded, packet_budget_band: "under_60pct" })).toEqual([]);
+  });
+
+  it("is silent when the baseline row predates the band field", () => {
+    // The rollout case: every existing row lacks the key until the baseline is rewritten, and a
+    // missing baseline value is not evidence of a regression.
+    expect(unsafeBaselineMoves(before, { ...before, packet_budget_band: "over_95pct" })).toEqual([]);
+  });
+});
+
+describe("envelopeBudgetBand", () => {
+  it("bands a packet by its share of the budget", () => {
+    expect(envelopeBudgetBand(0)).toBe("under_60pct");
+    expect(envelopeBudgetBand(299_999)).toBe("under_60pct");
+    expect(envelopeBudgetBand(300_000)).toBe("60_to_80pct");
+    expect(envelopeBudgetBand(399_999)).toBe("60_to_80pct");
+    expect(envelopeBudgetBand(400_000)).toBe("80_to_95pct");
+    expect(envelopeBudgetBand(474_999)).toBe("80_to_95pct");
+    expect(envelopeBudgetBand(475_000)).toBe("over_95pct");
+    expect(envelopeBudgetBand(900_000)).toBe("over_95pct");
+  });
+
+  it("returns null rather than a band for an unmeasured packet", () => {
+    // `packet_bytes` is absent whenever prepare failed or its output would not parse. A band of
+    // "under_60pct" there would read as headroom that was never measured.
+    expect(envelopeBudgetBand(undefined)).toBeNull();
+    expect(envelopeBudgetBand(NaN)).toBeNull();
+    expect(envelopeBudgetBand(100, 0)).toBeNull();
+  });
+
+  it("keeps every suite repo clear of a band boundary", () => {
+    // The anti-flap requirement, asserted against the committed baseline rather than asserted in
+    // prose. `packet_bytes` moves by tens of bytes between runs; if a repo sat within a kilobyte
+    // of a boundary this ratchet would flap and get switched off, which is how gates die.
+    const rows = JSON.parse(readFileSync(new URL("./external-eval-baseline.json", import.meta.url), "utf8"));
+    for (const row of rows) {
+      if (typeof row.packet_bytes !== "number") continue;
+      const distance = Math.min(
+        ...ENVELOPE_BAND_EDGES.map((edge) => Math.abs(row.packet_bytes - edge * PACKET_ENVELOPE_BUDGET))
+      );
+      expect(distance, `${row.repo} sits ${distance} bytes from a band boundary`).toBeGreaterThan(10_000);
+    }
+  });
+
+  it("sees the growth the budget boolean cannot", () => {
+    // The defect this exists for, stated as a test: BB-6's ceiling is 500,000 and dub's packet is
+    // 270,193. A packet that grew to 480,000 - 78% larger, and 96% of the budget - still satisfies
+    // `packet_within_envelope_budget`, so repoVerdict passes it and `packet_bytes` is volatile so
+    // the diff stays silent. The band is the only field that moves.
+    const before = { packet_bytes: 270_193, packet_within_envelope_budget: true };
+    const after = { packet_bytes: 480_000, packet_within_envelope_budget: true };
+    expect(after.packet_within_envelope_budget).toBe(before.packet_within_envelope_budget);
+    expect(envelopeBudgetBand(after.packet_bytes)).not.toBe(envelopeBudgetBand(before.packet_bytes));
+    expect(
+      unsafeBaselineMoves(
+        { ...before, packet_budget_band: envelopeBudgetBand(before.packet_bytes) },
+        { ...after, packet_budget_band: envelopeBudgetBand(after.packet_bytes) }
+      )
+    ).toEqual(["packet_budget_band"]);
   });
 });
 

--- a/scripts/payload-invariants-baseline.json
+++ b/scripts/payload-invariants-baseline.json
@@ -1,0 +1,1378 @@
+{
+  "constants": [
+    {
+      "path": "prepare.guidance.truncated.conventions",
+      "value": false,
+      "kind": "matrix_gap",
+      "reason": "NOT a guarantee - the matrix never truncates. Truncation needs a guidance view over the 32,768-byte budget, which takes roughly 60 realistically-sized conventions; the largest fixture here produces three. This is the exact field D-M5 found hardcoded to false, so it is recorded as a known hole rather than as a property. Closing it needs a fixture built for the budget, not a bigger repo."
+    },
+    {
+      "path": "prepare.guidance.truncated.relevant_files",
+      "value": false,
+      "kind": "matrix_gap",
+      "reason": "NOT a guarantee - the matrix never truncates. Truncation needs a guidance view over the 32,768-byte budget, which takes roughly 60 realistically-sized conventions; the largest fixture here produces three. This is the exact field D-M5 found hardcoded to false, so it is recorded as a known hole rather than as a property. Closing it needs a fixture built for the budget, not a bigger repo."
+    },
+    {
+      "path": "prepare.guidance.truncated.required_checks",
+      "value": false,
+      "kind": "matrix_gap",
+      "reason": "NOT a guarantee - the matrix never truncates. Truncation needs a guidance view over the 32,768-byte budget, which takes roughly 60 realistically-sized conventions; the largest fixture here produces three. This is the exact field D-M5 found hardcoded to false, so it is recorded as a known hole rather than as a property. Closing it needs a fixture built for the budget, not a bigger repo."
+    },
+    {
+      "path": "prepare.agent_envelope.read_only",
+      "value": true,
+      "kind": "product_invariant",
+      "reason": "Every surface this gate drives is read-only by construction - check:surface-parity asserts zero storage writes in packages/mcp/src, and these CLI reads mutate nothing. If this ever varies, the STALE half of this gate fires and that is the intended alarm."
+    },
+    {
+      "path": "prepare.agent_envelope.policy.allowed",
+      "value": true,
+      "kind": "matrix_gap",
+      "reason": "The policy dimension is unexercised: no fixture sets a restrictive `context_egress` in its contract, so authorization is granted in every cell and the whole permission matrix reads as one value. Closing it needs a fixture whose contract denies a surface - not a bigger repo. Known hole, not a promise that policy cannot deny."
+    },
+    {
+      "path": "prepare.agent_envelope.redactions.snippets_included",
+      "value": false,
+      "kind": "product_invariant",
+      "reason": "Drift ships metadata about code, never the code. These are the fields that say so, and they are false on every surface deliberately rather than incidentally."
+    },
+    {
+      "path": "prepare.agent_envelope.redactions.context_truncated",
+      "value": false,
+      "kind": "matrix_gap",
+      "reason": "NOT a guarantee - the matrix never truncates. Truncation needs a guidance view over the 32,768-byte budget, which takes roughly 60 realistically-sized conventions; the largest fixture here produces three. This is the exact field D-M5 found hardcoded to false, so it is recorded as a known hole rather than as a property. Closing it needs a fixture built for the budget, not a bigger repo."
+    },
+    {
+      "path": "prepare.agent_envelope.policy_proof.allowed",
+      "value": true,
+      "kind": "matrix_gap",
+      "reason": "The policy dimension is unexercised: no fixture sets a restrictive `context_egress` in its contract, so authorization is granted in every cell and the whole permission matrix reads as one value. Closing it needs a fixture whose contract denies a surface - not a bigger repo. Known hole, not a promise that policy cannot deny."
+    },
+    {
+      "path": "prepare.agent_envelope.policy_proof.snippets_included",
+      "value": false,
+      "kind": "product_invariant",
+      "reason": "Drift ships metadata about code, never the code. These are the fields that say so, and they are false on every surface deliberately rather than incidentally."
+    },
+    {
+      "path": "prepare.agent_envelope.policy_proof.source_content_included",
+      "value": false,
+      "kind": "product_invariant",
+      "reason": "Drift ships metadata about code, never the code. These are the fields that say so, and they are false on every surface deliberately rather than incidentally."
+    },
+    {
+      "path": "prepare.agent_envelope.policy_proof.context_truncated",
+      "value": false,
+      "kind": "matrix_gap",
+      "reason": "NOT a guarantee - the matrix never truncates. Truncation needs a guidance view over the 32,768-byte budget, which takes roughly 60 realistically-sized conventions; the largest fixture here produces three. This is the exact field D-M5 found hardcoded to false, so it is recorded as a known hole rather than as a property. Closing it needs a fixture built for the budget, not a bigger repo."
+    },
+    {
+      "path": "prepare.policy.allowed",
+      "value": true,
+      "kind": "matrix_gap",
+      "reason": "The policy dimension is unexercised: no fixture sets a restrictive `context_egress` in its contract, so authorization is granted in every cell and the whole permission matrix reads as one value. Closing it needs a fixture whose contract denies a surface - not a bigger repo. Known hole, not a promise that policy cannot deny."
+    },
+    {
+      "path": "prepare.policy.reason",
+      "value": "metadata-only local preflight packet",
+      "kind": "matrix_gap",
+      "reason": "The policy dimension is unexercised: no fixture sets a restrictive `context_egress` in its contract, so authorization is granted in every cell and the whole permission matrix reads as one value. Closing it needs a fixture whose contract denies a surface - not a bigger repo. Known hole, not a promise that policy cannot deny."
+    },
+    {
+      "path": "prepare.readiness.schema_version",
+      "value": "drift.readiness.v1",
+      "kind": "payload_identity",
+      "reason": "Identity, not calibration: a repo-map readiness block reports surface `repo_map` in every cell because that is what it is. Pinned so a renamed surface or a bumped schema shows up."
+    },
+    {
+      "path": "prepare.readiness.surface",
+      "value": "prepare",
+      "kind": "payload_identity",
+      "reason": "Identity, not calibration: a repo-map readiness block reports surface `repo_map` in every cell because that is what it is. Pinned so a renamed surface or a bumped schema shows up."
+    },
+    {
+      "path": "prepare.readiness.graph_available",
+      "value": true,
+      "kind": "environment",
+      "reason": "The engine produces a graph for every fixture here, so the degraded path never engages. The absent-graph branch is covered where it can be forced directly rather than by hoping a fixture fails to parse."
+    },
+    {
+      "path": "prepare.readiness.required_capabilities[]",
+      "value": "route_flow",
+      "kind": "payload_identity",
+      "reason": "The capability list a surface requires is a property of that surface, not of the repo it is reporting on. Pinned so a silently narrowed requirement shows up."
+    },
+    {
+      "path": "prepare.audit_integrity.valid",
+      "value": true,
+      "kind": "matrix_gap",
+      "reason": "The audit chain verifies in every cell because nothing tampers with it. Making this false means corrupting a hash-linked log on purpose, which the storage suite does directly; this matrix only ever builds intact ones."
+    },
+    {
+      "path": "prepare.scan_status.latest_scan.dirty",
+      "value": false,
+      "kind": "environment",
+      "reason": "Every scan in this matrix completes against a clean checkout, so the manifest reports the same state throughout. A failed or dirty scan is a different harness."
+    },
+    {
+      "path": "prepare.scan_status.latest_scan.status",
+      "value": "completed",
+      "kind": "environment",
+      "reason": "Every scan in this matrix completes against a clean checkout, so the manifest reports the same state throughout. A failed or dirty scan is a different harness."
+    },
+    {
+      "path": "prepare.scan_status.governance.read_only",
+      "value": true,
+      "kind": "product_invariant",
+      "reason": "Every surface this gate drives is read-only by construction - check:surface-parity asserts zero storage writes in packages/mcp/src, and these CLI reads mutate nothing. If this ever varies, the STALE half of this gate fires and that is the intended alarm."
+    },
+    {
+      "path": "prepare.scan_status.governance.agent_can_mutate",
+      "value": false,
+      "kind": "product_invariant",
+      "reason": "Every surface this gate drives is read-only by construction - check:surface-parity asserts zero storage writes in packages/mcp/src, and these CLI reads mutate nothing. If this ever varies, the STALE half of this gate fires and that is the intended alarm."
+    },
+    {
+      "path": "prepare.scan_status.summary.audit_valid",
+      "value": true,
+      "kind": "matrix_gap",
+      "reason": "The audit chain verifies in every cell because nothing tampers with it. Making this false means corrupting a hash-linked log on purpose, which the storage suite does directly; this matrix only ever builds intact ones."
+    },
+    {
+      "path": "prepare.scan_status.audit_integrity.valid",
+      "value": true,
+      "kind": "matrix_gap",
+      "reason": "The audit chain verifies in every cell because nothing tampers with it. Making this false means corrupting a hash-linked log on purpose, which the storage suite does directly; this matrix only ever builds intact ones."
+    },
+    {
+      "path": "prepare.scan_status.readiness.schema_version",
+      "value": "drift.readiness.v1",
+      "kind": "payload_identity",
+      "reason": "Identity, not calibration: a repo-map readiness block reports surface `repo_map` in every cell because that is what it is. Pinned so a renamed surface or a bumped schema shows up."
+    },
+    {
+      "path": "prepare.scan_status.readiness.surface",
+      "value": "scan_status",
+      "kind": "payload_identity",
+      "reason": "Identity, not calibration: a repo-map readiness block reports surface `repo_map` in every cell because that is what it is. Pinned so a renamed surface or a bumped schema shows up."
+    },
+    {
+      "path": "prepare.scan_status.readiness.graph_available",
+      "value": true,
+      "kind": "environment",
+      "reason": "The engine produces a graph for every fixture here, so the degraded path never engages. The absent-graph branch is covered where it can be forced directly rather than by hoping a fixture fails to parse."
+    },
+    {
+      "path": "prepare.scan_status.readiness.graph_complete",
+      "value": true,
+      "kind": "environment",
+      "reason": "The engine produces a graph for every fixture here, so the degraded path never engages. The absent-graph branch is covered where it can be forced directly rather than by hoping a fixture fails to parse."
+    },
+    {
+      "path": "prepare.scan_status.readiness.required_capabilities[]",
+      "value": "fact_graph",
+      "kind": "payload_identity",
+      "reason": "The capability list a surface requires is a property of that surface, not of the repo it is reporting on. Pinned so a silently narrowed requirement shows up."
+    },
+    {
+      "path": "prepare.scan_status.capability_report.engine_source",
+      "value": "rust",
+      "kind": "environment",
+      "reason": "Fixed by the environment this gate runs in: the engine binary is always present, so the TypeScript fallback never engages. external-eval asserts the same two fields against the real corpus, where a fallback would be a genuine regression."
+    },
+    {
+      "path": "prepare.scan_status.capability_report.completeness[].can_block",
+      "value": true,
+      "kind": "matrix_gap",
+      "reason": "The policy dimension is unexercised: no fixture sets a restrictive `context_egress` in its contract, so authorization is granted in every cell and the whole permission matrix reads as one value. Closing it needs a fixture whose contract denies a surface - not a bigger repo. Known hole, not a promise that policy cannot deny."
+    },
+    {
+      "path": "prepare.scan_status.capability_report.fallback_used",
+      "value": false,
+      "kind": "environment",
+      "reason": "Fixed by the environment this gate runs in: the engine binary is always present, so the TypeScript fallback never engages. external-eval asserts the same two fields against the real corpus, where a fallback would be a genuine regression."
+    },
+    {
+      "path": "prepare.scan_status.capability_report.enforcement_degraded",
+      "value": false,
+      "kind": "environment",
+      "reason": "Fixed by the environment this gate runs in: the engine binary is always present, so the TypeScript fallback never engages. external-eval asserts the same two fields against the real corpus, where a fallback would be a genuine regression."
+    },
+    {
+      "path": "prepare.graph_context.available",
+      "value": true,
+      "kind": "matrix_gap",
+      "reason": "Constant at true across the matrix, and not yet explained. Either the matrix lacks the state that moves it, or the field is frozen and this gate has found one."
+    },
+    {
+      "path": "prepare.graph_context.diagnostic_summary.policy.local_only",
+      "value": true,
+      "kind": "matrix_gap",
+      "reason": "The policy dimension is unexercised: no fixture sets a restrictive `context_egress` in its contract, so authorization is granted in every cell and the whole permission matrix reads as one value. Closing it needs a fixture whose contract denies a surface - not a bigger repo. Known hole, not a promise that policy cannot deny."
+    },
+    {
+      "path": "prepare.task_model.human_approval_needed",
+      "value": false,
+      "kind": "matrix_gap",
+      "reason": "Constant at false across the matrix, and not yet explained. Either the matrix lacks the state that moves it, or the field is frozen and this gate has found one."
+    },
+    {
+      "path": "prepare.task_preflight_packet.task_model.human_approval_needed",
+      "value": false,
+      "kind": "matrix_gap",
+      "reason": "Constant at false across the matrix, and not yet explained. Either the matrix lacks the state that moves it, or the field is frozen and this gate has found one."
+    },
+    {
+      "path": "prepare.task_preflight_packet.context_policy.can_read_repo_map",
+      "value": true,
+      "kind": "matrix_gap",
+      "reason": "The policy dimension is unexercised: no fixture sets a restrictive `context_egress` in its contract, so authorization is granted in every cell and the whole permission matrix reads as one value. Closing it needs a fixture whose contract denies a surface - not a bigger repo. Known hole, not a promise that policy cannot deny."
+    },
+    {
+      "path": "prepare.task_preflight_packet.context_policy.can_read_source_snippets",
+      "value": false,
+      "kind": "matrix_gap",
+      "reason": "The policy dimension is unexercised: no fixture sets a restrictive `context_egress` in its contract, so authorization is granted in every cell and the whole permission matrix reads as one value. Closing it needs a fixture whose contract denies a surface - not a bigger repo. Known hole, not a promise that policy cannot deny."
+    },
+    {
+      "path": "prepare.task_preflight_packet.context_policy.can_read_contract",
+      "value": true,
+      "kind": "matrix_gap",
+      "reason": "The policy dimension is unexercised: no fixture sets a restrictive `context_egress` in its contract, so authorization is granted in every cell and the whole permission matrix reads as one value. Closing it needs a fixture whose contract denies a surface - not a bigger repo. Known hole, not a promise that policy cannot deny."
+    },
+    {
+      "path": "prepare.task_preflight_packet.context_policy.can_read_findings",
+      "value": true,
+      "kind": "matrix_gap",
+      "reason": "The policy dimension is unexercised: no fixture sets a restrictive `context_egress` in its contract, so authorization is granted in every cell and the whole permission matrix reads as one value. Closing it needs a fixture whose contract denies a surface - not a bigger repo. Known hole, not a promise that policy cannot deny."
+    },
+    {
+      "path": "prepare.task_preflight_packet.context_policy.can_execute_commands",
+      "value": false,
+      "kind": "matrix_gap",
+      "reason": "The policy dimension is unexercised: no fixture sets a restrictive `context_egress` in its contract, so authorization is granted in every cell and the whole permission matrix reads as one value. Closing it needs a fixture whose contract denies a surface - not a bigger repo. Known hole, not a promise that policy cannot deny."
+    },
+    {
+      "path": "prepare.task_preflight_packet.context_policy.can_modify_contract",
+      "value": false,
+      "kind": "matrix_gap",
+      "reason": "The policy dimension is unexercised: no fixture sets a restrictive `context_egress` in its contract, so authorization is granted in every cell and the whole permission matrix reads as one value. Closing it needs a fixture whose contract denies a surface - not a bigger repo. Known hole, not a promise that policy cannot deny."
+    },
+    {
+      "path": "prepare.task_preflight_packet.context_policy.can_create_waiver",
+      "value": false,
+      "kind": "matrix_gap",
+      "reason": "The policy dimension is unexercised: no fixture sets a restrictive `context_egress` in its contract, so authorization is granted in every cell and the whole permission matrix reads as one value. Closing it needs a fixture whose contract denies a surface - not a bigger repo. Known hole, not a promise that policy cannot deny."
+    },
+    {
+      "path": "prepare.task_preflight_packet.context_policy.can_request_human_approval",
+      "value": true,
+      "kind": "matrix_gap",
+      "reason": "The policy dimension is unexercised: no fixture sets a restrictive `context_egress` in its contract, so authorization is granted in every cell and the whole permission matrix reads as one value. Closing it needs a fixture whose contract denies a surface - not a bigger repo. Known hole, not a promise that policy cannot deny."
+    },
+    {
+      "path": "prepare.task_preflight_packet.context_policy.can_access_secret_like_files",
+      "value": false,
+      "kind": "matrix_gap",
+      "reason": "The policy dimension is unexercised: no fixture sets a restrictive `context_egress` in its contract, so authorization is granted in every cell and the whole permission matrix reads as one value. Closing it needs a fixture whose contract denies a surface - not a bigger repo. Known hole, not a promise that policy cannot deny."
+    },
+    {
+      "path": "prepare.task_preflight_packet.context_policy.can_emit_patch",
+      "value": false,
+      "kind": "matrix_gap",
+      "reason": "The policy dimension is unexercised: no fixture sets a restrictive `context_egress` in its contract, so authorization is granted in every cell and the whole permission matrix reads as one value. Closing it needs a fixture whose contract denies a surface - not a bigger repo. Known hole, not a promise that policy cannot deny."
+    },
+    {
+      "path": "prepare.agent_contract_packet.selected_contracts_reason",
+      "value": "no_contracts_accepted",
+      "kind": "matrix_gap",
+      "reason": "`no_contracts_accepted` in every cell because no fixture carries an AGENT contract - a different object from the repo contract the accept step materializes. Closing it needs a fixture with one; until then this field's other values are unexercised here."
+    },
+    {
+      "path": "prepare.governance.read_only",
+      "value": true,
+      "kind": "product_invariant",
+      "reason": "Every surface this gate drives is read-only by construction - check:surface-parity asserts zero storage writes in packages/mcp/src, and these CLI reads mutate nothing. If this ever varies, the STALE half of this gate fires and that is the intended alarm."
+    },
+    {
+      "path": "prepare.governance.agent_can_mutate",
+      "value": false,
+      "kind": "product_invariant",
+      "reason": "Every surface this gate drives is read-only by construction - check:surface-parity asserts zero storage writes in packages/mcp/src, and these CLI reads mutate nothing. If this ever varies, the STALE half of this gate fires and that is the intended alarm."
+    },
+    {
+      "path": "prepare.context_policy.can_read_repo_map",
+      "value": true,
+      "kind": "matrix_gap",
+      "reason": "The policy dimension is unexercised: no fixture sets a restrictive `context_egress` in its contract, so authorization is granted in every cell and the whole permission matrix reads as one value. Closing it needs a fixture whose contract denies a surface - not a bigger repo. Known hole, not a promise that policy cannot deny."
+    },
+    {
+      "path": "prepare.context_policy.can_read_source_snippets",
+      "value": false,
+      "kind": "matrix_gap",
+      "reason": "The policy dimension is unexercised: no fixture sets a restrictive `context_egress` in its contract, so authorization is granted in every cell and the whole permission matrix reads as one value. Closing it needs a fixture whose contract denies a surface - not a bigger repo. Known hole, not a promise that policy cannot deny."
+    },
+    {
+      "path": "prepare.context_policy.can_read_contract",
+      "value": true,
+      "kind": "matrix_gap",
+      "reason": "The policy dimension is unexercised: no fixture sets a restrictive `context_egress` in its contract, so authorization is granted in every cell and the whole permission matrix reads as one value. Closing it needs a fixture whose contract denies a surface - not a bigger repo. Known hole, not a promise that policy cannot deny."
+    },
+    {
+      "path": "prepare.context_policy.can_read_findings",
+      "value": true,
+      "kind": "matrix_gap",
+      "reason": "The policy dimension is unexercised: no fixture sets a restrictive `context_egress` in its contract, so authorization is granted in every cell and the whole permission matrix reads as one value. Closing it needs a fixture whose contract denies a surface - not a bigger repo. Known hole, not a promise that policy cannot deny."
+    },
+    {
+      "path": "prepare.context_policy.can_execute_commands",
+      "value": false,
+      "kind": "matrix_gap",
+      "reason": "The policy dimension is unexercised: no fixture sets a restrictive `context_egress` in its contract, so authorization is granted in every cell and the whole permission matrix reads as one value. Closing it needs a fixture whose contract denies a surface - not a bigger repo. Known hole, not a promise that policy cannot deny."
+    },
+    {
+      "path": "prepare.context_policy.can_modify_contract",
+      "value": false,
+      "kind": "matrix_gap",
+      "reason": "The policy dimension is unexercised: no fixture sets a restrictive `context_egress` in its contract, so authorization is granted in every cell and the whole permission matrix reads as one value. Closing it needs a fixture whose contract denies a surface - not a bigger repo. Known hole, not a promise that policy cannot deny."
+    },
+    {
+      "path": "prepare.context_policy.can_create_waiver",
+      "value": false,
+      "kind": "matrix_gap",
+      "reason": "The policy dimension is unexercised: no fixture sets a restrictive `context_egress` in its contract, so authorization is granted in every cell and the whole permission matrix reads as one value. Closing it needs a fixture whose contract denies a surface - not a bigger repo. Known hole, not a promise that policy cannot deny."
+    },
+    {
+      "path": "prepare.context_policy.can_request_human_approval",
+      "value": true,
+      "kind": "matrix_gap",
+      "reason": "The policy dimension is unexercised: no fixture sets a restrictive `context_egress` in its contract, so authorization is granted in every cell and the whole permission matrix reads as one value. Closing it needs a fixture whose contract denies a surface - not a bigger repo. Known hole, not a promise that policy cannot deny."
+    },
+    {
+      "path": "prepare.context_policy.can_access_secret_like_files",
+      "value": false,
+      "kind": "matrix_gap",
+      "reason": "The policy dimension is unexercised: no fixture sets a restrictive `context_egress` in its contract, so authorization is granted in every cell and the whole permission matrix reads as one value. Closing it needs a fixture whose contract denies a surface - not a bigger repo. Known hole, not a promise that policy cannot deny."
+    },
+    {
+      "path": "prepare.context_policy.can_emit_patch",
+      "value": false,
+      "kind": "matrix_gap",
+      "reason": "The policy dimension is unexercised: no fixture sets a restrictive `context_egress` in its contract, so authorization is granted in every cell and the whole permission matrix reads as one value. Closing it needs a fixture whose contract denies a surface - not a bigger repo. Known hole, not a promise that policy cannot deny."
+    },
+    {
+      "path": "prepare.redactions.snippets_included",
+      "value": false,
+      "kind": "product_invariant",
+      "reason": "Drift ships metadata about code, never the code. These are the fields that say so, and they are false on every surface deliberately rather than incidentally."
+    },
+    {
+      "path": "prepare.redactions.source_content_included",
+      "value": false,
+      "kind": "product_invariant",
+      "reason": "Drift ships metadata about code, never the code. These are the fields that say so, and they are false on every surface deliberately rather than incidentally."
+    },
+    {
+      "path": "prepare.redactions.graph_context_included",
+      "value": true,
+      "kind": "product_invariant",
+      "reason": "Drift ships metadata about code, never the code. These are the fields that say so, and they are false on every surface deliberately rather than incidentally."
+    },
+    {
+      "path": "prepare.redactions.context_truncated",
+      "value": false,
+      "kind": "matrix_gap",
+      "reason": "NOT a guarantee - the matrix never truncates. Truncation needs a guidance view over the 32,768-byte budget, which takes roughly 60 realistically-sized conventions; the largest fixture here produces three. This is the exact field D-M5 found hardcoded to false, so it is recorded as a known hole rather than as a property. Closing it needs a fixture built for the budget, not a bigger repo."
+    },
+    {
+      "path": "repo_map.agent_envelope.read_only",
+      "value": true,
+      "kind": "product_invariant",
+      "reason": "Every surface this gate drives is read-only by construction - check:surface-parity asserts zero storage writes in packages/mcp/src, and these CLI reads mutate nothing. If this ever varies, the STALE half of this gate fires and that is the intended alarm."
+    },
+    {
+      "path": "repo_map.agent_envelope.policy.allowed",
+      "value": true,
+      "kind": "matrix_gap",
+      "reason": "The policy dimension is unexercised: no fixture sets a restrictive `context_egress` in its contract, so authorization is granted in every cell and the whole permission matrix reads as one value. Closing it needs a fixture whose contract denies a surface - not a bigger repo. Known hole, not a promise that policy cannot deny."
+    },
+    {
+      "path": "repo_map.agent_envelope.policy.reason",
+      "value": "metadata-only local preflight packet",
+      "kind": "matrix_gap",
+      "reason": "The policy dimension is unexercised: no fixture sets a restrictive `context_egress` in its contract, so authorization is granted in every cell and the whole permission matrix reads as one value. Closing it needs a fixture whose contract denies a surface - not a bigger repo. Known hole, not a promise that policy cannot deny."
+    },
+    {
+      "path": "repo_map.agent_envelope.scan.required_fresh",
+      "value": false,
+      "kind": "matrix_gap",
+      "reason": "Constant at false across the matrix, and not yet explained. Either the matrix lacks the state that moves it, or the field is frozen and this gate has found one."
+    },
+    {
+      "path": "repo_map.agent_envelope.redactions.snippets_included",
+      "value": false,
+      "kind": "product_invariant",
+      "reason": "Drift ships metadata about code, never the code. These are the fields that say so, and they are false on every surface deliberately rather than incidentally."
+    },
+    {
+      "path": "repo_map.agent_envelope.redactions.context_truncated",
+      "value": false,
+      "kind": "matrix_gap",
+      "reason": "NOT a guarantee - the matrix never truncates. Truncation needs a guidance view over the 32,768-byte budget, which takes roughly 60 realistically-sized conventions; the largest fixture here produces three. This is the exact field D-M5 found hardcoded to false, so it is recorded as a known hole rather than as a property. Closing it needs a fixture built for the budget, not a bigger repo."
+    },
+    {
+      "path": "repo_map.agent_envelope.policy_proof.allowed",
+      "value": true,
+      "kind": "matrix_gap",
+      "reason": "The policy dimension is unexercised: no fixture sets a restrictive `context_egress` in its contract, so authorization is granted in every cell and the whole permission matrix reads as one value. Closing it needs a fixture whose contract denies a surface - not a bigger repo. Known hole, not a promise that policy cannot deny."
+    },
+    {
+      "path": "repo_map.agent_envelope.policy_proof.reason",
+      "value": "metadata-only local preflight packet",
+      "kind": "matrix_gap",
+      "reason": "The policy dimension is unexercised: no fixture sets a restrictive `context_egress` in its contract, so authorization is granted in every cell and the whole permission matrix reads as one value. Closing it needs a fixture whose contract denies a surface - not a bigger repo. Known hole, not a promise that policy cannot deny."
+    },
+    {
+      "path": "repo_map.agent_envelope.policy_proof.snippets_included",
+      "value": false,
+      "kind": "product_invariant",
+      "reason": "Drift ships metadata about code, never the code. These are the fields that say so, and they are false on every surface deliberately rather than incidentally."
+    },
+    {
+      "path": "repo_map.agent_envelope.policy_proof.source_content_included",
+      "value": false,
+      "kind": "product_invariant",
+      "reason": "Drift ships metadata about code, never the code. These are the fields that say so, and they are false on every surface deliberately rather than incidentally."
+    },
+    {
+      "path": "repo_map.agent_envelope.policy_proof.context_truncated",
+      "value": false,
+      "kind": "matrix_gap",
+      "reason": "NOT a guarantee - the matrix never truncates. Truncation needs a guidance view over the 32,768-byte budget, which takes roughly 60 realistically-sized conventions; the largest fixture here produces three. This is the exact field D-M5 found hardcoded to false, so it is recorded as a known hole rather than as a property. Closing it needs a fixture built for the budget, not a bigger repo."
+    },
+    {
+      "path": "repo_map.policy.allowed",
+      "value": true,
+      "kind": "matrix_gap",
+      "reason": "The policy dimension is unexercised: no fixture sets a restrictive `context_egress` in its contract, so authorization is granted in every cell and the whole permission matrix reads as one value. Closing it needs a fixture whose contract denies a surface - not a bigger repo. Known hole, not a promise that policy cannot deny."
+    },
+    {
+      "path": "repo_map.policy.reason",
+      "value": "metadata-only local preflight packet",
+      "kind": "matrix_gap",
+      "reason": "The policy dimension is unexercised: no fixture sets a restrictive `context_egress` in its contract, so authorization is granted in every cell and the whole permission matrix reads as one value. Closing it needs a fixture whose contract denies a surface - not a bigger repo. Known hole, not a promise that policy cannot deny."
+    },
+    {
+      "path": "repo_map.readiness.schema_version",
+      "value": "drift.readiness.v1",
+      "kind": "payload_identity",
+      "reason": "Identity, not calibration: a repo-map readiness block reports surface `repo_map` in every cell because that is what it is. Pinned so a renamed surface or a bumped schema shows up."
+    },
+    {
+      "path": "repo_map.readiness.surface",
+      "value": "repo_map",
+      "kind": "payload_identity",
+      "reason": "Identity, not calibration: a repo-map readiness block reports surface `repo_map` in every cell because that is what it is. Pinned so a renamed surface or a bumped schema shows up."
+    },
+    {
+      "path": "repo_map.readiness.graph_available",
+      "value": true,
+      "kind": "environment",
+      "reason": "The engine produces a graph for every fixture here, so the degraded path never engages. The absent-graph branch is covered where it can be forced directly rather than by hoping a fixture fails to parse."
+    },
+    {
+      "path": "repo_map.readiness.graph_complete",
+      "value": true,
+      "kind": "environment",
+      "reason": "The engine produces a graph for every fixture here, so the degraded path never engages. The absent-graph branch is covered where it can be forced directly rather than by hoping a fixture fails to parse."
+    },
+    {
+      "path": "repo_map.readiness.required_capabilities[]",
+      "value": "fact_graph",
+      "kind": "payload_identity",
+      "reason": "The capability list a surface requires is a property of that surface, not of the repo it is reporting on. Pinned so a silently narrowed requirement shows up."
+    },
+    {
+      "path": "repo_map.governance.read_only",
+      "value": true,
+      "kind": "product_invariant",
+      "reason": "Every surface this gate drives is read-only by construction - check:surface-parity asserts zero storage writes in packages/mcp/src, and these CLI reads mutate nothing. If this ever varies, the STALE half of this gate fires and that is the intended alarm."
+    },
+    {
+      "path": "repo_map.governance.agent_can_mutate",
+      "value": false,
+      "kind": "product_invariant",
+      "reason": "Every surface this gate drives is read-only by construction - check:surface-parity asserts zero storage writes in packages/mcp/src, and these CLI reads mutate nothing. If this ever varies, the STALE half of this gate fires and that is the intended alarm."
+    },
+    {
+      "path": "repo_map.latest_scan.dirty",
+      "value": false,
+      "kind": "environment",
+      "reason": "Every scan in this matrix completes against a clean checkout, so the manifest reports the same state throughout. A failed or dirty scan is a different harness."
+    },
+    {
+      "path": "repo_map.latest_scan.status",
+      "value": "completed",
+      "kind": "environment",
+      "reason": "Every scan in this matrix completes against a clean checkout, so the manifest reports the same state throughout. A failed or dirty scan is a different harness."
+    },
+    {
+      "path": "repo_map.scan_status.latest_scan.dirty",
+      "value": false,
+      "kind": "environment",
+      "reason": "Every scan in this matrix completes against a clean checkout, so the manifest reports the same state throughout. A failed or dirty scan is a different harness."
+    },
+    {
+      "path": "repo_map.scan_status.latest_scan.status",
+      "value": "completed",
+      "kind": "environment",
+      "reason": "Every scan in this matrix completes against a clean checkout, so the manifest reports the same state throughout. A failed or dirty scan is a different harness."
+    },
+    {
+      "path": "repo_map.scan_status.governance.read_only",
+      "value": true,
+      "kind": "product_invariant",
+      "reason": "Every surface this gate drives is read-only by construction - check:surface-parity asserts zero storage writes in packages/mcp/src, and these CLI reads mutate nothing. If this ever varies, the STALE half of this gate fires and that is the intended alarm."
+    },
+    {
+      "path": "repo_map.scan_status.governance.agent_can_mutate",
+      "value": false,
+      "kind": "product_invariant",
+      "reason": "Every surface this gate drives is read-only by construction - check:surface-parity asserts zero storage writes in packages/mcp/src, and these CLI reads mutate nothing. If this ever varies, the STALE half of this gate fires and that is the intended alarm."
+    },
+    {
+      "path": "repo_map.scan_status.summary.audit_valid",
+      "value": true,
+      "kind": "matrix_gap",
+      "reason": "The audit chain verifies in every cell because nothing tampers with it. Making this false means corrupting a hash-linked log on purpose, which the storage suite does directly; this matrix only ever builds intact ones."
+    },
+    {
+      "path": "repo_map.scan_status.audit_integrity.valid",
+      "value": true,
+      "kind": "matrix_gap",
+      "reason": "The audit chain verifies in every cell because nothing tampers with it. Making this false means corrupting a hash-linked log on purpose, which the storage suite does directly; this matrix only ever builds intact ones."
+    },
+    {
+      "path": "repo_map.scan_status.readiness.schema_version",
+      "value": "drift.readiness.v1",
+      "kind": "payload_identity",
+      "reason": "Identity, not calibration: a repo-map readiness block reports surface `repo_map` in every cell because that is what it is. Pinned so a renamed surface or a bumped schema shows up."
+    },
+    {
+      "path": "repo_map.scan_status.readiness.surface",
+      "value": "scan_status",
+      "kind": "payload_identity",
+      "reason": "Identity, not calibration: a repo-map readiness block reports surface `repo_map` in every cell because that is what it is. Pinned so a renamed surface or a bumped schema shows up."
+    },
+    {
+      "path": "repo_map.scan_status.readiness.graph_available",
+      "value": true,
+      "kind": "environment",
+      "reason": "The engine produces a graph for every fixture here, so the degraded path never engages. The absent-graph branch is covered where it can be forced directly rather than by hoping a fixture fails to parse."
+    },
+    {
+      "path": "repo_map.scan_status.readiness.graph_complete",
+      "value": true,
+      "kind": "environment",
+      "reason": "The engine produces a graph for every fixture here, so the degraded path never engages. The absent-graph branch is covered where it can be forced directly rather than by hoping a fixture fails to parse."
+    },
+    {
+      "path": "repo_map.scan_status.readiness.required_capabilities[]",
+      "value": "fact_graph",
+      "kind": "payload_identity",
+      "reason": "The capability list a surface requires is a property of that surface, not of the repo it is reporting on. Pinned so a silently narrowed requirement shows up."
+    },
+    {
+      "path": "repo_map.scan_status.capability_report.engine_source",
+      "value": "rust",
+      "kind": "environment",
+      "reason": "Fixed by the environment this gate runs in: the engine binary is always present, so the TypeScript fallback never engages. external-eval asserts the same two fields against the real corpus, where a fallback would be a genuine regression."
+    },
+    {
+      "path": "repo_map.scan_status.capability_report.completeness[].can_block",
+      "value": true,
+      "kind": "matrix_gap",
+      "reason": "The policy dimension is unexercised: no fixture sets a restrictive `context_egress` in its contract, so authorization is granted in every cell and the whole permission matrix reads as one value. Closing it needs a fixture whose contract denies a surface - not a bigger repo. Known hole, not a promise that policy cannot deny."
+    },
+    {
+      "path": "repo_map.scan_status.capability_report.fallback_used",
+      "value": false,
+      "kind": "environment",
+      "reason": "Fixed by the environment this gate runs in: the engine binary is always present, so the TypeScript fallback never engages. external-eval asserts the same two fields against the real corpus, where a fallback would be a genuine regression."
+    },
+    {
+      "path": "repo_map.scan_status.capability_report.enforcement_degraded",
+      "value": false,
+      "kind": "environment",
+      "reason": "Fixed by the environment this gate runs in: the engine binary is always present, so the TypeScript fallback never engages. external-eval asserts the same two fields against the real corpus, where a fallback would be a genuine regression."
+    },
+    {
+      "path": "repo_map.pagination.has_more",
+      "value": false,
+      "kind": "matrix_gap",
+      "reason": "Constant at false across the matrix, and not yet explained. Either the matrix lacks the state that moves it, or the field is frozen and this gate has found one."
+    },
+    {
+      "path": "repo_map.routes[].security.proof_status",
+      "value": "unknown",
+      "kind": "matrix_gap",
+      "reason": "Security boundary proofs are produced by `check`, which this matrix does not run, so route trust reports `none`/`unknown` throughout. These are exactly the D-A2 fields the CLI used to omit, so the hole is worth naming: they are present and correct, and only one of their values is exercised."
+    },
+    {
+      "path": "repo_map.proof_freshness",
+      "value": "none",
+      "kind": "matrix_gap",
+      "reason": "Security boundary proofs are produced by `check`, which this matrix does not run, so route trust reports `none`/`unknown` throughout. These are exactly the D-A2 fields the CLI used to omit, so the hole is worth naming: they are present and correct, and only one of their values is exercised."
+    },
+    {
+      "path": "repo_map.freshness_requirement.required",
+      "value": false,
+      "kind": "matrix_gap",
+      "reason": "Constant at false across the matrix, and not yet explained. Either the matrix lacks the state that moves it, or the field is frozen and this gate has found one."
+    },
+    {
+      "path": "repo_map.files[].indexed",
+      "value": true,
+      "kind": "matrix_gap",
+      "reason": "Constant at true across the matrix, and not yet explained. Either the matrix lacks the state that moves it, or the field is frozen and this gate has found one."
+    },
+    {
+      "path": "repo_map.redactions.snippets_included",
+      "value": false,
+      "kind": "product_invariant",
+      "reason": "Drift ships metadata about code, never the code. These are the fields that say so, and they are false on every surface deliberately rather than incidentally."
+    },
+    {
+      "path": "repo_map.redactions.source_content_included",
+      "value": false,
+      "kind": "product_invariant",
+      "reason": "Drift ships metadata about code, never the code. These are the fields that say so, and they are false on every surface deliberately rather than incidentally."
+    },
+    {
+      "path": "repo_map.redactions.graph_context_included",
+      "value": true,
+      "kind": "product_invariant",
+      "reason": "Drift ships metadata about code, never the code. These are the fields that say so, and they are false on every surface deliberately rather than incidentally."
+    },
+    {
+      "path": "repo_map.redactions.context_truncated",
+      "value": false,
+      "kind": "matrix_gap",
+      "reason": "NOT a guarantee - the matrix never truncates. Truncation needs a guidance view over the 32,768-byte budget, which takes roughly 60 realistically-sized conventions; the largest fixture here produces three. This is the exact field D-M5 found hardcoded to false, so it is recorded as a known hole rather than as a property. Closing it needs a fixture built for the budget, not a bigger repo."
+    },
+    {
+      "path": "scan_status.latest_scan.dirty",
+      "value": false,
+      "kind": "environment",
+      "reason": "Every scan in this matrix completes against a clean checkout, so the manifest reports the same state throughout. A failed or dirty scan is a different harness."
+    },
+    {
+      "path": "scan_status.latest_scan.status",
+      "value": "completed",
+      "kind": "environment",
+      "reason": "Every scan in this matrix completes against a clean checkout, so the manifest reports the same state throughout. A failed or dirty scan is a different harness."
+    },
+    {
+      "path": "scan_status.governance.read_only",
+      "value": true,
+      "kind": "product_invariant",
+      "reason": "Every surface this gate drives is read-only by construction - check:surface-parity asserts zero storage writes in packages/mcp/src, and these CLI reads mutate nothing. If this ever varies, the STALE half of this gate fires and that is the intended alarm."
+    },
+    {
+      "path": "scan_status.governance.agent_can_mutate",
+      "value": false,
+      "kind": "product_invariant",
+      "reason": "Every surface this gate drives is read-only by construction - check:surface-parity asserts zero storage writes in packages/mcp/src, and these CLI reads mutate nothing. If this ever varies, the STALE half of this gate fires and that is the intended alarm."
+    },
+    {
+      "path": "scan_status.summary.audit_valid",
+      "value": true,
+      "kind": "matrix_gap",
+      "reason": "The audit chain verifies in every cell because nothing tampers with it. Making this false means corrupting a hash-linked log on purpose, which the storage suite does directly; this matrix only ever builds intact ones."
+    },
+    {
+      "path": "scan_status.audit_integrity.valid",
+      "value": true,
+      "kind": "matrix_gap",
+      "reason": "The audit chain verifies in every cell because nothing tampers with it. Making this false means corrupting a hash-linked log on purpose, which the storage suite does directly; this matrix only ever builds intact ones."
+    },
+    {
+      "path": "scan_status.readiness.schema_version",
+      "value": "drift.readiness.v1",
+      "kind": "payload_identity",
+      "reason": "Identity, not calibration: a repo-map readiness block reports surface `repo_map` in every cell because that is what it is. Pinned so a renamed surface or a bumped schema shows up."
+    },
+    {
+      "path": "scan_status.readiness.surface",
+      "value": "scan_status",
+      "kind": "payload_identity",
+      "reason": "Identity, not calibration: a repo-map readiness block reports surface `repo_map` in every cell because that is what it is. Pinned so a renamed surface or a bumped schema shows up."
+    },
+    {
+      "path": "scan_status.readiness.graph_available",
+      "value": true,
+      "kind": "environment",
+      "reason": "The engine produces a graph for every fixture here, so the degraded path never engages. The absent-graph branch is covered where it can be forced directly rather than by hoping a fixture fails to parse."
+    },
+    {
+      "path": "scan_status.readiness.graph_complete",
+      "value": true,
+      "kind": "environment",
+      "reason": "The engine produces a graph for every fixture here, so the degraded path never engages. The absent-graph branch is covered where it can be forced directly rather than by hoping a fixture fails to parse."
+    },
+    {
+      "path": "scan_status.readiness.required_capabilities[]",
+      "value": "fact_graph",
+      "kind": "payload_identity",
+      "reason": "The capability list a surface requires is a property of that surface, not of the repo it is reporting on. Pinned so a silently narrowed requirement shows up."
+    },
+    {
+      "path": "scan_status.capability_report.engine_source",
+      "value": "rust",
+      "kind": "environment",
+      "reason": "Fixed by the environment this gate runs in: the engine binary is always present, so the TypeScript fallback never engages. external-eval asserts the same two fields against the real corpus, where a fallback would be a genuine regression."
+    },
+    {
+      "path": "scan_status.capability_report.completeness[].can_block",
+      "value": true,
+      "kind": "matrix_gap",
+      "reason": "The policy dimension is unexercised: no fixture sets a restrictive `context_egress` in its contract, so authorization is granted in every cell and the whole permission matrix reads as one value. Closing it needs a fixture whose contract denies a surface - not a bigger repo. Known hole, not a promise that policy cannot deny."
+    },
+    {
+      "path": "scan_status.capability_report.fallback_used",
+      "value": false,
+      "kind": "environment",
+      "reason": "Fixed by the environment this gate runs in: the engine binary is always present, so the TypeScript fallback never engages. external-eval asserts the same two fields against the real corpus, where a fallback would be a genuine regression."
+    },
+    {
+      "path": "scan_status.capability_report.enforcement_degraded",
+      "value": false,
+      "kind": "environment",
+      "reason": "Fixed by the environment this gate runs in: the engine binary is always present, so the TypeScript fallback never engages. external-eval asserts the same two fields against the real corpus, where a fallback would be a genuine regression."
+    },
+    {
+      "path": "preflight.guidance.truncated.conventions",
+      "value": false,
+      "kind": "matrix_gap",
+      "reason": "NOT a guarantee - the matrix never truncates. Truncation needs a guidance view over the 32,768-byte budget, which takes roughly 60 realistically-sized conventions; the largest fixture here produces three. This is the exact field D-M5 found hardcoded to false, so it is recorded as a known hole rather than as a property. Closing it needs a fixture built for the budget, not a bigger repo."
+    },
+    {
+      "path": "preflight.guidance.truncated.relevant_files",
+      "value": false,
+      "kind": "matrix_gap",
+      "reason": "NOT a guarantee - the matrix never truncates. Truncation needs a guidance view over the 32,768-byte budget, which takes roughly 60 realistically-sized conventions; the largest fixture here produces three. This is the exact field D-M5 found hardcoded to false, so it is recorded as a known hole rather than as a property. Closing it needs a fixture built for the budget, not a bigger repo."
+    },
+    {
+      "path": "preflight.guidance.truncated.required_checks",
+      "value": false,
+      "kind": "matrix_gap",
+      "reason": "NOT a guarantee - the matrix never truncates. Truncation needs a guidance view over the 32,768-byte budget, which takes roughly 60 realistically-sized conventions; the largest fixture here produces three. This is the exact field D-M5 found hardcoded to false, so it is recorded as a known hole rather than as a property. Closing it needs a fixture built for the budget, not a bigger repo."
+    },
+    {
+      "path": "preflight.agent_envelope.read_only",
+      "value": true,
+      "kind": "product_invariant",
+      "reason": "Every surface this gate drives is read-only by construction - check:surface-parity asserts zero storage writes in packages/mcp/src, and these CLI reads mutate nothing. If this ever varies, the STALE half of this gate fires and that is the intended alarm."
+    },
+    {
+      "path": "preflight.agent_envelope.policy.allowed",
+      "value": true,
+      "kind": "matrix_gap",
+      "reason": "The policy dimension is unexercised: no fixture sets a restrictive `context_egress` in its contract, so authorization is granted in every cell and the whole permission matrix reads as one value. Closing it needs a fixture whose contract denies a surface - not a bigger repo. Known hole, not a promise that policy cannot deny."
+    },
+    {
+      "path": "preflight.agent_envelope.policy.reason",
+      "value": "metadata-only local preflight packet",
+      "kind": "matrix_gap",
+      "reason": "The policy dimension is unexercised: no fixture sets a restrictive `context_egress` in its contract, so authorization is granted in every cell and the whole permission matrix reads as one value. Closing it needs a fixture whose contract denies a surface - not a bigger repo. Known hole, not a promise that policy cannot deny."
+    },
+    {
+      "path": "preflight.agent_envelope.redactions.snippets_included",
+      "value": false,
+      "kind": "product_invariant",
+      "reason": "Drift ships metadata about code, never the code. These are the fields that say so, and they are false on every surface deliberately rather than incidentally."
+    },
+    {
+      "path": "preflight.agent_envelope.redactions.context_truncated",
+      "value": false,
+      "kind": "matrix_gap",
+      "reason": "NOT a guarantee - the matrix never truncates. Truncation needs a guidance view over the 32,768-byte budget, which takes roughly 60 realistically-sized conventions; the largest fixture here produces three. This is the exact field D-M5 found hardcoded to false, so it is recorded as a known hole rather than as a property. Closing it needs a fixture built for the budget, not a bigger repo."
+    },
+    {
+      "path": "preflight.agent_envelope.policy_proof.allowed",
+      "value": true,
+      "kind": "matrix_gap",
+      "reason": "The policy dimension is unexercised: no fixture sets a restrictive `context_egress` in its contract, so authorization is granted in every cell and the whole permission matrix reads as one value. Closing it needs a fixture whose contract denies a surface - not a bigger repo. Known hole, not a promise that policy cannot deny."
+    },
+    {
+      "path": "preflight.agent_envelope.policy_proof.reason",
+      "value": "metadata-only local preflight packet",
+      "kind": "matrix_gap",
+      "reason": "The policy dimension is unexercised: no fixture sets a restrictive `context_egress` in its contract, so authorization is granted in every cell and the whole permission matrix reads as one value. Closing it needs a fixture whose contract denies a surface - not a bigger repo. Known hole, not a promise that policy cannot deny."
+    },
+    {
+      "path": "preflight.agent_envelope.policy_proof.snippets_included",
+      "value": false,
+      "kind": "product_invariant",
+      "reason": "Drift ships metadata about code, never the code. These are the fields that say so, and they are false on every surface deliberately rather than incidentally."
+    },
+    {
+      "path": "preflight.agent_envelope.policy_proof.source_content_included",
+      "value": false,
+      "kind": "product_invariant",
+      "reason": "Drift ships metadata about code, never the code. These are the fields that say so, and they are false on every surface deliberately rather than incidentally."
+    },
+    {
+      "path": "preflight.agent_envelope.policy_proof.context_truncated",
+      "value": false,
+      "kind": "matrix_gap",
+      "reason": "NOT a guarantee - the matrix never truncates. Truncation needs a guidance view over the 32,768-byte budget, which takes roughly 60 realistically-sized conventions; the largest fixture here produces three. This is the exact field D-M5 found hardcoded to false, so it is recorded as a known hole rather than as a property. Closing it needs a fixture built for the budget, not a bigger repo."
+    },
+    {
+      "path": "preflight.policy.allowed",
+      "value": true,
+      "kind": "matrix_gap",
+      "reason": "The policy dimension is unexercised: no fixture sets a restrictive `context_egress` in its contract, so authorization is granted in every cell and the whole permission matrix reads as one value. Closing it needs a fixture whose contract denies a surface - not a bigger repo. Known hole, not a promise that policy cannot deny."
+    },
+    {
+      "path": "preflight.policy.reason",
+      "value": "metadata-only local preflight packet",
+      "kind": "matrix_gap",
+      "reason": "The policy dimension is unexercised: no fixture sets a restrictive `context_egress` in its contract, so authorization is granted in every cell and the whole permission matrix reads as one value. Closing it needs a fixture whose contract denies a surface - not a bigger repo. Known hole, not a promise that policy cannot deny."
+    },
+    {
+      "path": "preflight.readiness.schema_version",
+      "value": "drift.readiness.v1",
+      "kind": "payload_identity",
+      "reason": "Identity, not calibration: a repo-map readiness block reports surface `repo_map` in every cell because that is what it is. Pinned so a renamed surface or a bumped schema shows up."
+    },
+    {
+      "path": "preflight.readiness.surface",
+      "value": "prepare",
+      "kind": "payload_identity",
+      "reason": "Identity, not calibration: a repo-map readiness block reports surface `repo_map` in every cell because that is what it is. Pinned so a renamed surface or a bumped schema shows up."
+    },
+    {
+      "path": "preflight.readiness.graph_available",
+      "value": true,
+      "kind": "environment",
+      "reason": "The engine produces a graph for every fixture here, so the degraded path never engages. The absent-graph branch is covered where it can be forced directly rather than by hoping a fixture fails to parse."
+    },
+    {
+      "path": "preflight.readiness.required_capabilities[]",
+      "value": "route_flow",
+      "kind": "payload_identity",
+      "reason": "The capability list a surface requires is a property of that surface, not of the repo it is reporting on. Pinned so a silently narrowed requirement shows up."
+    },
+    {
+      "path": "preflight.audit_integrity.valid",
+      "value": true,
+      "kind": "matrix_gap",
+      "reason": "The audit chain verifies in every cell because nothing tampers with it. Making this false means corrupting a hash-linked log on purpose, which the storage suite does directly; this matrix only ever builds intact ones."
+    },
+    {
+      "path": "preflight.scan_status.governance.read_only",
+      "value": true,
+      "kind": "product_invariant",
+      "reason": "Every surface this gate drives is read-only by construction - check:surface-parity asserts zero storage writes in packages/mcp/src, and these CLI reads mutate nothing. If this ever varies, the STALE half of this gate fires and that is the intended alarm."
+    },
+    {
+      "path": "preflight.scan_status.governance.agent_can_mutate",
+      "value": false,
+      "kind": "product_invariant",
+      "reason": "Every surface this gate drives is read-only by construction - check:surface-parity asserts zero storage writes in packages/mcp/src, and these CLI reads mutate nothing. If this ever varies, the STALE half of this gate fires and that is the intended alarm."
+    },
+    {
+      "path": "preflight.scan_status.latest_scan.dirty",
+      "value": false,
+      "kind": "environment",
+      "reason": "Every scan in this matrix completes against a clean checkout, so the manifest reports the same state throughout. A failed or dirty scan is a different harness."
+    },
+    {
+      "path": "preflight.scan_status.latest_scan.status",
+      "value": "completed",
+      "kind": "environment",
+      "reason": "Every scan in this matrix completes against a clean checkout, so the manifest reports the same state throughout. A failed or dirty scan is a different harness."
+    },
+    {
+      "path": "preflight.scan_status.audit_integrity.valid",
+      "value": true,
+      "kind": "matrix_gap",
+      "reason": "The audit chain verifies in every cell because nothing tampers with it. Making this false means corrupting a hash-linked log on purpose, which the storage suite does directly; this matrix only ever builds intact ones."
+    },
+    {
+      "path": "preflight.scan_status.summary.audit_valid",
+      "value": true,
+      "kind": "matrix_gap",
+      "reason": "The audit chain verifies in every cell because nothing tampers with it. Making this false means corrupting a hash-linked log on purpose, which the storage suite does directly; this matrix only ever builds intact ones."
+    },
+    {
+      "path": "preflight.scan_status.readiness.schema_version",
+      "value": "drift.readiness.v1",
+      "kind": "payload_identity",
+      "reason": "Identity, not calibration: a repo-map readiness block reports surface `repo_map` in every cell because that is what it is. Pinned so a renamed surface or a bumped schema shows up."
+    },
+    {
+      "path": "preflight.scan_status.readiness.surface",
+      "value": "scan_status",
+      "kind": "payload_identity",
+      "reason": "Identity, not calibration: a repo-map readiness block reports surface `repo_map` in every cell because that is what it is. Pinned so a renamed surface or a bumped schema shows up."
+    },
+    {
+      "path": "preflight.scan_status.readiness.graph_available",
+      "value": true,
+      "kind": "environment",
+      "reason": "The engine produces a graph for every fixture here, so the degraded path never engages. The absent-graph branch is covered where it can be forced directly rather than by hoping a fixture fails to parse."
+    },
+    {
+      "path": "preflight.scan_status.readiness.graph_complete",
+      "value": true,
+      "kind": "environment",
+      "reason": "The engine produces a graph for every fixture here, so the degraded path never engages. The absent-graph branch is covered where it can be forced directly rather than by hoping a fixture fails to parse."
+    },
+    {
+      "path": "preflight.scan_status.readiness.required_capabilities[]",
+      "value": "fact_graph",
+      "kind": "payload_identity",
+      "reason": "The capability list a surface requires is a property of that surface, not of the repo it is reporting on. Pinned so a silently narrowed requirement shows up."
+    },
+    {
+      "path": "preflight.scan_status.capability_report.engine_source",
+      "value": "rust",
+      "kind": "environment",
+      "reason": "Fixed by the environment this gate runs in: the engine binary is always present, so the TypeScript fallback never engages. external-eval asserts the same two fields against the real corpus, where a fallback would be a genuine regression."
+    },
+    {
+      "path": "preflight.scan_status.capability_report.completeness[].can_block",
+      "value": true,
+      "kind": "matrix_gap",
+      "reason": "The policy dimension is unexercised: no fixture sets a restrictive `context_egress` in its contract, so authorization is granted in every cell and the whole permission matrix reads as one value. Closing it needs a fixture whose contract denies a surface - not a bigger repo. Known hole, not a promise that policy cannot deny."
+    },
+    {
+      "path": "preflight.scan_status.capability_report.fallback_used",
+      "value": false,
+      "kind": "environment",
+      "reason": "Fixed by the environment this gate runs in: the engine binary is always present, so the TypeScript fallback never engages. external-eval asserts the same two fields against the real corpus, where a fallback would be a genuine regression."
+    },
+    {
+      "path": "preflight.scan_status.capability_report.enforcement_degraded",
+      "value": false,
+      "kind": "environment",
+      "reason": "Fixed by the environment this gate runs in: the engine binary is always present, so the TypeScript fallback never engages. external-eval asserts the same two fields against the real corpus, where a fallback would be a genuine regression."
+    },
+    {
+      "path": "preflight.graph_context.available",
+      "value": true,
+      "kind": "matrix_gap",
+      "reason": "Constant at true across the matrix, and not yet explained. Either the matrix lacks the state that moves it, or the field is frozen and this gate has found one."
+    },
+    {
+      "path": "preflight.graph_context.diagnostic_summary.policy.local_only",
+      "value": true,
+      "kind": "matrix_gap",
+      "reason": "The policy dimension is unexercised: no fixture sets a restrictive `context_egress` in its contract, so authorization is granted in every cell and the whole permission matrix reads as one value. Closing it needs a fixture whose contract denies a surface - not a bigger repo. Known hole, not a promise that policy cannot deny."
+    },
+    {
+      "path": "preflight.task_model.human_approval_needed",
+      "value": false,
+      "kind": "matrix_gap",
+      "reason": "Constant at false across the matrix, and not yet explained. Either the matrix lacks the state that moves it, or the field is frozen and this gate has found one."
+    },
+    {
+      "path": "preflight.task_preflight_packet.task_model.human_approval_needed",
+      "value": false,
+      "kind": "matrix_gap",
+      "reason": "Constant at false across the matrix, and not yet explained. Either the matrix lacks the state that moves it, or the field is frozen and this gate has found one."
+    },
+    {
+      "path": "preflight.task_preflight_packet.context_policy.can_read_repo_map",
+      "value": true,
+      "kind": "matrix_gap",
+      "reason": "The policy dimension is unexercised: no fixture sets a restrictive `context_egress` in its contract, so authorization is granted in every cell and the whole permission matrix reads as one value. Closing it needs a fixture whose contract denies a surface - not a bigger repo. Known hole, not a promise that policy cannot deny."
+    },
+    {
+      "path": "preflight.task_preflight_packet.context_policy.can_read_source_snippets",
+      "value": false,
+      "kind": "matrix_gap",
+      "reason": "The policy dimension is unexercised: no fixture sets a restrictive `context_egress` in its contract, so authorization is granted in every cell and the whole permission matrix reads as one value. Closing it needs a fixture whose contract denies a surface - not a bigger repo. Known hole, not a promise that policy cannot deny."
+    },
+    {
+      "path": "preflight.task_preflight_packet.context_policy.can_read_contract",
+      "value": true,
+      "kind": "matrix_gap",
+      "reason": "The policy dimension is unexercised: no fixture sets a restrictive `context_egress` in its contract, so authorization is granted in every cell and the whole permission matrix reads as one value. Closing it needs a fixture whose contract denies a surface - not a bigger repo. Known hole, not a promise that policy cannot deny."
+    },
+    {
+      "path": "preflight.task_preflight_packet.context_policy.can_read_findings",
+      "value": true,
+      "kind": "matrix_gap",
+      "reason": "The policy dimension is unexercised: no fixture sets a restrictive `context_egress` in its contract, so authorization is granted in every cell and the whole permission matrix reads as one value. Closing it needs a fixture whose contract denies a surface - not a bigger repo. Known hole, not a promise that policy cannot deny."
+    },
+    {
+      "path": "preflight.task_preflight_packet.context_policy.can_execute_commands",
+      "value": false,
+      "kind": "matrix_gap",
+      "reason": "The policy dimension is unexercised: no fixture sets a restrictive `context_egress` in its contract, so authorization is granted in every cell and the whole permission matrix reads as one value. Closing it needs a fixture whose contract denies a surface - not a bigger repo. Known hole, not a promise that policy cannot deny."
+    },
+    {
+      "path": "preflight.task_preflight_packet.context_policy.can_modify_contract",
+      "value": false,
+      "kind": "matrix_gap",
+      "reason": "The policy dimension is unexercised: no fixture sets a restrictive `context_egress` in its contract, so authorization is granted in every cell and the whole permission matrix reads as one value. Closing it needs a fixture whose contract denies a surface - not a bigger repo. Known hole, not a promise that policy cannot deny."
+    },
+    {
+      "path": "preflight.task_preflight_packet.context_policy.can_create_waiver",
+      "value": false,
+      "kind": "matrix_gap",
+      "reason": "The policy dimension is unexercised: no fixture sets a restrictive `context_egress` in its contract, so authorization is granted in every cell and the whole permission matrix reads as one value. Closing it needs a fixture whose contract denies a surface - not a bigger repo. Known hole, not a promise that policy cannot deny."
+    },
+    {
+      "path": "preflight.task_preflight_packet.context_policy.can_request_human_approval",
+      "value": true,
+      "kind": "matrix_gap",
+      "reason": "The policy dimension is unexercised: no fixture sets a restrictive `context_egress` in its contract, so authorization is granted in every cell and the whole permission matrix reads as one value. Closing it needs a fixture whose contract denies a surface - not a bigger repo. Known hole, not a promise that policy cannot deny."
+    },
+    {
+      "path": "preflight.task_preflight_packet.context_policy.can_access_secret_like_files",
+      "value": false,
+      "kind": "matrix_gap",
+      "reason": "The policy dimension is unexercised: no fixture sets a restrictive `context_egress` in its contract, so authorization is granted in every cell and the whole permission matrix reads as one value. Closing it needs a fixture whose contract denies a surface - not a bigger repo. Known hole, not a promise that policy cannot deny."
+    },
+    {
+      "path": "preflight.task_preflight_packet.context_policy.can_emit_patch",
+      "value": false,
+      "kind": "matrix_gap",
+      "reason": "The policy dimension is unexercised: no fixture sets a restrictive `context_egress` in its contract, so authorization is granted in every cell and the whole permission matrix reads as one value. Closing it needs a fixture whose contract denies a surface - not a bigger repo. Known hole, not a promise that policy cannot deny."
+    },
+    {
+      "path": "preflight.agent_contract_packet.selected_contracts_reason",
+      "value": "no_contracts_accepted",
+      "kind": "matrix_gap",
+      "reason": "`no_contracts_accepted` in every cell because no fixture carries an AGENT contract - a different object from the repo contract the accept step materializes. Closing it needs a fixture with one; until then this field's other values are unexercised here."
+    },
+    {
+      "path": "preflight.governance.read_only",
+      "value": true,
+      "kind": "product_invariant",
+      "reason": "Every surface this gate drives is read-only by construction - check:surface-parity asserts zero storage writes in packages/mcp/src, and these CLI reads mutate nothing. If this ever varies, the STALE half of this gate fires and that is the intended alarm."
+    },
+    {
+      "path": "preflight.governance.agent_can_mutate",
+      "value": false,
+      "kind": "product_invariant",
+      "reason": "Every surface this gate drives is read-only by construction - check:surface-parity asserts zero storage writes in packages/mcp/src, and these CLI reads mutate nothing. If this ever varies, the STALE half of this gate fires and that is the intended alarm."
+    },
+    {
+      "path": "preflight.context_policy.can_read_repo_map",
+      "value": true,
+      "kind": "matrix_gap",
+      "reason": "The policy dimension is unexercised: no fixture sets a restrictive `context_egress` in its contract, so authorization is granted in every cell and the whole permission matrix reads as one value. Closing it needs a fixture whose contract denies a surface - not a bigger repo. Known hole, not a promise that policy cannot deny."
+    },
+    {
+      "path": "preflight.context_policy.can_read_source_snippets",
+      "value": false,
+      "kind": "matrix_gap",
+      "reason": "The policy dimension is unexercised: no fixture sets a restrictive `context_egress` in its contract, so authorization is granted in every cell and the whole permission matrix reads as one value. Closing it needs a fixture whose contract denies a surface - not a bigger repo. Known hole, not a promise that policy cannot deny."
+    },
+    {
+      "path": "preflight.context_policy.can_read_contract",
+      "value": true,
+      "kind": "matrix_gap",
+      "reason": "The policy dimension is unexercised: no fixture sets a restrictive `context_egress` in its contract, so authorization is granted in every cell and the whole permission matrix reads as one value. Closing it needs a fixture whose contract denies a surface - not a bigger repo. Known hole, not a promise that policy cannot deny."
+    },
+    {
+      "path": "preflight.context_policy.can_read_findings",
+      "value": true,
+      "kind": "matrix_gap",
+      "reason": "The policy dimension is unexercised: no fixture sets a restrictive `context_egress` in its contract, so authorization is granted in every cell and the whole permission matrix reads as one value. Closing it needs a fixture whose contract denies a surface - not a bigger repo. Known hole, not a promise that policy cannot deny."
+    },
+    {
+      "path": "preflight.context_policy.can_execute_commands",
+      "value": false,
+      "kind": "matrix_gap",
+      "reason": "The policy dimension is unexercised: no fixture sets a restrictive `context_egress` in its contract, so authorization is granted in every cell and the whole permission matrix reads as one value. Closing it needs a fixture whose contract denies a surface - not a bigger repo. Known hole, not a promise that policy cannot deny."
+    },
+    {
+      "path": "preflight.context_policy.can_modify_contract",
+      "value": false,
+      "kind": "matrix_gap",
+      "reason": "The policy dimension is unexercised: no fixture sets a restrictive `context_egress` in its contract, so authorization is granted in every cell and the whole permission matrix reads as one value. Closing it needs a fixture whose contract denies a surface - not a bigger repo. Known hole, not a promise that policy cannot deny."
+    },
+    {
+      "path": "preflight.context_policy.can_create_waiver",
+      "value": false,
+      "kind": "matrix_gap",
+      "reason": "The policy dimension is unexercised: no fixture sets a restrictive `context_egress` in its contract, so authorization is granted in every cell and the whole permission matrix reads as one value. Closing it needs a fixture whose contract denies a surface - not a bigger repo. Known hole, not a promise that policy cannot deny."
+    },
+    {
+      "path": "preflight.context_policy.can_request_human_approval",
+      "value": true,
+      "kind": "matrix_gap",
+      "reason": "The policy dimension is unexercised: no fixture sets a restrictive `context_egress` in its contract, so authorization is granted in every cell and the whole permission matrix reads as one value. Closing it needs a fixture whose contract denies a surface - not a bigger repo. Known hole, not a promise that policy cannot deny."
+    },
+    {
+      "path": "preflight.context_policy.can_access_secret_like_files",
+      "value": false,
+      "kind": "matrix_gap",
+      "reason": "The policy dimension is unexercised: no fixture sets a restrictive `context_egress` in its contract, so authorization is granted in every cell and the whole permission matrix reads as one value. Closing it needs a fixture whose contract denies a surface - not a bigger repo. Known hole, not a promise that policy cannot deny."
+    },
+    {
+      "path": "preflight.context_policy.can_emit_patch",
+      "value": false,
+      "kind": "matrix_gap",
+      "reason": "The policy dimension is unexercised: no fixture sets a restrictive `context_egress` in its contract, so authorization is granted in every cell and the whole permission matrix reads as one value. Closing it needs a fixture whose contract denies a surface - not a bigger repo. Known hole, not a promise that policy cannot deny."
+    },
+    {
+      "path": "preflight.redactions.snippets_included",
+      "value": false,
+      "kind": "product_invariant",
+      "reason": "Drift ships metadata about code, never the code. These are the fields that say so, and they are false on every surface deliberately rather than incidentally."
+    },
+    {
+      "path": "preflight.redactions.source_content_included",
+      "value": false,
+      "kind": "product_invariant",
+      "reason": "Drift ships metadata about code, never the code. These are the fields that say so, and they are false on every surface deliberately rather than incidentally."
+    },
+    {
+      "path": "preflight.redactions.graph_context_included",
+      "value": true,
+      "kind": "product_invariant",
+      "reason": "Drift ships metadata about code, never the code. These are the fields that say so, and they are false on every surface deliberately rather than incidentally."
+    },
+    {
+      "path": "preflight.redactions.context_truncated",
+      "value": false,
+      "kind": "matrix_gap",
+      "reason": "NOT a guarantee - the matrix never truncates. Truncation needs a guidance view over the 32,768-byte budget, which takes roughly 60 realistically-sized conventions; the largest fixture here produces three. This is the exact field D-M5 found hardcoded to false, so it is recorded as a known hole rather than as a property. Closing it needs a fixture built for the budget, not a bigger repo."
+    },
+    {
+      "path": "prepare.guidance.required_checks[].reason",
+      "value": "Block newly introduced deterministic convention violations before code is merged.",
+      "kind": "payload_identity",
+      "reason": "The default contract's own wording. Every fixture materializes the same default checks and risky areas, so the sentence explaining each is the same sentence. Pinned so a reworded rationale is visible rather than silent."
+    },
+    {
+      "path": "prepare.graph_context.route_flows[].policy.local_only",
+      "value": true,
+      "kind": "matrix_gap",
+      "reason": "The policy dimension is unexercised: no fixture sets a restrictive `context_egress` in its contract, so authorization is granted in every cell and the whole permission matrix reads as one value. Closing it needs a fixture whose contract denies a surface - not a bigger repo. Known hole, not a promise that policy cannot deny."
+    },
+    {
+      "path": "prepare.graph_context.route_flows[].complete",
+      "value": true,
+      "kind": "matrix_gap",
+      "reason": "Constant at true across the matrix, and not yet explained. Either the matrix lacks the state that moves it, or the field is frozen and this gate has found one."
+    },
+    {
+      "path": "prepare.graph_context.reachable_data_access[].policy.local_only",
+      "value": true,
+      "kind": "matrix_gap",
+      "reason": "The policy dimension is unexercised: no fixture sets a restrictive `context_egress` in its contract, so authorization is granted in every cell and the whole permission matrix reads as one value. Closing it needs a fixture whose contract denies a surface - not a bigger repo. Known hole, not a promise that policy cannot deny."
+    },
+    {
+      "path": "prepare.graph_context.affected_files[].policy.local_only",
+      "value": true,
+      "kind": "matrix_gap",
+      "reason": "The policy dimension is unexercised: no fixture sets a restrictive `context_egress` in its contract, so authorization is granted in every cell and the whole permission matrix reads as one value. Closing it needs a fixture whose contract denies a surface - not a bigger repo. Known hole, not a promise that policy cannot deny."
+    },
+    {
+      "path": "prepare.task_preflight_packet.required_checks[].reason",
+      "value": "Block newly introduced deterministic convention violations before code is merged.",
+      "kind": "payload_identity",
+      "reason": "The default contract's own wording. Every fixture materializes the same default checks and risky areas, so the sentence explaining each is the same sentence. Pinned so a reworded rationale is visible rather than silent."
+    },
+    {
+      "path": "prepare.risky_areas[].reason",
+      "value": "API route changes can bypass the accepted data-access layering convention.",
+      "kind": "payload_identity",
+      "reason": "The default contract's own wording. Every fixture materializes the same default checks and risky areas, so the sentence explaining each is the same sentence. Pinned so a reworded rationale is visible rather than silent."
+    },
+    {
+      "path": "prepare.required_checks[].reason",
+      "value": "Block newly introduced deterministic convention violations before code is merged.",
+      "kind": "payload_identity",
+      "reason": "The default contract's own wording. Every fixture materializes the same default checks and risky areas, so the sentence explaining each is the same sentence. Pinned so a reworded rationale is visible rather than silent."
+    },
+    {
+      "path": "preflight.guidance.required_checks[].reason",
+      "value": "Block newly introduced deterministic convention violations before code is merged.",
+      "kind": "payload_identity",
+      "reason": "The default contract's own wording. Every fixture materializes the same default checks and risky areas, so the sentence explaining each is the same sentence. Pinned so a reworded rationale is visible rather than silent."
+    },
+    {
+      "path": "preflight.graph_context.route_flows[].policy.local_only",
+      "value": true,
+      "kind": "matrix_gap",
+      "reason": "The policy dimension is unexercised: no fixture sets a restrictive `context_egress` in its contract, so authorization is granted in every cell and the whole permission matrix reads as one value. Closing it needs a fixture whose contract denies a surface - not a bigger repo. Known hole, not a promise that policy cannot deny."
+    },
+    {
+      "path": "preflight.graph_context.route_flows[].complete",
+      "value": true,
+      "kind": "matrix_gap",
+      "reason": "Constant at true across the matrix, and not yet explained. Either the matrix lacks the state that moves it, or the field is frozen and this gate has found one."
+    },
+    {
+      "path": "preflight.graph_context.reachable_data_access[].policy.local_only",
+      "value": true,
+      "kind": "matrix_gap",
+      "reason": "The policy dimension is unexercised: no fixture sets a restrictive `context_egress` in its contract, so authorization is granted in every cell and the whole permission matrix reads as one value. Closing it needs a fixture whose contract denies a surface - not a bigger repo. Known hole, not a promise that policy cannot deny."
+    },
+    {
+      "path": "preflight.graph_context.affected_files[].policy.local_only",
+      "value": true,
+      "kind": "matrix_gap",
+      "reason": "The policy dimension is unexercised: no fixture sets a restrictive `context_egress` in its contract, so authorization is granted in every cell and the whole permission matrix reads as one value. Closing it needs a fixture whose contract denies a surface - not a bigger repo. Known hole, not a promise that policy cannot deny."
+    },
+    {
+      "path": "preflight.task_preflight_packet.required_checks[].reason",
+      "value": "Block newly introduced deterministic convention violations before code is merged.",
+      "kind": "payload_identity",
+      "reason": "The default contract's own wording. Every fixture materializes the same default checks and risky areas, so the sentence explaining each is the same sentence. Pinned so a reworded rationale is visible rather than silent."
+    },
+    {
+      "path": "preflight.risky_areas[].reason",
+      "value": "API route changes can bypass the accepted data-access layering convention.",
+      "kind": "payload_identity",
+      "reason": "The default contract's own wording. Every fixture materializes the same default checks and risky areas, so the sentence explaining each is the same sentence. Pinned so a reworded rationale is visible rather than silent."
+    },
+    {
+      "path": "preflight.required_checks[].reason",
+      "value": "Block newly introduced deterministic convention violations before code is merged.",
+      "kind": "payload_identity",
+      "reason": "The default contract's own wording. Every fixture materializes the same default checks and risky areas, so the sentence explaining each is the same sentence. Pinned so a reworded rationale is visible rather than silent."
+    },
+    {
+      "path": "refusal.agent_envelope.read_only",
+      "value": true,
+      "kind": "product_invariant",
+      "reason": "Every surface this gate drives is read-only by construction - check:surface-parity asserts zero storage writes in packages/mcp/src, and these CLI reads mutate nothing. If this ever varies, the STALE half of this gate fires and that is the intended alarm."
+    },
+    {
+      "path": "refusal.agent_envelope.redactions.snippets_included",
+      "value": false,
+      "kind": "product_invariant",
+      "reason": "Drift ships metadata about code, never the code. These are the fields that say so, and they are false on every surface deliberately rather than incidentally."
+    },
+    {
+      "path": "refusal.agent_envelope.redactions.context_truncated",
+      "value": false,
+      "kind": "matrix_gap",
+      "reason": "NOT a guarantee - the matrix never truncates. Truncation needs a guidance view over the 32,768-byte budget, which takes roughly 60 realistically-sized conventions; the largest fixture here produces three. This is the exact field D-M5 found hardcoded to false, so it is recorded as a known hole rather than as a property. Closing it needs a fixture built for the budget, not a bigger repo."
+    },
+    {
+      "path": "refusal.agent_envelope.policy_proof.snippets_included",
+      "value": false,
+      "kind": "product_invariant",
+      "reason": "Drift ships metadata about code, never the code. These are the fields that say so, and they are false on every surface deliberately rather than incidentally."
+    },
+    {
+      "path": "refusal.agent_envelope.policy_proof.source_content_included",
+      "value": false,
+      "kind": "product_invariant",
+      "reason": "Drift ships metadata about code, never the code. These are the fields that say so, and they are false on every surface deliberately rather than incidentally."
+    },
+    {
+      "path": "refusal.agent_envelope.policy_proof.context_truncated",
+      "value": false,
+      "kind": "matrix_gap",
+      "reason": "NOT a guarantee - the matrix never truncates. Truncation needs a guidance view over the 32,768-byte budget, which takes roughly 60 realistically-sized conventions; the largest fixture here produces three. This is the exact field D-M5 found hardcoded to false, so it is recorded as a known hole rather than as a property. Closing it needs a fixture built for the budget, not a bigger repo."
+    },
+    {
+      "path": "prepare.task_preflight_packet.test_intelligence[].test_type",
+      "value": "integration",
+      "kind": "matrix_gap",
+      "reason": "Constant at \"integration\" across the matrix, and not yet explained. Either the matrix lacks the state that moves it, or the field is frozen and this gate has found one."
+    },
+    {
+      "path": "prepare.task_preflight_packet.test_intelligence[].snapshot_usage",
+      "value": false,
+      "kind": "unimplemented_placeholder",
+      "reason": "Hardcoded in query/src/test-intelligence.ts and never computed - nothing inspects a test for snapshots or staleness, so these are declared shape rather than measurement. Recorded as a placeholder rather than as an invariant, because `false` here reads to an agent as `checked, and no` when it means `never looked`. This is the EW-3 shape and the honest fix is to compute them or drop them, not to baseline them as properties."
+    },
+    {
+      "path": "prepare.task_preflight_packet.test_intelligence[].missing_test_candidate",
+      "value": false,
+      "kind": "product_invariant",
+      "reason": "False by construction: an entry exists in this array only because a test was FOUND for the subject, so a per-entry `missing` flag can never be true. The real signal is the sibling `missing_test_candidate` on the selection itself, which does vary."
+    },
+    {
+      "path": "prepare.task_preflight_packet.test_intelligence[].stale_test_candidate",
+      "value": false,
+      "kind": "unimplemented_placeholder",
+      "reason": "Hardcoded in query/src/test-intelligence.ts and never computed - nothing inspects a test for snapshots or staleness, so these are declared shape rather than measurement. Recorded as a placeholder rather than as an invariant, because `false` here reads to an agent as `checked, and no` when it means `never looked`. This is the EW-3 shape and the honest fix is to compute them or drop them, not to baseline them as properties."
+    },
+    {
+      "path": "prepare.test_intelligence[].test_type",
+      "value": "integration",
+      "kind": "matrix_gap",
+      "reason": "Constant at \"integration\" across the matrix, and not yet explained. Either the matrix lacks the state that moves it, or the field is frozen and this gate has found one."
+    },
+    {
+      "path": "prepare.test_intelligence[].snapshot_usage",
+      "value": false,
+      "kind": "unimplemented_placeholder",
+      "reason": "Hardcoded in query/src/test-intelligence.ts and never computed - nothing inspects a test for snapshots or staleness, so these are declared shape rather than measurement. Recorded as a placeholder rather than as an invariant, because `false` here reads to an agent as `checked, and no` when it means `never looked`. This is the EW-3 shape and the honest fix is to compute them or drop them, not to baseline them as properties."
+    },
+    {
+      "path": "prepare.test_intelligence[].missing_test_candidate",
+      "value": false,
+      "kind": "product_invariant",
+      "reason": "False by construction: an entry exists in this array only because a test was FOUND for the subject, so a per-entry `missing` flag can never be true. The real signal is the sibling `missing_test_candidate` on the selection itself, which does vary."
+    },
+    {
+      "path": "prepare.test_intelligence[].stale_test_candidate",
+      "value": false,
+      "kind": "unimplemented_placeholder",
+      "reason": "Hardcoded in query/src/test-intelligence.ts and never computed - nothing inspects a test for snapshots or staleness, so these are declared shape rather than measurement. Recorded as a placeholder rather than as an invariant, because `false` here reads to an agent as `checked, and no` when it means `never looked`. This is the EW-3 shape and the honest fix is to compute them or drop them, not to baseline them as properties."
+    },
+    {
+      "path": "preflight.task_preflight_packet.test_intelligence[].test_type",
+      "value": "integration",
+      "kind": "matrix_gap",
+      "reason": "Constant at \"integration\" across the matrix, and not yet explained. Either the matrix lacks the state that moves it, or the field is frozen and this gate has found one."
+    },
+    {
+      "path": "preflight.task_preflight_packet.test_intelligence[].snapshot_usage",
+      "value": false,
+      "kind": "unimplemented_placeholder",
+      "reason": "Hardcoded in query/src/test-intelligence.ts and never computed - nothing inspects a test for snapshots or staleness, so these are declared shape rather than measurement. Recorded as a placeholder rather than as an invariant, because `false` here reads to an agent as `checked, and no` when it means `never looked`. This is the EW-3 shape and the honest fix is to compute them or drop them, not to baseline them as properties."
+    },
+    {
+      "path": "preflight.task_preflight_packet.test_intelligence[].missing_test_candidate",
+      "value": false,
+      "kind": "product_invariant",
+      "reason": "False by construction: an entry exists in this array only because a test was FOUND for the subject, so a per-entry `missing` flag can never be true. The real signal is the sibling `missing_test_candidate` on the selection itself, which does vary."
+    },
+    {
+      "path": "preflight.task_preflight_packet.test_intelligence[].stale_test_candidate",
+      "value": false,
+      "kind": "unimplemented_placeholder",
+      "reason": "Hardcoded in query/src/test-intelligence.ts and never computed - nothing inspects a test for snapshots or staleness, so these are declared shape rather than measurement. Recorded as a placeholder rather than as an invariant, because `false` here reads to an agent as `checked, and no` when it means `never looked`. This is the EW-3 shape and the honest fix is to compute them or drop them, not to baseline them as properties."
+    },
+    {
+      "path": "preflight.test_intelligence[].test_type",
+      "value": "integration",
+      "kind": "matrix_gap",
+      "reason": "Constant at \"integration\" across the matrix, and not yet explained. Either the matrix lacks the state that moves it, or the field is frozen and this gate has found one."
+    },
+    {
+      "path": "preflight.test_intelligence[].snapshot_usage",
+      "value": false,
+      "kind": "unimplemented_placeholder",
+      "reason": "Hardcoded in query/src/test-intelligence.ts and never computed - nothing inspects a test for snapshots or staleness, so these are declared shape rather than measurement. Recorded as a placeholder rather than as an invariant, because `false` here reads to an agent as `checked, and no` when it means `never looked`. This is the EW-3 shape and the honest fix is to compute them or drop them, not to baseline them as properties."
+    },
+    {
+      "path": "preflight.test_intelligence[].missing_test_candidate",
+      "value": false,
+      "kind": "product_invariant",
+      "reason": "False by construction: an entry exists in this array only because a test was FOUND for the subject, so a per-entry `missing` flag can never be true. The real signal is the sibling `missing_test_candidate` on the selection itself, which does vary."
+    },
+    {
+      "path": "preflight.test_intelligence[].stale_test_candidate",
+      "value": false,
+      "kind": "unimplemented_placeholder",
+      "reason": "Hardcoded in query/src/test-intelligence.ts and never computed - nothing inspects a test for snapshots or staleness, so these are declared shape rather than measurement. Recorded as a placeholder rather than as an invariant, because `false` here reads to an agent as `checked, and no` when it means `never looked`. This is the EW-3 shape and the honest fix is to compute them or drop them, not to baseline them as properties."
+    }
+  ]
+}

--- a/scripts/payload-invariants.mjs
+++ b/scripts/payload-invariants.mjs
@@ -1,0 +1,727 @@
+#!/usr/bin/env node
+/**
+ * A trust-calibration field that cannot change is not calibrating anything.
+ *
+ * Drift's payloads carry a layer of fields whose entire job is telling an agent how much to
+ * believe the rest of the document: whether the list was truncated, whether the scan was fresh,
+ * why a section is empty, whether Drift refused rather than answered. Four of them shipped as
+ * values that could not move:
+ *
+ *   truncated.conventions      the literal `false`, while its two siblings were computed length
+ *                              comparisons. 200 conventions produced 189,211 bytes against a
+ *                              32,768 budget with the field still reporting false (D-M5).
+ *   error.type                 the literal "refusal" on every JSON error, including
+ *                              `drift frobnicate --json`, which is a usage error (W3).
+ *   test_intelligence_reason   "not_implemented_for_repo" whenever the list was empty, so a repo
+ *                              with no tests and a repo whose tests the matcher missed emitted
+ *                              the byte-identical string (D-A3).
+ *   full_list_command          named `drift doctor --repo <id> --json`, which accepts neither
+ *                              flag and returns no parser_gaps key (D-A5).
+ *
+ * Each was found by hand, one workstream at a time. This is the gate for the class.
+ *
+ * TWO CHECKS, because one principle does not cover all four. `full_list_command` VARIED - it
+ * embeds the repo id, so it differs on every repo - and a variance check would have passed it.
+ * Its defect was that it pointed at a command that does not exist. So:
+ *
+ *   A. VARIANCE      a trust discriminator that is identical across the whole matrix is either a
+ *                    hardcoded literal or a field with nothing behind it. Baseline it with a
+ *                    reason or make it move.
+ *   B. POINTERS      a field valued `drift <group> <command> ...` must name a command the router
+ *                    actually routes. Checked against the router's own source, the same way the
+ *                    D-CL3 command-surface test reads it - a restated list here would be the
+ *                    defect this catches, one level up.
+ *
+ * SCOPE. Check A evaluates trust DISCRIMINATORS, not every leaf. Booleans, fields named
+ * `*_reason`/`*_status`/`*_source`/`*_freshness`/`*_mode`/`decision`, and anything beneath
+ * `truncated`/`redactions`/`readiness`. Ids, hashes, timestamps, paths and free-running counts
+ * are out of scope BY CONSTRUCTION rather than by a several-hundred-entry baseline recording that
+ * `schema_version` is constant - a baseline nobody can read is one nobody checks.
+ *
+ * BOTH SURFACES are driven. W6 unified `repoMapPayload` and `preparedConvention`, so those are
+ * one derivation now - but 40 duplicated pairs remain across the CLI/MCP boundary (see
+ * scripts/surface-parity-baseline.json), ten of them in scan-status.ts, which produces
+ * `scan_status`, `readiness` and `freshness_requirement`. A field can still be live on one
+ * surface and frozen on the other.
+ *
+ *   node scripts/payload-invariants.mjs
+ *   node scripts/payload-invariants.mjs --update    # rewrite the baseline (reasons preserved)
+ */
+
+import { cp, mkdir, mkdtemp, rm, writeFile } from "node:fs/promises";
+import { readFileSync, writeFileSync, existsSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { dirname, join, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const HERE = dirname(fileURLToPath(import.meta.url));
+const REPO_ROOT = resolve(HERE, "..");
+const BASELINE = join(HERE, "payload-invariants-baseline.json");
+const ROUTER_SOURCE = join(REPO_ROOT, "packages/cli/src/app/router.ts");
+const RUN_CLI_SOURCE = join(REPO_ROOT, "packages/cli/src/app/run-cli.ts");
+
+/**
+ * The matrix. Each cell must differ from the others in a dimension a trust field is supposed to
+ * respond to - otherwise "this field never moved" says nothing about the field.
+ *
+ *   next-api-direct-db          violations present, conventions inferrable
+ *   next-api-service-delegated  the clean counterpart: same shape, nothing to report
+ *   no-ts-repo                  nothing indexable at all - the empty end of every count
+ *   mixed-js-ts                 .js parsed as TSX (W7), so facts exist where a suffix rule said
+ *                               they would not
+ *   security-middleware-dynamic-parser-gap
+ *                               parser gaps present, which is what `readiness` and
+ *                               `parser_gap_quality` exist to report
+ *   binary-and-unreadable       files the scan cannot read, so diagnostics are non-zero
+ */
+const FIXTURES = [
+  { name: "next-api-direct-db" },
+  { name: "next-api-service-delegated" },
+  { name: "no-ts-repo" },
+  { name: "mixed-js-ts" },
+  { name: "security-middleware-dynamic-parser-gap" },
+  { name: "binary-and-unreadable" },
+  // Two seeded variants, because NO fixture in test/fixtures carries a test file - so without
+  // these `test_intelligence_reason` reads `no_test_files_in_repo` in every cell and D-A3's whole
+  // point, that "this repo has no tests" and "the matcher missed them" are different answers, goes
+  // unexercised. This gate found that about itself, which is the argument for running it.
+  {
+    name: "next-api-direct-db",
+    as: "next-api-direct-db+matching-test",
+    async seed(repoRoot) {
+      await writeFile(
+        join(repoRoot, "apps/web/app/api/users/route.test.ts"),
+        "import { GET } from \"./route\";\nexport const covered = typeof GET;\n"
+      );
+    }
+  },
+  {
+    name: "next-api-direct-db",
+    as: "next-api-direct-db+unrelated-test",
+    // Tests exist and none of them is about the change: the `no_tests_matched_change` half.
+    async seed(repoRoot) {
+      await mkdir(join(repoRoot, "apps/web/lib"), { recursive: true });
+      await writeFile(
+        join(repoRoot, "apps/web/lib/billing-reports.test.ts"),
+        "export const unrelated = 1;\n"
+      );
+    }
+  }
+];
+
+/** Field names whose job is calibration. See SCOPE above. */
+const DISCRIMINATOR_SUFFIXES = [
+  "_reason",
+  "_status",
+  "_source",
+  "_freshness",
+  "_mode",
+  "_decision",
+  "_type"
+];
+const DISCRIMINATOR_NAMES = new Set(["decision", "reason", "status", "stale", "complete", "valid", "type"]);
+/** Objects whose every leaf is a calibration field, whatever it is called. */
+const DISCRIMINATOR_PARENTS = new Set(["truncated", "redactions", "readiness", "capability_completeness"]);
+
+export function isTrustDiscriminator(path, value) {
+  if (typeof value === "boolean") return true;
+  const segments = path.split(".");
+  const name = segments.at(-1) ?? "";
+  if (segments.some((segment) => DISCRIMINATOR_PARENTS.has(segment))) {
+    // Strings and nulls only. A COUNT beneath `readiness` (`parser_gaps_by_kind.parser_error`) is
+    // data the calibration fields summarise, not a calibration field, and treating it as one
+    // fills the baseline with numbers that are constant because the fixture is fixed.
+    return typeof value === "string" || value === null;
+  }
+  if (typeof value !== "string") return false;
+  return (
+    DISCRIMINATOR_NAMES.has(name) || DISCRIMINATOR_SUFFIXES.some((suffix) => name.endsWith(suffix))
+  );
+}
+
+/**
+ * Leaf paths of a payload, with array indices collapsed to `[]`.
+ *
+ * Collapsed because `conventions.0.enforcement_mode` and `conventions.1.enforcement_mode` are the
+ * same field, and keeping them apart would let a field look varying because two array elements
+ * differ while the field itself is a literal.
+ */
+export function leafFields(value, path = "", out = new Map()) {
+  if (value === null || typeof value !== "object") {
+    if (path) {
+      const existing = out.get(path);
+      if (existing) existing.push(value);
+      else out.set(path, [value]);
+    }
+    return out;
+  }
+  if (Array.isArray(value)) {
+    for (const entry of value) leafFields(entry, `${path}[]`, out);
+    return out;
+  }
+  for (const [key, entry] of Object.entries(value)) {
+    leafFields(entry, path ? `${path}.${key}` : key, out);
+  }
+  return out;
+}
+
+/**
+ * Why a constant is constant, and - the distinction that matters - whether that is a guarantee or
+ * a hole in the matrix.
+ *
+ * A flat list of reasons would let "this can never be true, by design" and "no fixture makes this
+ * true" sit next to each other reading identically. They are opposite facts: the first is a
+ * property worth pinning, the second is the gate admitting it did not look. `kind` separates them
+ * so a reader can see at a glance which constants are promises and which are untested corners,
+ * and so `matrix_gap` entries stay visible as work rather than dissolving into the baseline.
+ */
+export function classifyConstant(path, value) {
+  const name = path.split(".").at(-1) ?? "";
+
+  if (/(^|\.)(read_only|agent_can_mutate)$/.test(path) || name === "agent_can_mutate") {
+    return {
+      kind: "product_invariant",
+      reason:
+        "Every surface this gate drives is read-only by construction - check:surface-parity asserts " +
+        "zero storage writes in packages/mcp/src, and these CLI reads mutate nothing. If this ever " +
+        "varies, the STALE half of this gate fires and that is the intended alarm."
+    };
+  }
+  if (/(snippets_included|source_content_included|graph_context_included)$/.test(name)) {
+    return {
+      kind: "product_invariant",
+      reason:
+        "Drift ships metadata about code, never the code. These are the fields that say so, and " +
+        "they are false on every surface deliberately rather than incidentally."
+    };
+  }
+  if (name === "schema_version" || name === "surface" || name === "response_schema") {
+    return {
+      kind: "payload_identity",
+      reason:
+        "Identity, not calibration: a repo-map readiness block reports surface `repo_map` in every " +
+        "cell because that is what it is. Pinned so a renamed surface or a bumped schema shows up."
+    };
+  }
+  if (/(engine_source|fallback_used|enforcement_degraded)$/.test(name)) {
+    return {
+      kind: "environment",
+      reason:
+        "Fixed by the environment this gate runs in: the engine binary is always present, so the " +
+        "TypeScript fallback never engages. external-eval asserts the same two fields against the " +
+        "real corpus, where a fallback would be a genuine regression."
+    };
+  }
+  if (/^can_/.test(name) || /(^|\.)policy(_proof)?\.(allowed|reason)$/.test(path) || name === "local_only") {
+    return {
+      kind: "matrix_gap",
+      reason:
+        "The policy dimension is unexercised: no fixture sets a restrictive `context_egress` in its " +
+        "contract, so authorization is granted in every cell and the whole permission matrix reads " +
+        "as one value. Closing it needs a fixture whose contract denies a surface - not a bigger " +
+        "repo. Known hole, not a promise that policy cannot deny."
+    };
+  }
+  if (/(audit_integrity\.valid|audit_valid)$/.test(path)) {
+    return {
+      kind: "matrix_gap",
+      reason:
+        "The audit chain verifies in every cell because nothing tampers with it. Making this false " +
+        "means corrupting a hash-linked log on purpose, which the storage suite does directly; this " +
+        "matrix only ever builds intact ones."
+    };
+  }
+  if (/(graph_available|graph_complete)$/.test(name)) {
+    return {
+      kind: "environment",
+      reason:
+        "The engine produces a graph for every fixture here, so the degraded path never engages. " +
+        "The absent-graph branch is covered where it can be forced directly rather than by hoping " +
+        "a fixture fails to parse."
+    };
+  }
+  if (name === "can_block") {
+    return {
+      kind: "environment",
+      reason:
+        "Every scan in this matrix completes against a clean checkout, so the manifest reports the " +
+        "same state throughout. A failed or dirty scan is a different harness."
+    };
+  }
+  if (/test_intelligence\[\]\.(snapshot_usage|stale_test_candidate|covered_symbols|mocked_dependencies|fixture_usage)$/.test(path)) {
+    return {
+      kind: "unimplemented_placeholder",
+      reason:
+        "Hardcoded in query/src/test-intelligence.ts and never computed - nothing inspects a test " +
+        "for snapshots or staleness, so these are declared shape rather than measurement. Recorded " +
+        "as a placeholder rather than as an invariant, because `false` here reads to an agent as " +
+        "`checked, and no` when it means `never looked`. This is the EW-3 shape and the honest fix " +
+        "is to compute them or drop them, not to baseline them as properties."
+    };
+  }
+  if (/test_intelligence\[\]\.missing_test_candidate$/.test(path)) {
+    return {
+      kind: "product_invariant",
+      reason:
+        "False by construction: an entry exists in this array only because a test was FOUND for the " +
+        "subject, so a per-entry `missing` flag can never be true. The real signal is the sibling " +
+        "`missing_test_candidate` on the selection itself, which does vary."
+    };
+  }
+  if (/required_capabilities\[\]$/.test(path)) {
+    return {
+      kind: "payload_identity",
+      reason:
+        "The capability list a surface requires is a property of that surface, not of the repo it " +
+        "is reporting on. Pinned so a silently narrowed requirement shows up."
+    };
+  }
+  if (/latest_scan\.(status|dirty)$/.test(path)) {
+    return {
+      kind: "environment",
+      reason:
+        "Every scan in this matrix completes against a clean checkout, so the manifest reports the " +
+        "same state throughout. A failed or dirty scan is a different harness."
+    };
+  }
+  if (/(required_checks|risky_areas)\[\]\.reason$/.test(path)) {
+    return {
+      kind: "payload_identity",
+      reason:
+        "The default contract's own wording. Every fixture materializes the same default checks and " +
+        "risky areas, so the sentence explaining each is the same sentence. Pinned so a reworded " +
+        "rationale is visible rather than silent."
+    };
+  }
+  if (/selected_contracts_reason$/.test(path)) {
+    return {
+      kind: "matrix_gap",
+      reason:
+        "`no_contracts_accepted` in every cell because no fixture carries an AGENT contract - a " +
+        "different object from the repo contract the accept step materializes. Closing it needs a " +
+        "fixture with one; until then this field's other values are unexercised here."
+    };
+  }
+  if (/(proof_freshness|proof_status)$/.test(name)) {
+    return {
+      kind: "matrix_gap",
+      reason:
+        "Security boundary proofs are produced by `check`, which this matrix does not run, so route " +
+        "trust reports `none`/`unknown` throughout. These are exactly the D-A2 fields the CLI used " +
+        "to omit, so the hole is worth naming: they are present and correct, and only one of their " +
+        "values is exercised."
+    };
+  }
+  if (path.includes("truncated")) {
+    return {
+      kind: "matrix_gap",
+      reason:
+        "NOT a guarantee - the matrix never truncates. Truncation needs a guidance view over the " +
+        "32,768-byte budget, which takes roughly 60 realistically-sized conventions; the largest " +
+        "fixture here produces three. This is the exact field D-M5 found hardcoded to false, so it " +
+        "is recorded as a known hole rather than as a property. Closing it needs a fixture built " +
+        "for the budget, not a bigger repo."
+    };
+  }
+  return {
+    kind: "matrix_gap",
+    reason:
+      `Constant at ${JSON.stringify(value)} across the matrix, and not yet explained. Either the ` +
+      "matrix lacks the state that moves it, or the field is frozen and this gate has found one."
+  };
+}
+
+/** Every command the CLI dispatches, from the router and run-cli's pre-router branches. */
+export function routedCommandPrefixes(routerSource, runCliSource) {
+  const prefixes = new Set();
+  for (const [, group, command, maybeId] of routerSource.matchAll(
+    /group === "([a-z-]+)"\s*&&\s*command === "([a-z-]+)"(?:[^\n]*?maybeId === "([a-z-]+)")?/g
+  )) {
+    prefixes.add(maybeId ? `${group} ${command} ${maybeId}` : `${group} ${command}`);
+  }
+  for (const [, group] of routerSource.matchAll(/group === "([a-z-]+)"/g)) prefixes.add(group);
+  for (const [, group] of runCliSource.matchAll(/parsed\.positional\[0\] === "([a-z-]+)"/g)) {
+    prefixes.add(group);
+  }
+  return prefixes;
+}
+
+
+/**
+ * Pointer fields in a payload, as { path, command, promises }.
+ *
+ * `promises` is the object key the pointer sits inside - `guidance.parser_gaps.full_list_command`
+ * promises `parser_gaps` - which is what makes following it a real check rather than a spell check.
+ * D-A5 is the reason: `drift doctor --repo <id> --json` is a ROUTED command that EXITS 0 and
+ * simply has no `parser_gaps` key, so both "does this command exist" and "does it succeed" pass
+ * it. Only asking for the data the field's own name promised finds it.
+ */
+export function pointerFields(payload) {
+  const found = [];
+  const walk = (value, path, parentKey) => {
+    if (value === null || typeof value !== "object") {
+      const leaf = path.split(".").at(-1) ?? "";
+      if (typeof value === "string" && /^drift\s+[a-z]/.test(value) && /_commands?$/.test(leaf)) {
+        // Two kinds, and conflating them produces false positives. A DATA pointer says "the rest
+        // of this list lives over there" and must actually serve it. A REMEDIATION pointer
+        // (`next_command`) says "here is what to run next" - `drift scan --repo-root ...` does not
+        // owe anyone a `scan_status` key, and executing it would re-scan the repo as a side effect.
+        const isData = /(list|records)_commands?$/.test(leaf);
+        found.push({ path, command: value, promises: isData ? parentKey : null, kind: isData ? "data" : "remediation" });
+      }
+      return;
+    }
+    if (Array.isArray(value)) {
+      for (const entry of value) walk(entry, `${path}[]`, parentKey);
+      return;
+    }
+    for (const [key, entry] of Object.entries(value)) {
+      walk(entry, path ? `${path}.${key}` : key, key === "" ? parentKey : path.split(".").at(-1) ?? null);
+    }
+  };
+  walk(payload, "", null);
+  return found;
+}
+
+/** Does `drift x y --flag` name something the CLI routes? */
+export function pointerIsRoutable(command, prefixes) {
+  const words = command
+    .replace(/^drift\s+/, "")
+    .split(/\s+/)
+    .filter((word) => word && !word.startsWith("-") && !word.startsWith("<") && !word.startsWith('"'));
+  // Longest-first: `contract waiver show` must not be satisfied by `contract` alone when the
+  // router only branches on the three-word form.
+  for (let length = Math.min(3, words.length); length >= 1; length--) {
+    if (prefixes.has(words.slice(0, length).join(" "))) return true;
+  }
+  return false;
+}
+
+async function collectPayloads() {
+  const { runCli } = await import(join(REPO_ROOT, "packages/cli/dist/index.js"));
+  const { handleMcpJsonRpcRequest } = await import(join(REPO_ROOT, "packages/mcp/dist/index.js"));
+
+  const engine = ["target/release/drift-engine", "target/debug/drift-engine"]
+    .map((candidate) => join(REPO_ROOT, candidate))
+    .find((candidate) => existsSync(candidate));
+  if (!engine) {
+    console.error("Missing drift-engine. Run: cargo build --release -p drift-engine");
+    process.exit(1);
+  }
+  process.env.DRIFT_ENGINE_BIN = engine;
+
+  const cells = [];
+  const dirs = [];
+  const pointerChecks = [];
+  const followed = new Set();
+  for (const entry of FIXTURES) {
+    const fixture = entry.as ?? entry.name;
+    const dir = await mkdtemp(join(tmpdir(), "drift-payload-invariants-"));
+    dirs.push(dir);
+    const repoRoot = join(dir, "repo");
+    const stateRoot = join(dir, "state");
+    await cp(join(REPO_ROOT, "test/fixtures", entry.name), repoRoot, { recursive: true });
+    if (entry.seed) await entry.seed(repoRoot);
+
+    const scan = await runCli(["scan", "--repo-root", repoRoot, "--state-root", stateRoot, "--json"]);
+    if (scan.exitCode !== 0) {
+      console.error(`fixture ${fixture}: scan failed (${scan.exitCode}) ${scan.stderr.slice(0, 200)}`);
+      process.exit(1);
+    }
+    const scanned = JSON.parse(scan.stdout);
+    const repoId = scanned.repo.id;
+    const databasePath = scanned.database_path;
+    const cli = (args, extra = []) =>
+      runCli([...args, "--repo", repoId, "--db", databasePath, "--json", ...extra]);
+
+    const mcp = (name, args) => {
+      const response = handleMcpJsonRpcRequest(
+        { databasePath },
+        {
+          jsonrpc: "2.0",
+          id: 1,
+          method: "tools/call",
+          params: { name, arguments: { repo_id: repoId, ...args } }
+        }
+      );
+      const text = response?.result?.content?.[0]?.text;
+      try {
+        return text ? JSON.parse(text) : response?.error?.data ?? null;
+      } catch {
+        return null;
+      }
+    };
+
+    const parseOr = (result) => {
+      try {
+        return JSON.parse(result.stdout);
+      } catch {
+        return null;
+      }
+    };
+
+    const record = (state, surface, name, raw) => {
+      if (raw) cells.push({ cell: `${fixture}/${state}/${surface}:${name}`, payload: raw });
+      // Follow every pointer this payload hands an agent, once per distinct command.
+      for (const pointer of raw ? pointerFields(raw) : []) {
+        if (followed.has(pointer.command)) continue;
+        followed.add(pointer.command);
+        pointerChecks.push({ ...pointer, cell: `${fixture}/${state}/${surface}:${name}`, databasePath });
+      }
+    };
+
+    const captureAll = async (state) => {
+      record(state, "cli", "prepare", parseOr(await cli(["prepare", "add an endpoint that lists items"])));
+      record(state, "cli", "repo_map", parseOr(await cli(["repo", "map"])));
+      record(state, "cli", "scan_status", parseOr(await cli(["scan", "status"])));
+      record(state, "mcp", "preflight", mcp("get_task_preflight", { task: "add an endpoint that lists items" }));
+      record(state, "mcp", "repo_map", mcp("get_repo_map", {}));
+      record(state, "mcp", "scan_status", mcp("get_scan_status", {}));
+    };
+
+    // STATE DIMENSIONS. The fixtures differ in CONTENT; without these every cell would share one
+    // state, and a field that responds to staleness or to an accepted contract would read as
+    // frozen because nothing in the matrix ever moved it. That is the failure mode a variance
+    // gate has: it measures the matrix at least as much as the code.
+    await captureAll("fresh");
+
+    // 1. An accepted contract, so `contract`, the convention list and everything keyed on
+    //    "does this repo enforce anything" has both states in the matrix.
+    const candidates = parseOr(await cli(["conventions", "list", "--status", "candidate"]));
+    for (const [index, candidate] of (candidates?.candidates ?? []).slice(0, 3).entries()) {
+      // The first in BLOCK mode, deliberately. Every inferred candidate suggests `warn`, so
+      // accepting them all as suggested left `enforcement_mode` and `will_this_block` reading one
+      // value across the matrix - the two fields an agent uses to decide whether a violation stops
+      // a merge. A matrix that only ever warns cannot show that they move.
+      const blocking = index === 0 && candidate.enforcement_capability === "deterministic_check";
+      await cli([
+        "conventions", "accept", candidate.id,
+        "--confirm",
+        "--severity", blocking ? "error" : candidate.suggested_severity ?? "warning",
+        "--mode", blocking ? "block" : candidate.suggested_enforcement_mode ?? "warn"
+      ]);
+    }
+    await captureAll("accepted");
+
+    // 2. `--require-fresh` on a current scan: the demand is recorded even when it is satisfied.
+    record(
+      "require_fresh",
+      "cli",
+      "prepare",
+      parseOr(await cli(["prepare", "add an endpoint that lists items"], ["--require-fresh"]))
+    );
+    record("require_fresh", "mcp", "preflight", mcp("get_task_preflight", {
+      task: "add an endpoint that lists items",
+      require_fresh: true
+    }));
+
+    // 3. A stale scan. Editing a source file after the scan is what staleness IS, and it moves
+    //    `scan_status.stale`, the readiness decision and the freshness requirement together.
+    await writeFile(join(repoRoot, "drift-invariants-probe.ts"), "export const probe = 1;\n");
+    await captureAll("stale");
+    // 4. ... and demanding freshness against it, which is a refusal rather than an answer.
+    record(
+      "stale_require_fresh",
+      "cli",
+      "refusal",
+      parseOr(await cli(["prepare", "add an endpoint that lists items"], ["--require-fresh"]))
+    );
+
+    // 5. An operational error rather than a refusal, so `error.type` has both of its values.
+    record(
+      "unknown_repo",
+      "cli",
+      "refusal",
+      parseOr(await runCli(["prepare", "x", "--repo", "repo_missing", "--db", databasePath, "--json"]))
+    );
+  }
+
+  // Run each distinct pointer BEFORE the temp state is removed - a pointer is only checkable
+  // against the repo it was minted for.
+  const pointerResults = [];
+  for (const pointer of pointerChecks) {
+    // Only data pointers are RUN. A remediation pointer is checked for routability alone -
+    // executing `drift scan --repo-root ...` would rescan the repo, which is a side effect a gate
+    // has no business causing.
+    if (pointer.kind !== "data") {
+      pointerResults.push({ ...pointer, exitCode: 0, served: null, stderr: "" });
+      continue;
+    }
+    const argv = pointer.command
+      .replace(/^drift\s+/, "")
+      .split(/\s+/)
+      .filter(Boolean)
+      .filter((word) => !word.startsWith("<"));
+    const run = await runCli([...argv, "--db", pointer.databasePath]);
+    let served = null;
+    if (pointer.promises) {
+      try {
+        served = pointer.promises in JSON.parse(run.stdout);
+      } catch {
+        served = false;
+      }
+    }
+    pointerResults.push({ ...pointer, exitCode: run.exitCode, served, stderr: run.stderr.slice(0, 200) });
+  }
+
+  await Promise.all(dirs.map((dir) => rm(dir, { recursive: true, force: true })));
+  return { cells, pointerResults };
+}
+
+function main({ cells, pointerResults }) {
+  const update = process.argv.includes("--update");
+  const baseline = JSON.parse(readFileSync(BASELINE, "utf8"));
+  const known = new Map((baseline.constants ?? []).map((entry) => [entry.path, entry]));
+  const failures = [];
+
+  // Group by payload NAME rather than by fixture, so `prepare.readiness.decision` is compared
+  // across fixtures and never against `repo_map`'s.
+  const byPayload = new Map();
+  for (const { cell, payload } of cells) {
+    const name = cell.split(":")[1];
+    const leaves = leafFields(payload);
+    for (const [path, values] of leaves) {
+      const key = `${name}.${path}`;
+      const bucket = byPayload.get(key) ?? [];
+      bucket.push(...values);
+      byPayload.set(key, bucket);
+    }
+  }
+
+  if (cells.length === 0 || byPayload.size === 0) {
+    console.error(
+      `payload invariants: collected ${cells.length} payload(s) and ${byPayload.size} field(s). ` +
+        `A matrix that produced nothing cannot show that anything varies.`
+    );
+    process.exit(1);
+  }
+
+  const prefixes = routedCommandPrefixes(
+    readFileSync(ROUTER_SOURCE, "utf8"),
+    readFileSync(RUN_CLI_SOURCE, "utf8")
+  );
+  if (prefixes.size < 8) {
+    console.error(
+      `payload invariants: parsed only ${prefixes.size} routed command(s) - the router source no ` +
+        `longer matches, so check B would pass every pointer vacuously.`
+    );
+    process.exit(1);
+  }
+
+  // Check B. Three parts, because the first two both pass D-A5.
+  const brokenPointers = [];
+  for (const pointer of pointerResults) {
+    if (!pointerIsRoutable(pointer.command, prefixes)) {
+      brokenPointers.push(
+        `${pointer.path} -> \`${pointer.command}\` names no routed command.`
+      );
+      continue;
+    }
+    if (pointer.exitCode !== 0) {
+      brokenPointers.push(
+        `${pointer.path} -> \`${pointer.command}\` exits ${pointer.exitCode}. ${pointer.stderr}`
+      );
+      continue;
+    }
+    if (pointer.served === false) {
+      brokenPointers.push(
+        `${pointer.path} -> \`${pointer.command}\` succeeds but returns no \`${pointer.promises}\` key.\n` +
+          `    This is D-A5 exactly: the pointer named \`drift doctor --repo <id> --json\`, which is a ` +
+          `real command that exits 0 and simply does not serve parser gaps. Existence and exit code ` +
+          `both pass it; only asking for the data the field promised finds it.`
+      );
+    }
+  }
+  for (const broken of brokenPointers) {
+    failures.push(`POINTER ${broken}`);
+  }
+
+  // Check A.
+  const evaluated = [];
+  const constants = [];
+  for (const [path, values] of byPayload) {
+    if (values.length < 2) continue;
+    if (!isTrustDiscriminator(path, values[0])) continue;
+    evaluated.push(path);
+    const distinct = new Set(values.map((value) => JSON.stringify(value)));
+    if (distinct.size === 1) {
+      constants.push({ path, value: values[0] });
+    }
+  }
+
+  if (evaluated.length === 0) {
+    console.error(
+      "payload invariants: zero trust discriminators evaluated. The payload shape has changed " +
+        "out from under this gate, which would otherwise report success forever."
+    );
+    process.exit(1);
+  }
+
+  if (process.argv.includes("--report")) {
+    // Distinguishing "this field varies" from "this field is never looked at" is the whole
+    // difference between a gate and a decoration.
+    for (const path of evaluated.sort()) {
+      const distinct = new Set((byPayload.get(path) ?? []).map((value) => JSON.stringify(value)));
+      console.log(`${distinct.size === 1 ? "CONST" : `varies(${distinct.size})`}\t${path}`);
+    }
+    process.exit(0);
+  }
+
+  if (update) {
+    writeFileSync(
+      BASELINE,
+      `${JSON.stringify(
+        {
+          constants: constants.map((entry) => ({
+            ...entry,
+            ...(known.get(entry.path)
+              ? { kind: known.get(entry.path).kind, reason: known.get(entry.path).reason }
+              : classifyConstant(entry.path, entry.value))
+          }))
+        },
+        null,
+        2
+      )}\n`
+    );
+    console.log(`payload invariants baseline updated - ${constants.length} declared constant(s)`);
+    process.exit(0);
+  }
+
+  const seen = new Set(constants.map((entry) => entry.path));
+  for (const entry of constants) {
+    if (!known.has(entry.path)) {
+      failures.push(
+        `NEW constant trust field: ${entry.path} = ${JSON.stringify(entry.value)}\n` +
+          `    Identical across all ${cells.length} matrix cells. A calibration field that cannot ` +
+          `move tells an agent nothing. Make it vary, or declare it in ` +
+          `scripts/payload-invariants-baseline.json with a reason.`
+      );
+    }
+  }
+  for (const [path, entry] of known) {
+    if (!seen.has(path)) {
+      failures.push(
+        `STALE baseline entry: ${path} now varies (or is gone). Remove it from ` +
+          `scripts/payload-invariants-baseline.json - a field recorded as frozen that is not is a ` +
+          `false record, and it is how a baseline stops describing anything.\n` +
+          `    Recorded reason: ${entry.reason}`
+      );
+    }
+  }
+
+  if (failures.length > 0) {
+    console.error("payload invariants FAILED:\n");
+    for (const failure of failures) console.error(`  ${failure}\n`);
+    process.exit(1);
+  }
+
+  console.log(
+    `payload invariants: ${cells.length} payload(s) across ${FIXTURES.length} fixture(s), ` +
+      `${evaluated.length} trust discriminator(s) evaluated, ${constants.length} declared constant, ` +
+      `${pointerResults.length} pointer(s) followed.`
+  );
+}
+
+if (process.argv[1] && resolve(process.argv[1]) === resolve(fileURLToPath(import.meta.url))) {
+  main(await collectPayloads());
+}

--- a/scripts/payload-invariants.test.mjs
+++ b/scripts/payload-invariants.test.mjs
@@ -1,0 +1,219 @@
+import { readFileSync, writeFileSync } from "node:fs";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+import { execFileSync } from "node:child_process";
+import { afterEach, describe, expect, it } from "vitest";
+
+import {
+  classifyConstant,
+  isTrustDiscriminator,
+  leafFields,
+  pointerFields,
+  pointerIsRoutable,
+  routedCommandPrefixes
+} from "./payload-invariants.mjs";
+
+/**
+ * Tests for the trust-calibration gate.
+ *
+ * Its own failure modes are the ones every gate in this repo has had: evaluating nothing and
+ * reporting success, ratcheting in one direction only, and holding a baseline that has stopped
+ * describing the payloads. The end-to-end run is expensive (it scans eight fixtures), so the
+ * expensive path is exercised once and the logic is tested directly.
+ */
+
+const HERE = dirname(fileURLToPath(import.meta.url));
+const GATE = join(HERE, "payload-invariants.mjs");
+const BASELINE = join(HERE, "payload-invariants-baseline.json");
+const original = readFileSync(BASELINE, "utf8");
+
+afterEach(() => writeFileSync(BASELINE, original));
+
+function runGate() {
+  try {
+    return { code: 0, stdout: execFileSync(process.execPath, [GATE], { encoding: "utf8" }), stderr: "" };
+  } catch (error) {
+    return {
+      code: error.status ?? 1,
+      stdout: error.stdout?.toString() ?? "",
+      stderr: error.stderr?.toString() ?? ""
+    };
+  }
+}
+
+describe("payload invariants gate", () => {
+  it("passes against the committed baseline", () => {
+    const result = runGate();
+    expect(result.stderr).toBe("");
+    expect(result.code).toBe(0);
+    expect(result.stdout).toContain("trust discriminator(s) evaluated");
+  }, 300_000);
+
+  it("fails on a NEW constant trust field", () => {
+    // The forward ratchet: a field that stops varying must be declared, not absorbed. Dropping an
+    // entry stands in for a field that has newly frozen.
+    const baseline = JSON.parse(original);
+    const dropped = baseline.constants[0];
+    writeFileSync(BASELINE, `${JSON.stringify({ constants: baseline.constants.slice(1) }, null, 2)}\n`);
+    const result = runGate();
+    expect(result.code).toBe(1);
+    expect(result.stderr).toContain("NEW constant trust field");
+    expect(result.stderr).toContain(dropped.path);
+  }, 300_000);
+
+  it("fails on a STALE baseline entry", () => {
+    // The other direction. A field recorded as frozen that now varies is a false record, and
+    // without this half, making a field vary is a silent no-op and the baseline drifts out of
+    // contact with the payloads it describes.
+    const baseline = JSON.parse(original);
+    writeFileSync(
+      BASELINE,
+      `${JSON.stringify(
+        {
+          constants: [
+            ...baseline.constants,
+            {
+              path: "prepare.this_field_was_never_here",
+              value: false,
+              kind: "product_invariant",
+              reason: "recorded, but this field does not exist"
+            }
+          ]
+        },
+        null,
+        2
+      )}\n`
+    );
+    const result = runGate();
+    expect(result.code).toBe(1);
+    expect(result.stderr).toContain("STALE baseline entry");
+    expect(result.stderr).toContain("this_field_was_never_here");
+  }, 300_000);
+});
+
+describe("baseline honesty", () => {
+  it("gives every constant a kind and a reason", () => {
+    for (const entry of JSON.parse(original).constants) {
+      expect(entry.kind, `${entry.path} has no kind`).toBeTruthy();
+      expect(entry.reason, `${entry.path} has no reason`).toBeTruthy();
+    }
+  });
+
+  it("keeps matrix gaps distinguishable from guarantees", () => {
+    // The distinction this baseline exists to preserve. `product_invariant` says "this cannot
+    // vary"; `matrix_gap` says "we did not make it vary". Collapsing them would let an untested
+    // corner read as a promise, which is the failure this whole gate is about one level up.
+    const constants = JSON.parse(original).constants;
+    const kinds = new Set(constants.map((entry) => entry.kind));
+    expect(kinds.has("matrix_gap")).toBe(true);
+    expect(kinds.has("product_invariant")).toBe(true);
+    // The truncation fields are the gate's own headline example and must stay recorded as a hole,
+    // never as a property: D-M5 found `truncated.conventions` hardcoded false, and a baseline
+    // calling that an invariant would re-freeze it with a certificate.
+    for (const entry of constants.filter((row) => row.path.includes("truncated"))) {
+      expect(entry.kind, `${entry.path} must stay a matrix_gap`).toBe("matrix_gap");
+    }
+  });
+
+  it("records the unimplemented placeholders as placeholders", () => {
+    // `snapshot_usage` and `stale_test_candidate` are hardcoded false in test-intelligence.ts and
+    // nothing computes them. Recording them as invariants would say "checked, and no" about a
+    // field that never looked.
+    const placeholders = JSON.parse(original).constants.filter(
+      (entry) => entry.kind === "unimplemented_placeholder"
+    );
+    expect(placeholders.length).toBeGreaterThan(0);
+    for (const entry of placeholders) {
+      expect(entry.reason).toMatch(/never computed|placeholder/i);
+    }
+  });
+});
+
+describe("discriminator selection", () => {
+  it("treats every boolean as a discriminator", () => {
+    expect(isTrustDiscriminator("anything.at.all", true)).toBe(true);
+    expect(isTrustDiscriminator("guidance.truncated.conventions", false)).toBe(true);
+  });
+
+  it("treats a reason, status or decision string as a discriminator", () => {
+    expect(isTrustDiscriminator("prepare.test_intelligence_reason", "no_test_files_in_repo")).toBe(true);
+    expect(isTrustDiscriminator("refusal.error.type", "refusal")).toBe(true);
+    expect(isTrustDiscriminator("readiness.decision", "proceed")).toBe(true);
+  });
+
+  it("does not treat identity strings as discriminators", () => {
+    // Scope, and the reason the baseline is readable: ids, paths and hashes are constant or
+    // varying for reasons that have nothing to do with calibration.
+    expect(isTrustDiscriminator("prepare.repo_id", "repo_abc")).toBe(false);
+    expect(isTrustDiscriminator("prepare.relevant_files[].path", "app/api/route.ts")).toBe(false);
+  });
+
+  it("does not treat a count under readiness as a discriminator", () => {
+    // Numbers beneath a discriminator parent are the data the calibration fields summarise. Left
+    // in, they filled the baseline with counts that are constant because the fixture is fixed.
+    expect(isTrustDiscriminator("readiness.parser_gaps_by_kind.parser_error", 1)).toBe(false);
+    expect(isTrustDiscriminator("readiness.graph_available", true)).toBe(true);
+  });
+});
+
+describe("leaf flattening", () => {
+  it("collapses array indices so a field is compared with itself", () => {
+    const leaves = leafFields({ conventions: [{ mode: "warn" }, { mode: "block" }] });
+    expect([...leaves.keys()]).toEqual(["conventions[].mode"]);
+    expect(leaves.get("conventions[].mode")).toEqual(["warn", "block"]);
+  });
+
+  it("keeps nulls, which are answers", () => {
+    expect(leafFields({ reason: null }).get("reason")).toEqual([null]);
+  });
+});
+
+describe("pointer checking", () => {
+  const prefixes = routedCommandPrefixes(
+    readFileSync(join(HERE, "../packages/cli/src/app/router.ts"), "utf8"),
+    readFileSync(join(HERE, "../packages/cli/src/app/run-cli.ts"), "utf8")
+  );
+
+  it("reads the routed command surface rather than restating it", () => {
+    // Liveness: if the router stops matching, every pointer passes vacuously.
+    expect(prefixes.size).toBeGreaterThan(8);
+    expect(prefixes.has("scan status")).toBe(true);
+    expect(prefixes.has("doctor")).toBe(true);
+  });
+
+  it("accepts a routed command and rejects an invented one", () => {
+    expect(pointerIsRoutable("drift scan status --repo x --json", prefixes)).toBe(true);
+    expect(pointerIsRoutable("drift frobnicate --repo x --json", prefixes)).toBe(false);
+  });
+
+  it("separates a data pointer from a remediation pointer", () => {
+    // Conflating them is a false positive: `next_command` says what to run next and owes nobody a
+    // key named after its parent. Only a *_list_command / *_records_command promises data.
+    const found = pointerFields({
+      guidance: { parser_gaps: { full_list_command: "drift scan status --repo x --json" } },
+      scan_status: { next_command: "drift scan --repo-root . --json" }
+    });
+    const byPath = Object.fromEntries(found.map((entry) => [entry.path, entry]));
+    expect(byPath["guidance.parser_gaps.full_list_command"]).toMatchObject({
+      kind: "data",
+      promises: "parser_gaps"
+    });
+    expect(byPath["scan_status.next_command"]).toMatchObject({ kind: "remediation", promises: null });
+  });
+});
+
+describe("constant classification", () => {
+  it("calls a read-only guarantee a product invariant", () => {
+    expect(classifyConstant("prepare.agent_envelope.read_only", true).kind).toBe("product_invariant");
+  });
+
+  it("calls a truncation field a matrix gap, never an invariant", () => {
+    expect(classifyConstant("prepare.guidance.truncated.conventions", false).kind).toBe("matrix_gap");
+  });
+
+  it("says plainly when it cannot explain a constant", () => {
+    const classified = classifyConstant("prepare.something.unexpected_flag", false);
+    expect(classified.kind).toBe("matrix_gap");
+    expect(classified.reason).toContain("not yet explained");
+  });
+});

--- a/scripts/surface-parity-baseline.json
+++ b/scripts/surface-parity-baseline.json
@@ -1,0 +1,324 @@
+{
+  "duplicates": [
+    {
+      "key": "allRequiredChecks<->allRequiredChecks",
+      "mcp": "packages/mcp/src/index.ts:allRequiredChecks",
+      "cli": "packages/cli/src/domain/preflight.ts:allRequiredChecks",
+      "similarity": 1,
+      "both_private": false,
+      "reason": "Not yet unified. W6 moved the preflight derivation that PRODUCES payload fields (preparedConvention/instructionForConvention, where the two copies had actually diverged); these are the scope/matching helpers around it and are next."
+    },
+    {
+      "key": "auditVerifyNextCommands<->auditVerifyNextCommands",
+      "mcp": "packages/mcp/src/index.ts:auditVerifyNextCommands",
+      "cli": "packages/cli/src/domain/audit-review.ts:auditVerifyNextCommands",
+      "similarity": 1,
+      "both_private": false,
+      "reason": "Not yet unified. Audit verification summary and its next-commands list."
+    },
+    {
+      "key": "auditVerifySummary<->auditVerifySummary",
+      "mcp": "packages/mcp/src/index.ts:auditVerifySummary",
+      "cli": "packages/cli/src/domain/audit-review.ts:auditVerifySummary",
+      "similarity": 1,
+      "both_private": false,
+      "reason": "Not yet unified. Audit verification summary and its next-commands list."
+    },
+    {
+      "key": "baselineSummary<->baselineSummary",
+      "mcp": "packages/mcp/src/index.ts:baselineSummary",
+      "cli": "packages/cli/src/domain/baselines.ts:baselineSummary",
+      "similarity": 1,
+      "both_private": false,
+      "reason": "Not yet unified. Baseline counting; reaches storage on both sides."
+    },
+    {
+      "key": "collectResolverInputPaths<->collectResolverInputPaths",
+      "mcp": "packages/mcp/src/index.ts:collectResolverInputPaths",
+      "cli": "packages/cli/src/domain/scan-status.ts:collectResolverInputPaths",
+      "similarity": 1,
+      "both_private": true,
+      "reason": "Not yet unified. scan-status.ts is the largest remaining unit (~1300 lines) and MCP's copy of it spans ten functions; moving it is its own change because scanStatusPayload reaches storage on both sides and the CLI's copy also serves `drift scan status`, which MCP has no equivalent of."
+    },
+    {
+      "key": "conventionSummary<->acceptedConventionSummary",
+      "mcp": "packages/mcp/src/index.ts:conventionSummary",
+      "cli": "packages/cli/src/commands/conventions.ts:acceptedConventionSummary",
+      "similarity": 1,
+      "both_private": true,
+      "reason": "Not yet unified. Convention listing/ordering for review surfaces."
+    },
+    {
+      "key": "countBy<->countBy",
+      "mcp": "packages/mcp/src/index.ts:countBy",
+      "cli": "packages/cli/src/domain/pagination.ts:countBy",
+      "similarity": 1,
+      "both_private": false,
+      "reason": "Not yet unified. Generic counting helper."
+    },
+    {
+      "key": "defaultSafeCommandsForRepo<->defaultSafeCommandsForRepo",
+      "mcp": "packages/mcp/src/index.ts:defaultSafeCommandsForRepo",
+      "cli": "packages/cli/src/domain/contract-materialization.ts:defaultSafeCommandsForRepo",
+      "similarity": 1,
+      "both_private": false,
+      "reason": "Not yet unified. Default safe-command materialization."
+    },
+    {
+      "key": "graphConfidenceReasons<->graphConfidenceReasons",
+      "mcp": "packages/mcp/src/index.ts:graphConfidenceReasons",
+      "cli": "packages/cli/src/commands/prepare.ts:graphConfidenceReasons",
+      "similarity": 1,
+      "both_private": true,
+      "reason": "Not yet unified, and module-private on both sides - the class the census could not see. These feed the change-impact and graph-confidence sections of the preflight packet."
+    },
+    {
+      "key": "graphPreflightContext<->graphPreflightContext",
+      "mcp": "packages/mcp/src/index.ts:graphPreflightContext",
+      "cli": "packages/cli/src/domain/graph-preflight.ts:graphPreflightContext",
+      "similarity": 1,
+      "both_private": false,
+      "reason": "Not yet unified. Graph preflight context assembly; reaches storage on both sides."
+    },
+    {
+      "key": "isRepoRelativeMcpPath<->isRepoRelativePolicyPattern",
+      "mcp": "packages/mcp/src/index.ts:isRepoRelativeMcpPath",
+      "cli": "packages/cli/src/domain/repo-paths.ts:isRepoRelativePolicyPattern",
+      "similarity": 1,
+      "both_private": false,
+      "reason": "Different concepts that score alike: MCP validates a repo-relative TOOL argument, the CLI validates a repo-relative POLICY pattern. Same three-line shape, different callers and different error surfaces. Two copies are defensible here; recorded so the score does not have to be re-litigated."
+    },
+    {
+      "key": "isResolverInputPath<->isResolverInputPath",
+      "mcp": "packages/mcp/src/index.ts:isResolverInputPath",
+      "cli": "packages/cli/src/domain/scan-status.ts:isResolverInputPath",
+      "similarity": 1,
+      "both_private": true,
+      "reason": "Not yet unified. scan-status.ts is the largest remaining unit (~1300 lines) and MCP's copy of it spans ten functions; moving it is its own change because scanStatusPayload reaches storage on both sides and the CLI's copy also serves `drift scan status`, which MCP has no equivalent of."
+    },
+    {
+      "key": "latestIndexedScan<->latestIndexedScan",
+      "mcp": "packages/mcp/src/index.ts:latestIndexedScan",
+      "cli": "packages/cli/src/domain/scan-status.ts:latestIndexedScan",
+      "similarity": 1,
+      "both_private": false,
+      "reason": "Not yet unified. scan-status.ts is the largest remaining unit (~1300 lines) and MCP's copy of it spans ten functions; moving it is its own change because scanStatusPayload reaches storage on both sides and the CLI's copy also serves `drift scan status`, which MCP has no equivalent of."
+    },
+    {
+      "key": "latestSecurityScan<->latestIndexedScan",
+      "mcp": "packages/mcp/src/security-context.ts:latestSecurityScan",
+      "cli": "packages/cli/src/domain/scan-status.ts:latestIndexedScan",
+      "similarity": 1,
+      "both_private": false,
+      "reason": "Not yet unified. scan-status.ts is the largest remaining unit (~1300 lines) and MCP's copy of it spans ten functions; moving it is its own change because scanStatusPayload reaches storage on both sides and the CLI's copy also serves `drift scan status`, which MCP has no equivalent of."
+    },
+    {
+      "key": "mcpV1Scope<->doctorV1Scope",
+      "mcp": "packages/mcp/src/index.ts:mcpV1Scope",
+      "cli": "packages/cli/src/domain/versions.ts:doctorV1Scope",
+      "similarity": 1,
+      "both_private": false,
+      "reason": "Not yet unified. Version/runtime reporting; the two differ only in the surface name they report, which is the argument for one function with a parameter."
+    },
+    {
+      "key": "orderAcceptedConventionsForReview<->orderAcceptedConventionsForReview",
+      "mcp": "packages/mcp/src/index.ts:orderAcceptedConventionsForReview",
+      "cli": "packages/cli/src/commands/conventions.ts:orderAcceptedConventionsForReview",
+      "similarity": 1,
+      "both_private": true,
+      "reason": "Not yet unified. Convention listing/ordering for review surfaces."
+    },
+    {
+      "key": "policyContextNextCommands<->policyContextNextCommands",
+      "mcp": "packages/mcp/src/index.ts:policyContextNextCommands",
+      "cli": "packages/cli/src/domain/policy-context.ts:policyContextNextCommands",
+      "similarity": 1,
+      "both_private": false,
+      "reason": "Not yet unified. Policy-context summary and its next-commands list."
+    },
+    {
+      "key": "policyContextSummary<->policyContextSummary",
+      "mcp": "packages/mcp/src/index.ts:policyContextSummary",
+      "cli": "packages/cli/src/domain/policy-context.ts:policyContextSummary",
+      "similarity": 1,
+      "both_private": false,
+      "reason": "Not yet unified. Policy-context summary and its next-commands list."
+    },
+    {
+      "key": "policyFileContext<->policyFileContext",
+      "mcp": "packages/mcp/src/index.ts:policyFileContext",
+      "cli": "packages/cli/src/domain/repo-map.ts:policyFileContext",
+      "similarity": 1,
+      "both_private": false,
+      "reason": "EXPECTED, and the shape W6 is aiming for. Both are now thin wrappers that resolve their own repo/contract/policy and delegate to buildRepoMapPayload in @drift/query. They still score high because a wrapper is mostly its argument list - but the derivation underneath is one function, which is the property that matters. policyFileContext is genuinely not yet unified."
+    },
+    {
+      "key": "preflightSummary<->preflightSummary",
+      "mcp": "packages/mcp/src/index.ts:preflightSummary",
+      "cli": "packages/cli/src/domain/preflight.ts:preflightSummary",
+      "similarity": 1,
+      "both_private": false,
+      "reason": "Not yet unified. W6 moved the preflight derivation that PRODUCES payload fields (preparedConvention/instructionForConvention, where the two copies had actually diverged); these are the scope/matching helpers around it and are next."
+    },
+    {
+      "key": "readinessForStoredScan<->readinessForStoredScan",
+      "mcp": "packages/mcp/src/index.ts:readinessForStoredScan",
+      "cli": "packages/cli/src/domain/scan-status.ts:readinessForStoredScan",
+      "similarity": 1,
+      "both_private": false,
+      "reason": "Not yet unified. scan-status.ts is the largest remaining unit (~1300 lines) and MCP's copy of it spans ten functions; moving it is its own change because scanStatusPayload reaches storage on both sides and the CLI's copy also serves `drift scan status`, which MCP has no equivalent of."
+    },
+    {
+      "key": "requiredChecksForFiles<->requiredChecksForFiles",
+      "mcp": "packages/mcp/src/index.ts:requiredChecksForFiles",
+      "cli": "packages/cli/src/domain/preflight.ts:requiredChecksForFiles",
+      "similarity": 1,
+      "both_private": false,
+      "reason": "Not yet unified. W6 moved the preflight derivation that PRODUCES payload fields (preparedConvention/instructionForConvention, where the two copies had actually diverged); these are the scope/matching helpers around it and are next."
+    },
+    {
+      "key": "requiredChecksFromGraphRisk<->requiredChecksFromGraphRisk",
+      "mcp": "packages/mcp/src/index.ts:requiredChecksFromGraphRisk",
+      "cli": "packages/cli/src/domain/graph-risk-checks.ts:requiredChecksFromGraphRisk",
+      "similarity": 1,
+      "both_private": false,
+      "reason": "Not yet unified. Required checks derived from graph risk."
+    },
+    {
+      "key": "resolverInputPaths<->resolverInputPaths",
+      "mcp": "packages/mcp/src/index.ts:resolverInputPaths",
+      "cli": "packages/cli/src/domain/scan-status.ts:resolverInputPaths",
+      "similarity": 1,
+      "both_private": true,
+      "reason": "Not yet unified. scan-status.ts is the largest remaining unit (~1300 lines) and MCP's copy of it spans ten functions; moving it is its own change because scanStatusPayload reaches storage on both sides and the CLI's copy also serves `drift scan status`, which MCP has no equivalent of."
+    },
+    {
+      "key": "routeFlowsForChangeImpact<->routeFlowsForChangeImpact",
+      "mcp": "packages/mcp/src/index.ts:routeFlowsForChangeImpact",
+      "cli": "packages/cli/src/commands/prepare.ts:routeFlowsForChangeImpact",
+      "similarity": 1,
+      "both_private": true,
+      "reason": "Not yet unified, and module-private on both sides - the class the census could not see. These feed the change-impact and graph-confidence sections of the preflight packet."
+    },
+    {
+      "key": "scanStatusNextCommands<->scanStatusNextCommands",
+      "mcp": "packages/mcp/src/index.ts:scanStatusNextCommands",
+      "cli": "packages/cli/src/domain/scan-status.ts:scanStatusNextCommands",
+      "similarity": 1,
+      "both_private": false,
+      "reason": "Not yet unified. scan-status.ts is the largest remaining unit (~1300 lines) and MCP's copy of it spans ten functions; moving it is its own change because scanStatusPayload reaches storage on both sides and the CLI's copy also serves `drift scan status`, which MCP has no equivalent of."
+    },
+    {
+      "key": "scanStatusSummary<->scanStatusSummary",
+      "mcp": "packages/mcp/src/index.ts:scanStatusSummary",
+      "cli": "packages/cli/src/domain/scan-status.ts:scanStatusSummary",
+      "similarity": 1,
+      "both_private": false,
+      "reason": "Not yet unified. scan-status.ts is the largest remaining unit (~1300 lines) and MCP's copy of it spans ten functions; moving it is its own change because scanStatusPayload reaches storage on both sides and the CLI's copy also serves `drift scan status`, which MCP has no equivalent of."
+    },
+    {
+      "key": "unavailableGraphContext<->unavailableGraphContext",
+      "mcp": "packages/mcp/src/index.ts:unavailableGraphContext",
+      "cli": "packages/cli/src/domain/graph-preflight.ts:unavailableGraphContext",
+      "similarity": 1,
+      "both_private": true,
+      "reason": "Not yet unified. Graph preflight context assembly; reaches storage on both sides."
+    },
+    {
+      "key": "waiversForFiles<->waiversForFiles",
+      "mcp": "packages/mcp/src/index.ts:waiversForFiles",
+      "cli": "packages/cli/src/domain/preflight.ts:waiversForFiles",
+      "similarity": 0.989,
+      "both_private": false,
+      "reason": "Not yet unified. W6 moved the preflight derivation that PRODUCES payload fields (preparedConvention/instructionForConvention, where the two copies had actually diverged); these are the scope/matching helpers around it and are next."
+    },
+    {
+      "key": "riskyAreasForFiles<->riskyAreasForFiles",
+      "mcp": "packages/mcp/src/index.ts:riskyAreasForFiles",
+      "cli": "packages/cli/src/domain/preflight.ts:riskyAreasForFiles",
+      "similarity": 0.984,
+      "both_private": false,
+      "reason": "Not yet unified. W6 moved the preflight derivation that PRODUCES payload fields (preparedConvention/instructionForConvention, where the two copies had actually diverged); these are the scope/matching helpers around it and are next."
+    },
+    {
+      "key": "countDeniedFiles<->countDeniedFiles",
+      "mcp": "packages/mcp/src/index.ts:countDeniedFiles",
+      "cli": "packages/cli/src/domain/preflight.ts:countDeniedFiles",
+      "similarity": 0.974,
+      "both_private": false,
+      "reason": "Not yet unified. W6 moved the preflight derivation that PRODUCES payload fields (preparedConvention/instructionForConvention, where the two copies had actually diverged); these are the scope/matching helpers around it and are next."
+    },
+    {
+      "key": "scopeMatchesFile<->scopeMatchesFile",
+      "mcp": "packages/mcp/src/index.ts:scopeMatchesFile",
+      "cli": "packages/cli/src/domain/preflight.ts:scopeMatchesFile",
+      "similarity": 0.974,
+      "both_private": false,
+      "reason": "Not yet unified. W6 moved the preflight derivation that PRODUCES payload fields (preparedConvention/instructionForConvention, where the two copies had actually diverged); these are the scope/matching helpers around it and are next."
+    },
+    {
+      "key": "currentMachineContractVersions<->currentMachineContractVersions",
+      "mcp": "packages/mcp/src/index.ts:currentMachineContractVersions",
+      "cli": "packages/cli/src/domain/versions.ts:currentMachineContractVersions",
+      "similarity": 0.971,
+      "both_private": false,
+      "reason": "Not yet unified. Version/runtime reporting; the two differ only in the surface name they report, which is the argument for one function with a parameter."
+    },
+    {
+      "key": "mcpRuntime<->doctorRuntime",
+      "mcp": "packages/mcp/src/index.ts:mcpRuntime",
+      "cli": "packages/cli/src/domain/versions.ts:doctorRuntime",
+      "similarity": 0.97,
+      "both_private": false,
+      "reason": "Not yet unified. Version/runtime reporting; the two differ only in the surface name they report, which is the argument for one function with a parameter."
+    },
+    {
+      "key": "graphNodeIdsForPreflight<->graphNodeIdsForPreflight",
+      "mcp": "packages/mcp/src/index.ts:graphNodeIdsForPreflight",
+      "cli": "packages/cli/src/commands/prepare.ts:graphNodeIdsForPreflight",
+      "similarity": 0.957,
+      "both_private": true,
+      "reason": "Not yet unified, and module-private on both sides - the class the census could not see. These feed the change-impact and graph-confidence sections of the preflight packet."
+    },
+    {
+      "key": "gitOutput<->gitOutput",
+      "mcp": "packages/mcp/src/index.ts:gitOutput",
+      "cli": "packages/cli/src/io/git.ts:gitOutput",
+      "similarity": 0.912,
+      "both_private": false,
+      "reason": "Not yet unified. Thin execFileSync wrapper; the CLI's variant carries CLI-specific error text."
+    },
+    {
+      "key": "scanInvalidationReasons<->scanInvalidationReasons",
+      "mcp": "packages/mcp/src/index.ts:scanInvalidationReasons",
+      "cli": "packages/cli/src/domain/scan-status.ts:scanInvalidationReasons",
+      "similarity": 0.887,
+      "both_private": false,
+      "reason": "Not yet unified. scan-status.ts is the largest remaining unit (~1300 lines) and MCP's copy of it spans ten functions; moving it is its own change because scanStatusPayload reaches storage on both sides and the CLI's copy also serves `drift scan status`, which MCP has no equivalent of."
+    },
+    {
+      "key": "resolverInputFingerprint<->resolverInputFingerprint",
+      "mcp": "packages/mcp/src/index.ts:resolverInputFingerprint",
+      "cli": "packages/cli/src/domain/scan-status.ts:resolverInputFingerprint",
+      "similarity": 0.882,
+      "both_private": false,
+      "reason": "Not yet unified. scan-status.ts is the largest remaining unit (~1300 lines) and MCP's copy of it spans ten functions; moving it is its own change because scanStatusPayload reaches storage on both sides and the CLI's copy also serves `drift scan status`, which MCP has no equivalent of."
+    },
+    {
+      "key": "repoMapPayload<->repoMapPayload",
+      "mcp": "packages/mcp/src/index.ts:repoMapPayload",
+      "cli": "packages/cli/src/domain/repo-map.ts:repoMapPayload",
+      "similarity": 0.88,
+      "both_private": false,
+      "reason": "EXPECTED, and the shape W6 is aiming for. Both are now thin wrappers that resolve their own repo/contract/policy and delegate to buildRepoMapPayload in @drift/query. They still score high because a wrapper is mostly its argument list - but the derivation underneath is one function, which is the property that matters. policyFileContext is genuinely not yet unified."
+    },
+    {
+      "key": "validatePolicySurface<->policySurface",
+      "mcp": "packages/mcp/src/index.ts:validatePolicySurface",
+      "cli": "packages/cli/src/domain/policy-context.ts:policySurface",
+      "similarity": 0.868,
+      "both_private": false,
+      "reason": "Not yet unified. Policy-context summary and its next-commands list."
+    }
+  ]
+}

--- a/scripts/surface-parity.mjs
+++ b/scripts/surface-parity.mjs
@@ -1,0 +1,273 @@
+#!/usr/bin/env node
+/**
+ * W6: the CLI and the MCP server must SHARE a derivation, never keep two of it.
+ *
+ * `beta:proof` already diffs the two surfaces' payloads and has caught two of the three
+ * parser-gap divergences in this remediation. What it cannot see is the structural cause: a
+ * derivation implemented twice. It compares OUTPUT on one fixture repo, so a second
+ * implementation is invisible until some input tells the two copies apart - and the fixture
+ * has to be the input that does it. It was not, three times:
+ *
+ *   - `buildParserGapSection`: both surfaces wrapped the shared builder in a private,
+ *     near-identical function, W4 added `records` to one, and beta:proof went red only because
+ *     the field was structurally absent (`cli=[] mcp=undefined`) rather than differently valued.
+ *   - `instructionForConvention`: MCP's copy never received CV-5's `presence` branch. beta:proof
+ *     is blind to it because its fixture repo accepts no presence-kind convention, so both
+ *     copies take the same branch on the only input that is ever compared.
+ *   - `preparedConvention`: MCP passed no `referenceFile`, which only changes the answer when
+ *     the request names a path that is itself conforming. beta:proof does not send one.
+ *
+ * So this gate reads the SOURCE, not the output. Every function body in packages/mcp/src is
+ * compared against every function body in packages/cli/src; a pair above the similarity
+ * threshold is a duplicated derivation and must be either removed or recorded in
+ * scripts/surface-parity-baseline.json with a reason.
+ *
+ * It ratchets in both directions, which is the vocabulary-parity lesson: a NEW pair fails
+ * (duplication may not grow), and a baseline entry whose pair no longer duplicates also fails
+ * (a stale record is a false claim about the codebase, and it is how a baseline stops
+ * describing anything).
+ *
+ *   node scripts/surface-parity.mjs
+ *   node scripts/surface-parity.mjs --update    # rewrite the baseline (reasons are preserved)
+ *
+ * The census this replaces indexed only symbols carrying a top-level `export`, and recorded
+ * that blind spot as an open gap. All three divergences above were module-private. This
+ * indexes every function regardless of export, because `export` describes who may call a
+ * thing, not whether there are two of it.
+ */
+
+import { readdirSync, readFileSync, writeFileSync } from "node:fs";
+import { dirname, join, relative, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const HERE = dirname(fileURLToPath(import.meta.url));
+const REPO_ROOT = resolve(HERE, "..");
+const BASELINE = join(HERE, "surface-parity-baseline.json");
+
+const CLI_SRC = join(REPO_ROOT, "packages/cli/src");
+const MCP_SRC = join(REPO_ROOT, "packages/mcp/src");
+
+/**
+ * Two bodies this similar are the same derivation written twice.
+ *
+ * 0.85 rather than 1.0 deliberately: an exact-copy check is trivially defeated by a renamed
+ * local or a reordered field, and every divergence in this remediation began as an exact copy
+ * that someone then edited on ONE side. Catching them only after they are byte-identical is
+ * catching them only before they matter.
+ */
+const SIMILARITY_THRESHOLD = 0.85;
+
+/**
+ * Bodies shorter than this are not evidence of a shared derivation.
+ *
+ * Measured rather than guessed: below ~120 normalized characters the matches are things like
+ * `return storage.getRepo(repoId) ?? null;` and one-line type guards, which are similar because
+ * there is only one way to write them, not because a derivation was copied.
+ */
+const MIN_BODY_CHARS = 120;
+
+/** Writes MCP must not perform. The read-only property is structural, so it is checked here. */
+const MUTATION_CALL = /\bstorage\s*\.\s*(upsert|append|record|delete)[A-Za-z0-9_]*\s*\(/;
+
+function listTypeScriptFiles(dir) {
+  return readdirSync(dir, { withFileTypes: true }).flatMap((entry) => {
+    const full = join(dir, entry.name);
+    if (entry.isDirectory()) return listTypeScriptFiles(full);
+    return entry.isFile() && full.endsWith(".ts") && !full.endsWith(".d.ts") ? [full] : [];
+  });
+}
+
+/**
+ * Strip comments and collapse whitespace.
+ *
+ * Comments are removed because a copy whose comment was reworded is still a copy - and that is
+ * the observed shape, not a hypothetical: MCP's `preflightConvention` carried a comment saying
+ * it matched "the CLI's preparedConvention" while its body had already diverged.
+ */
+function normalizeBody(body) {
+  return body
+    .replace(/\/\*[\s\S]*?\*\//g, " ")
+    .replace(/(^|[^:])\/\/[^\n]*/g, "$1")
+    .replace(/\s+/g, " ")
+    .trim();
+}
+
+/** Every `function name(...)` body in a file, by brace matching. */
+export function functionsIn(file, source) {
+  const out = [];
+  const signature = /^[ \t]*(export\s+)?(async\s+)?function\s+([A-Za-z0-9_$]+)\s*[(<]/gm;
+  let match;
+  while ((match = signature.exec(source))) {
+    let depth = 0;
+    let bodyStart = -1;
+    for (let i = signature.lastIndex - 1; i < source.length; i++) {
+      const char = source[i];
+      if (char === "(" || char === "<" || char === "[") depth++;
+      else if (char === ")" || char === ">" || char === "]") depth--;
+      else if (char === "{" && depth <= 0) {
+        bodyStart = i;
+        break;
+      }
+    }
+    if (bodyStart < 0) continue;
+    let braces = 0;
+    let end = bodyStart;
+    for (let i = bodyStart; i < source.length; i++) {
+      if (source[i] === "{") braces++;
+      else if (source[i] === "}") {
+        braces--;
+        if (braces === 0) {
+          end = i;
+          break;
+        }
+      }
+    }
+    out.push({
+      name: match[3],
+      exported: Boolean(match[1]),
+      file: relative(REPO_ROOT, file),
+      line: source.slice(0, match.index).split("\n").length,
+      normalized: normalizeBody(source.slice(bodyStart, end + 1))
+    });
+  }
+  return out;
+}
+
+/**
+ * Token-multiset overlap (Dice). Chosen over raw string equality so a renamed local or a
+ * reordered object literal still scores as the same derivation, and over an edit distance
+ * because this runs over ~700 x ~140 pairs on every CI run.
+ */
+export function similarity(left, right) {
+  if (left === right) return 1;
+  const tokenize = (value) => value.split(/([^A-Za-z0-9_$]+)/).filter((part) => part.trim());
+  const leftTokens = tokenize(left);
+  const rightTokens = tokenize(right);
+  if (leftTokens.length === 0 || rightTokens.length === 0) return 0;
+  const counts = new Map();
+  for (const token of leftTokens) counts.set(token, (counts.get(token) ?? 0) + 1);
+  let shared = 0;
+  for (const token of rightTokens) {
+    const remaining = counts.get(token) ?? 0;
+    if (remaining > 0) {
+      shared++;
+      counts.set(token, remaining - 1);
+    }
+  }
+  return (2 * shared) / (leftTokens.length + rightTokens.length);
+}
+
+/** Every duplicated pair across the boundary, worst (most similar) first. */
+export function duplicatePairs(cliFunctions, mcpFunctions, threshold = SIMILARITY_THRESHOLD) {
+  const pairs = [];
+  for (const mcpFunction of mcpFunctions) {
+    if (mcpFunction.normalized.length < MIN_BODY_CHARS) continue;
+    let best = null;
+    for (const cliFunction of cliFunctions) {
+      if (cliFunction.normalized.length < MIN_BODY_CHARS) continue;
+      const score = similarity(mcpFunction.normalized, cliFunction.normalized);
+      if (!best || score > best.score) best = { score, cliFunction };
+    }
+    if (best && best.score >= threshold) {
+      pairs.push({
+        key: `${mcpFunction.name}<->${best.cliFunction.name}`,
+        mcp: `${mcpFunction.file}:${mcpFunction.name}`,
+        cli: `${best.cliFunction.file}:${best.cliFunction.name}`,
+        similarity: Number(best.score.toFixed(3)),
+        both_private: !mcpFunction.exported && !best.cliFunction.exported
+      });
+    }
+  }
+  return pairs.sort((left, right) => right.similarity - left.similarity || left.key.localeCompare(right.key));
+}
+
+/** MCP source files performing a storage write. The read-only property, checked structurally. */
+export function mutationSites(files) {
+  return files.flatMap(({ file, source }) =>
+    source
+      .split("\n")
+      .map((line, index) => ({ line, number: index + 1 }))
+      .filter(({ line }) => MUTATION_CALL.test(line))
+      .map(({ number }) => `${relative(REPO_ROOT, file)}:${number}`)
+  );
+}
+
+function main() {
+  const update = process.argv.includes("--update");
+
+  const cliFiles = listTypeScriptFiles(CLI_SRC).map((file) => ({ file, source: readFileSync(file, "utf8") }));
+  const mcpFiles = listTypeScriptFiles(MCP_SRC).map((file) => ({ file, source: readFileSync(file, "utf8") }));
+
+  const cliFunctions = cliFiles.flatMap(({ file, source }) => functionsIn(file, source));
+  const mcpFunctions = mcpFiles.flatMap(({ file, source }) => functionsIn(file, source));
+
+  // Fail rather than pass when the parser finds nothing: a gate that silently stops reading its
+  // source reports "no duplicates" forever. This is the shape BB-8's dead cell had.
+  if (cliFunctions.length === 0 || mcpFunctions.length === 0) {
+    console.error(
+      `surface parity: parsed ${cliFunctions.length} CLI and ${mcpFunctions.length} MCP functions. ` +
+        `One of them is zero, so this gate is not reading the source it claims to read.`
+    );
+    process.exit(1);
+  }
+
+  const failures = [];
+
+  const writes = mutationSites(mcpFiles);
+  if (writes.length > 0) {
+    failures.push(
+      `MCP performs ${writes.length} storage write(s), and it is structurally read-only:\n` +
+        writes.map((site) => `    ${site}`).join("\n")
+    );
+  }
+
+  const pairs = duplicatePairs(cliFunctions, mcpFunctions);
+  const baseline = JSON.parse(readFileSync(BASELINE, "utf8"));
+  const known = new Map((baseline.duplicates ?? []).map((entry) => [entry.key, entry]));
+
+  if (update) {
+    const merged = pairs.map((pair) => ({
+      ...pair,
+      reason: known.get(pair.key)?.reason ?? "TODO: unify this derivation, or state why two copies are correct"
+    }));
+    writeFileSync(BASELINE, `${JSON.stringify({ duplicates: merged }, null, 2)}\n`);
+    console.log(`surface parity baseline updated - ${merged.length} recorded duplicate(s)`);
+    process.exit(0);
+  }
+
+  const seen = new Set(pairs.map((pair) => pair.key));
+  for (const pair of pairs) {
+    if (!known.has(pair.key)) {
+      failures.push(
+        `NEW duplicated derivation across the CLI/MCP boundary (${pair.similarity}):\n` +
+          `    mcp ${pair.mcp}\n    cli ${pair.cli}\n` +
+          `    Share it through @drift/query or @drift/core. If two copies are genuinely correct, ` +
+          `record it in scripts/surface-parity-baseline.json with a reason.`
+      );
+    }
+  }
+  for (const key of known.keys()) {
+    if (!seen.has(key)) {
+      failures.push(
+        `STALE baseline entry: ${key} is no longer a duplicated pair. Remove it from ` +
+          `scripts/surface-parity-baseline.json - a recorded duplicate that does not exist is a false record.`
+      );
+    }
+  }
+
+  if (failures.length > 0) {
+    console.error("surface parity FAILED:\n");
+    for (const failure of failures) console.error(`  ${failure}\n`);
+    process.exit(1);
+  }
+
+  const privateCount = pairs.filter((pair) => pair.both_private).length;
+  console.log(
+    `surface parity: ${cliFunctions.length} CLI and ${mcpFunctions.length} MCP function bodies compared, ` +
+      `${pairs.length} recorded duplicate(s) (${privateCount} module-private), 0 MCP storage writes.`
+  );
+}
+
+if (process.argv[1] && resolve(process.argv[1]) === resolve(fileURLToPath(import.meta.url))) {
+  main();
+}

--- a/scripts/surface-parity.test.mjs
+++ b/scripts/surface-parity.test.mjs
@@ -1,0 +1,166 @@
+import { execFileSync } from "node:child_process";
+import { readFileSync, writeFileSync } from "node:fs";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+import { afterEach, describe, expect, it } from "vitest";
+
+import { duplicatePairs, functionsIn, mutationSites, similarity } from "./surface-parity.mjs";
+
+/**
+ * W6: tests for the duplicate-derivation gate.
+ *
+ * The gate exists because `beta:proof` compares OUTPUT and therefore cannot see a derivation
+ * implemented twice until some input tells the two copies apart. Its own failure modes are the
+ * same ones every gate in this repo has had: reading nothing and reporting success, ratcheting in
+ * only one direction, and holding a baseline that has stopped describing the codebase.
+ */
+
+const HERE = dirname(fileURLToPath(import.meta.url));
+const GATE = join(HERE, "surface-parity.mjs");
+const BASELINE = join(HERE, "surface-parity-baseline.json");
+
+function runGate() {
+  try {
+    const stdout = execFileSync(process.execPath, [GATE], { encoding: "utf8" });
+    return { code: 0, stdout, stderr: "" };
+  } catch (error) {
+    return {
+      code: error.status ?? 1,
+      stdout: error.stdout?.toString() ?? "",
+      stderr: error.stderr?.toString() ?? ""
+    };
+  }
+}
+
+const original = readFileSync(BASELINE, "utf8");
+afterEach(() => writeFileSync(BASELINE, original));
+
+describe("surface parity gate", () => {
+  it("passes against the committed baseline", () => {
+    const result = runGate();
+    expect(result.stderr).toBe("");
+    expect(result.code).toBe(0);
+    expect(result.stdout).toContain("recorded duplicate(s)");
+  });
+
+  it("fails on a NEW duplicated derivation", () => {
+    // The ratchet's forward direction: duplication may not grow. Dropping one entry stands in for
+    // a newly copied function - the gate sees a pair it has no record of either way.
+    const baseline = JSON.parse(original);
+    const dropped = baseline.duplicates[0];
+    writeFileSync(
+      BASELINE,
+      `${JSON.stringify({ duplicates: baseline.duplicates.slice(1) }, null, 2)}\n`
+    );
+    const result = runGate();
+    expect(result.code).toBe(1);
+    expect(result.stderr).toContain("NEW duplicated derivation");
+    expect(result.stderr).toContain(dropped.key.split("<->")[0]);
+  });
+
+  it("fails on a STALE baseline entry", () => {
+    // The other direction, and the one gates usually lack. A recorded duplicate that no longer
+    // exists is a false claim about the codebase; left alone, the baseline stops describing
+    // anything and unifying a pair becomes a silent no-op.
+    const baseline = JSON.parse(original);
+    writeFileSync(
+      BASELINE,
+      `${JSON.stringify(
+        {
+          duplicates: [
+            ...baseline.duplicates,
+            {
+              key: "unifiedLongAgo<->unifiedLongAgo",
+              mcp: "packages/mcp/src/index.ts:unifiedLongAgo",
+              cli: "packages/cli/src/domain/gone.ts:unifiedLongAgo",
+              similarity: 1,
+              both_private: false,
+              reason: "recorded, but these were unified"
+            }
+          ]
+        },
+        null,
+        2
+      )}\n`
+    );
+    const result = runGate();
+    expect(result.code).toBe(1);
+    expect(result.stderr).toContain("STALE baseline entry");
+    expect(result.stderr).toContain("unifiedLongAgo");
+  });
+
+  it("records the pairs the export-only census could not see", () => {
+    // The blind spot this replaces: the architecture census indexed only symbols carrying a
+    // top-level `export`, and all three parser-gap divergences in this remediation were
+    // module-private. A baseline with no private pairs in it would mean the parser regressed to
+    // the census's view.
+    const baseline = JSON.parse(original);
+    expect(baseline.duplicates.filter((entry) => entry.both_private).length).toBeGreaterThan(0);
+  });
+
+  it("gives every recorded duplicate a reason", () => {
+    const baseline = JSON.parse(original);
+    for (const entry of baseline.duplicates) {
+      expect(entry.reason, `${entry.key} has no reason`).toBeTruthy();
+      expect(entry.reason, `${entry.key} still carries the placeholder reason`).not.toContain("TODO");
+    }
+  });
+});
+
+describe("surface parity mechanics", () => {
+  it("scores a copy with a reworded comment as identical", () => {
+    // The observed shape, not a hypothetical: MCP's preflightConvention carried a comment saying
+    // it matched the CLI's preparedConvention while its body had already diverged.
+    const withOneComment = functionsIn("a.ts", "function f() {\n  // does a thing\n  return compute(input) + 1;\n}");
+    const withAnother = functionsIn("b.ts", "function f() {\n  /* entirely different words */\n  return compute(input) + 1;\n}");
+    expect(similarity(withOneComment[0].normalized, withAnother[0].normalized)).toBe(1);
+  });
+
+  it("indexes module-private functions, not only exported ones", () => {
+    const found = functionsIn("a.ts", "function privateOne() { return 1; }\nexport function publicOne() { return 2; }");
+    expect(found.map((entry) => entry.name)).toEqual(["privateOne", "publicOne"]);
+    expect(found[0].exported).toBe(false);
+    expect(found[1].exported).toBe(true);
+  });
+
+  it("ignores bodies too short to be evidence of a shared derivation", () => {
+    // Below the floor the matches are things like `return storage.getRepo(id) ?? null;` - alike
+    // because there is one way to write them, not because anything was copied.
+    const cli = functionsIn("cli.ts", "function short() { return a ? b : c; }");
+    const mcp = functionsIn("mcp.ts", "function short() { return a ? b : c; }");
+    expect(duplicatePairs(cli, mcp)).toEqual([]);
+  });
+
+  it("sees a copy whose locals were renamed", () => {
+    // An exact-copy check is defeated by one rename, and every divergence in this remediation
+    // began as an exact copy that someone then edited on one side.
+    const body = (name) =>
+      `function build(${name}) {\n` +
+      `  const rows = ${name}.listFindings(repoId).filter(isOpen);\n` +
+      `  const counts = rows.map((row) => row.severity);\n` +
+      `  return { rows, counts, total: rows.length, repo: repoId, kind: "summary" };\n}`;
+    const cli = functionsIn("cli.ts", body("storage"));
+    const mcp = functionsIn("mcp.ts", body("handle"));
+    const pairs = duplicatePairs(cli, mcp);
+    expect(pairs).toHaveLength(1);
+    expect(pairs[0].similarity).toBeGreaterThan(0.85);
+    expect(pairs[0].similarity).toBeLessThan(1);
+  });
+
+  it("names a storage write in MCP", () => {
+    // The read-only property, checked structurally rather than trusted. MCP's payloads assert
+    // `read_only: true`; nothing compared that claim to the source.
+    const writes = mutationSites([
+      { file: join(HERE, "../packages/mcp/src/index.ts"), source: "storage.upsertFinding({ id });" }
+    ]);
+    expect(writes).toHaveLength(1);
+    expect(writes[0]).toContain("packages/mcp/src/index.ts:1");
+  });
+
+  it("does not mistake a read for a write", () => {
+    const reads = mutationSites([
+      { file: join(HERE, "../packages/mcp/src/index.ts"), source: "storage.listFindings(repoId);\nstorage.getRepo(repoId);" }
+    ]);
+    expect(reads).toEqual([]);
+  });
+});

--- a/test/e2e/release-hygiene.test.ts
+++ b/test/e2e/release-hygiene.test.ts
@@ -75,11 +75,19 @@ describe("release hygiene", () => {
       // fixture repo, so a derivation implemented twice stays invisible until some input tells the
       // copies apart - and three times running, the fixture was not that input. This gate reads the
       // source instead and fails on a function body duplicated across the CLI/MCP boundary.
-      "pnpm verify && pnpm test:harness && pnpm format:engine:check && pnpm lint:engine && pnpm check:boundaries && pnpm check:storage-lifecycle && pnpm check:storage-invariants && pnpm check:error-contract && pnpm check:vocabulary && pnpm check:surface-parity && node scripts/validate-engine-release-matrix.mjs --allow-unverified && pnpm validate:claims && pnpm beta:proof && git diff --check",
+      //
+      // And `pnpm check:payload-invariants`: a trust-calibration field that cannot change is not
+      // calibrating anything. Four shipped that way - `truncated.conventions`, `error.type`,
+      // `test_intelligence_reason`, `full_list_command` - each found by hand, one workstream at a
+      // time. It drives a fixture matrix through both surfaces and fails on a discriminator that is
+      // identical everywhere, and it FOLLOWS every data pointer, because `full_list_command` named
+      // a real command that exits 0 and simply did not serve the data.
+      "pnpm verify && pnpm test:harness && pnpm format:engine:check && pnpm lint:engine && pnpm check:boundaries && pnpm check:storage-lifecycle && pnpm check:storage-invariants && pnpm check:error-contract && pnpm check:vocabulary && pnpm check:surface-parity && pnpm check:payload-invariants && node scripts/validate-engine-release-matrix.mjs --allow-unverified && pnpm validate:claims && pnpm beta:proof && git diff --check",
     );
     expect(manifest.scripts["check:storage-invariants"]).toBe("node scripts/storage-invariants.mjs");
     expect(manifest.scripts["check:error-contract"]).toBe("node scripts/error-contract.mjs");
     expect(manifest.scripts["check:surface-parity"]).toBe("node scripts/surface-parity.mjs");
+    expect(manifest.scripts["check:payload-invariants"]).toBe("node scripts/payload-invariants.mjs");
     expect(manifest.scripts["verify:evals"]).toBe(
       // W7 added `pnpm eval:breadth`, the detection-breadth ratchet. Pinned whole for the same
       // reason as verify:ci above: an eval silently dropped is indistinguishable from one that

--- a/test/e2e/release-hygiene.test.ts
+++ b/test/e2e/release-hygiene.test.ts
@@ -70,10 +70,16 @@ describe("release hygiene", () => {
       // hand-maintained mirrors, and the day this was written check-repo silently dropped 6 of 36
       // fact kinds while semantic coverage refused on every repo. Neither is visible from any
       // behaviour a test would naturally assert, which is what makes it a gate rather than a test.
-      "pnpm verify && pnpm test:harness && pnpm format:engine:check && pnpm lint:engine && pnpm check:boundaries && pnpm check:storage-lifecycle && pnpm check:storage-invariants && pnpm check:error-contract && pnpm check:vocabulary && node scripts/validate-engine-release-matrix.mjs --allow-unverified && pnpm validate:claims && pnpm beta:proof && git diff --check",
+      //
+      // W6 adds `pnpm check:surface-parity`: `beta:proof` compares the two surfaces' OUTPUT on one
+      // fixture repo, so a derivation implemented twice stays invisible until some input tells the
+      // copies apart - and three times running, the fixture was not that input. This gate reads the
+      // source instead and fails on a function body duplicated across the CLI/MCP boundary.
+      "pnpm verify && pnpm test:harness && pnpm format:engine:check && pnpm lint:engine && pnpm check:boundaries && pnpm check:storage-lifecycle && pnpm check:storage-invariants && pnpm check:error-contract && pnpm check:vocabulary && pnpm check:surface-parity && node scripts/validate-engine-release-matrix.mjs --allow-unverified && pnpm validate:claims && pnpm beta:proof && git diff --check",
     );
     expect(manifest.scripts["check:storage-invariants"]).toBe("node scripts/storage-invariants.mjs");
     expect(manifest.scripts["check:error-contract"]).toBe("node scripts/error-contract.mjs");
+    expect(manifest.scripts["check:surface-parity"]).toBe("node scripts/surface-parity.mjs");
     expect(manifest.scripts["verify:evals"]).toBe(
       // W7 added `pnpm eval:breadth`, the detection-breadth ratchet. Pinned whole for the same
       // reason as verify:ci above: an eval silently dropped is indistinguishable from one that


### PR DESCRIPTION
Four workstreams, five commits. Each task is its own commit; the two gate baselines are
separate from the fixes that moved them.

## What changed

**`fcf2d1f5` — eval envelope ratchet.** `packet_within_envelope_budget` is a cliff that only
trips at 500,000 bytes, and W7 put the measurement (`packet_bytes`) in `VOLATILE` — the set the
baseline diff *skips*. dub sits at 270,193 and could reach 499,999 while the suite prints "no
change vs baseline". Adds a compared `packet_budget_band` with an unsafe-move ratchet.

**`e542dc3d` — W6, the two surfaces share a derivation.** `repoMapPayload` existed twice;
`mcp keys − cli keys` was exactly `route_source_summary`, `canonical_route_fallback`,
`proof_freshness` — all three computed inside the CLI's copy and dropped, so two documents
claiming `drift.repo.map.v1` disagreed about which keys that schema has. Also unifies
`preparedConvention` (D-A1) and, **not in the audit**, MCP's `instructionForConvention`, which
never received CV-5's `presence` branch — so the MCP packet never told an agent that Drift
checks only that an auth/rate-limit helper is *called*, not that it guards the route.
New gate: `scripts/surface-parity.mjs`.

**`f7ca05ae` — W4 remainder.** `test_intelligence` fixed three ways (D-A3); `supporting_examples_count`
deduped, **plus a second instance at `candidate_command.rs:249` the audit did not name**;
`selfClassifiedError` so MCP's refusals classify from a code rather than their prose (D-E7);
six commands given a human-readable path (D-CL2).

**`6e7dc8f6` — D-CL3.** The command surface is enumerated **four** times, not three — `doctor`,
`capabilities` and `restore` dispatch in `run-cli.ts` before the router. Cross-checked by
reading the router's own source.

**`2e7b8570` — payload-invariants gate.** A trust-calibration field that cannot change is not
calibrating anything. Two checks, because the brief's stated principle does not cover one of its
own four examples: `full_list_command` *varied*, and its defect was pointing at a command that
exits 0 and serves nothing. So the gate also **follows every data pointer**.

## What the brief got wrong

- **The eval baseline was not stale.** It was rewritten at `07bdbb6f` (W7); a clean run against
  `main` printed `no change vs baseline — 7/7 passing`. The brief's paragraph is W7's own
  pre-fix diagnosis restated as current, and its figure of 774,327 bytes appears nowhere —
  W7 measured 715,023.
- **D-M3 and D-M2 are non-defects.** MCP's `isTypescriptPath` has zero call sites; staleness
  already runs through the shared walker, which already handles `.gitignore` and `.prisma`.
- **D-CL4 is largely a non-defect.** `warn`→0 is asserted at `cli.test.ts:3111`.
- **Both predicted baseline moves did not happen**, and the reason is checkable: external-eval
  never calls `repo map`, and its `prepare` passes no `--path`.

## Known gaps, recorded rather than hidden

- 40 duplicate CLI/MCP pairs remain, baselined with reasons; the largest cluster is
  `scan-status.ts` (10 functions).
- The payload baseline separates `product_invariant` (cannot vary) from `matrix_gap` (we did not
  make it vary) — 115 of the latter. Collapsing them would let an untested corner read as a
  promise.
- 8 entries are `unimplemented_placeholder`: `snapshot_usage` and `stale_test_candidate` are
  hardcoded and nothing computes them. Three more (`covered_symbols`, `mocked_dependencies`,
  `fixture_usage`) are the same class but invisible to the gate, because an always-empty array
  produces no leaf. Follow-up work.

## Validation

cli 678 · core 220 · storage 60 · mcp 67 · query 68 · harness 190 (was 154) · e2e 83 · engine 335

`beta:proof` exit 0 · `external-eval` 7/7 no change vs baseline · `presence-precision-recall` no
change · `cargo fmt --check` and `clippy -D warnings` clean · `git diff --check` clean · all
seven static gates pass.

Every new test was confirmed red by reintroducing its specific defect, not by stashing a file
that would not compile.

🤖 Generated with [Claude Code](https://claude.com/claude-code)