### PR TITLE
test_intelligence: compute three fields, drop one, hold the rest honestly

### DIFF
--- a/packages/cli/src/commands/prepare.ts
+++ b/packages/cli/src/commands/prepare.ts
@@ -118,7 +118,10 @@ export function prepareTask(storage: SqliteDriftStorage, parsed: ParsedArgs): Co
     // D-A3(a): every relevant file, not just the head of the ranked list.
     changed_files: relevantFiles.map((file) => file.path),
     route_flow: changeImpactRouteFlows[0],
-    test_files: testFiles
+    test_files: testFiles,
+    // Lets the matched tests be read for snapshot/mock/fixture evidence. Without it those three
+    // fields report `null` rather than a zero value they did not measure.
+    repo_root: repo.root_path
   });
   const agentContractPacket = createAgentPreflightPacket({
     repoContract: { ...contract, conventions: activeConventions },

--- a/packages/core/src/domain.ts
+++ b/packages/core/src/domain.ts
@@ -893,18 +893,28 @@ export interface ChangeImpact {
   missing_test_candidates: string[];
 }
 
+/**
+ * What is known about a test that covers a change.
+ *
+ * `missing_test_candidate` is NOT here, and its absence is the point. An entry exists in this array
+ * only because a test was FOUND for the subject, so a per-entry "a test is missing" flag was false
+ * by construction - it could not have been true in any payload Drift has ever emitted. The signal
+ * it looked like it carried is real and lives on the selection, where it varies.
+ *
+ * The three nullable fields are read from the test file's own source, and `null` means the source
+ * was not read - not that the answer is no. See TestFileEvidence in @drift/query.
+ */
 export interface TestIntelligence {
-  schema_version: "drift.test_intelligence.v1";
+  schema_version: "drift.test_intelligence.v2";
   test_subject: string;
   test_type: "unit" | "integration" | "e2e" | "unknown";
   test_framework: "vitest" | "jest" | "playwright" | "unknown";
   test_file_for: string[];
   covered_symbols: string[];
   covered_routes: string[];
-  mocked_dependencies: string[];
-  fixture_usage: string[];
-  snapshot_usage: boolean;
-  missing_test_candidate: boolean;
+  mocked_dependencies: string[] | null;
+  fixture_usage: string[] | null;
+  snapshot_usage: boolean | null;
   stale_test_candidate: boolean;
 }
 

--- a/packages/core/src/schemas.ts
+++ b/packages/core/src/schemas.ts
@@ -955,17 +955,20 @@ export const ChangeImpactSchema = z.object({
 });
 
 export const TestIntelligenceSchema = z.object({
-  schema_version: z.literal("drift.test_intelligence.v1"),
+  schema_version: z.literal("drift.test_intelligence.v2"),
   test_subject: z.string().min(1),
   test_type: z.enum(["unit", "integration", "e2e", "unknown"]),
   test_framework: z.enum(["vitest", "jest", "playwright", "unknown"]),
   test_file_for: z.array(z.string().min(1)),
   covered_symbols: z.array(z.string().min(1)),
   covered_routes: z.array(z.string().min(1)),
-  mocked_dependencies: z.array(z.string().min(1)),
-  fixture_usage: z.array(z.string().min(1)),
-  snapshot_usage: z.boolean(),
-  missing_test_candidate: z.boolean(),
+  // Nullable: read from the test file's source, and null when there was no source to read. See
+  // the TestIntelligence interface for why that is not the same answer as `[]` or `false`.
+  mocked_dependencies: z.array(z.string().min(1)).nullable(),
+  fixture_usage: z.array(z.string().min(1)).nullable(),
+  snapshot_usage: z.boolean().nullable(),
+  // `missing_test_candidate` is deliberately absent - false by construction for every entry that
+  // can exist. RelevantTestsSelection carries the one that varies.
   stale_test_candidate: z.boolean()
 });
 

--- a/packages/core/test/domain.test.ts
+++ b/packages/core/test/domain.test.ts
@@ -260,7 +260,7 @@ describe("core domain", () => {
     })).toMatchObject({ affected_routes: ["GET /api/users"] });
 
     expect(TestIntelligenceSchema.parse({
-      schema_version: "drift.test_intelligence.v1",
+      schema_version: "drift.test_intelligence.v2",
       test_subject: "server/services/users.ts",
       test_type: "unit",
       test_framework: "vitest",
@@ -270,9 +270,41 @@ describe("core domain", () => {
       mocked_dependencies: ["server/repositories/users.ts"],
       fixture_usage: [],
       snapshot_usage: false,
-      missing_test_candidate: false,
       stale_test_candidate: false
     })).toMatchObject({ test_framework: "vitest" });
+
+    // The read that did not happen. `null` is a legal value for the three source-derived fields
+    // and is NOT interchangeable with `[]`/`false`: it says the test file was never opened.
+    expect(TestIntelligenceSchema.parse({
+      schema_version: "drift.test_intelligence.v2",
+      test_subject: "server/services/users.ts",
+      test_type: "unit",
+      test_framework: "vitest",
+      test_file_for: ["server/services/users.ts"],
+      covered_symbols: [],
+      covered_routes: [],
+      mocked_dependencies: null,
+      fixture_usage: null,
+      snapshot_usage: null,
+      stale_test_candidate: false
+    })).toMatchObject({ snapshot_usage: null });
+
+    // And the dropped field is rejected rather than tolerated, so a producer still emitting the
+    // per-entry `missing_test_candidate` is a failure and not a silent no-op.
+    expect(() => TestIntelligenceSchema.strict().parse({
+      schema_version: "drift.test_intelligence.v2",
+      test_subject: "server/services/users.ts",
+      test_type: "unit",
+      test_framework: "vitest",
+      test_file_for: ["server/services/users.ts"],
+      covered_symbols: [],
+      covered_routes: [],
+      mocked_dependencies: null,
+      fixture_usage: null,
+      snapshot_usage: null,
+      missing_test_candidate: false,
+      stale_test_candidate: false
+    })).toThrow();
   });
 
   it("creates deterministic agent envelope actions", () => {

--- a/packages/mcp/src/index.ts
+++ b/packages/mcp/src/index.ts
@@ -269,7 +269,10 @@ export function createReadOnlyMcpHandlers(options: DriftMcpOptions): DriftMcpHan
         // D-A3(a): every relevant file, not just the head of the ranked list.
         changed_files: relevantFiles.map((file) => file.path),
         route_flow: changeImpactRouteFlows[0],
-        test_files: testFiles
+        test_files: testFiles,
+        // Lets the matched tests be read for snapshot/mock/fixture evidence. Without it those three
+        // fields report `null` rather than a zero value they did not measure.
+        repo_root: storage.getRepo(requestedRepoId)!.root_path
       });
       const waivers = waiversForFiles(contract, relevantFiles, generatedAt);
       const agentContractPacket = createAgentPreflightPacket({

--- a/packages/query/src/test-intelligence.ts
+++ b/packages/query/src/test-intelligence.ts
@@ -28,6 +28,9 @@
  *       collapse it - that gate indexes function bodies. Worth recording as a known limit of it.
  */
 
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+
 import type { TestIntelligence } from "@drift/core";
 
 export interface SelectRelevantTestsInput {
@@ -41,6 +44,18 @@ export interface SelectRelevantTestsInput {
     service_file?: string;
   };
   test_files: string[];
+  /**
+   * Where to read the MATCHED test files from, for the three fields that are answerable only from
+   * a test's own source. Optional, and its absence is reported rather than papered over: without
+   * it `snapshot_usage`, `mocked_dependencies` and `fixture_usage` are `null` - "not looked at" -
+   * instead of the `false`/`[]` that reads as "looked, and no".
+   *
+   * Reading lives here rather than in the two callers because that is the W6 shape: a derivation
+   * both surfaces need, kept in one place so `prepare` and `get_task_preflight` cannot come to
+   * different conclusions about the same file. Only MATCHED tests are read, so the cost is bounded
+   * by the size of the answer rather than by the size of the repo.
+   */
+  repo_root?: string;
 }
 
 /**
@@ -84,21 +99,29 @@ export function selectRelevantTests(input: SelectRelevantTestsInput): RelevantTe
     closest_tests: matches.map((entry) => entry.testFile),
     missing_test_candidate: matches.length === 0,
     required_check_hint: `npm test -- ${slug}`,
-    test_intelligence: matches.map((entry) => ({
-      schema_version: "drift.test_intelligence.v1",
-      test_subject: entry.subject,
-      test_type: entry.testFile.includes("/api/") ? "integration" : "unit",
-      test_framework:
-        entry.testFile.includes(".spec.") || entry.testFile.includes(".test.") ? "vitest" : "unknown",
-      test_file_for: subjects,
-      covered_symbols: [],
-      covered_routes: input.route_flow?.route ? [input.route_flow.route] : [],
-      mocked_dependencies: [],
-      fixture_usage: [],
-      snapshot_usage: false,
-      missing_test_candidate: false,
-      stale_test_candidate: false
-    })),
+    test_intelligence: matches.map((entry) => {
+      const evidence = readTestFileEvidence(input.repo_root, entry.testFile);
+      return {
+        schema_version: "drift.test_intelligence.v2",
+        test_subject: entry.subject,
+        test_type: entry.testFile.includes("/api/") ? "integration" : "unit",
+        test_framework:
+          entry.testFile.includes(".spec.") || entry.testFile.includes(".test.") ? "vitest" : "unknown",
+        test_file_for: subjects,
+        covered_routes: input.route_flow?.route ? [input.route_flow.route] : [],
+        // Read from the test's own source. `null` when there was no source to read - see
+        // TestFileEvidence for why that is a value and not a failure.
+        snapshot_usage: evidence?.snapshot_usage ?? null,
+        mocked_dependencies: evidence?.mocked_dependencies ?? null,
+        fixture_usage: evidence?.fixture_usage ?? null,
+        // NOT computed, and recorded as such in scripts/payload-invariants-baseline.json rather
+        // than presented as a measurement. `covered_symbols` needs the test's call sites resolved
+        // against the symbol graph, which is engine work; `stale_test_candidate` needs a stated
+        // definition of stale-relative-to-what before it can have an implementation.
+        covered_symbols: [],
+        stale_test_candidate: false
+      };
+    }),
     // (c): derived from the inputs that tell the two cases apart, rather than from the emptiness
     // of the output - which is the one thing both cases have in common.
     test_intelligence_reason:
@@ -108,6 +131,76 @@ export function selectRelevantTests(input: SelectRelevantTestsInput): RelevantTe
           ? "no_test_files_in_repo"
           : "no_tests_matched_change"
   };
+}
+
+/**
+ * What a test file says about itself, read from the test file.
+ *
+ * `null` rather than a zero value when there is nothing to read - no `repo_root`, or a path that
+ * no longer resolves because the scan is stale and the file is gone. That distinction is the whole
+ * point of this change: `snapshot_usage: false` reads to an agent as "checked, and this test has no
+ * snapshot", which is a confident answer to give from a field that never opened the file. `null`
+ * says "not looked at", and an agent deciding whether its edit breaks a snapshot can tell the two
+ * apart.
+ */
+interface TestFileEvidence {
+  snapshot_usage: boolean;
+  mocked_dependencies: string[];
+  fixture_usage: string[];
+}
+
+/**
+ * `expect(x).toMatchSnapshot()` and its inline/file variants, or a reference to a checked-in
+ * `.snap`. Deliberately a source scan and not a parse: the question is whether this test asserts
+ * against a stored snapshot, and the call by name answers it.
+ */
+const SNAPSHOT_ASSERTION = /\btoMatch(?:Inline|File)?Snapshot\s*\(|\.snap\b/;
+
+/** `vi.mock("x")` / `jest.mock('x')`, and the non-hoisted `doMock` forms of both. */
+const MOCK_CALL = /\b(?:vi|jest)\.(?:do)?[Mm]ock\s*\(\s*["'`]([^"'`]+)["'`]/g;
+
+/** Every `import ... from "x"`, bare `import "x"` and `require("x")` specifier. */
+const IMPORT_SPECIFIER = /(?:\bfrom|\bimport|\brequire)\s*\(?\s*["'`]([^"'`]+)["'`]/g;
+
+/**
+ * Which of those specifiers is a fixture. Stated as a rule rather than guessed at, because a field
+ * named `fixture_usage` that answers a question nobody wrote down is the defect one level up: a
+ * `__fixtures__` or `fixtures` path segment, or a `.fixture`/`.fixtures` filename suffix.
+ *
+ * The suffix has to admit end-of-string, not just `.fixture.`: an import specifier carries no
+ * extension, so `./users.fixture` is how the common case actually appears and a rule written for
+ * `users.fixture.ts` misses every one of them.
+ */
+const FIXTURE_SPECIFIER = /(^|\/)(__fixtures__|fixtures)(\/|$)|\.fixtures?(\.|\/|$)/;
+
+function readTestFileEvidence(
+  repoRoot: string | undefined,
+  testFile: string
+): TestFileEvidence | null {
+  if (!repoRoot) return null;
+  let source: string;
+  try {
+    source = readFileSync(join(repoRoot, testFile), "utf8");
+  } catch {
+    return null;
+  }
+  return {
+    snapshot_usage: SNAPSHOT_ASSERTION.test(source),
+    mocked_dependencies: sortedUnique(captured(source, MOCK_CALL)),
+    fixture_usage: sortedUnique(
+      captured(source, IMPORT_SPECIFIER).filter((specifier) => FIXTURE_SPECIFIER.test(specifier))
+    )
+  };
+}
+
+function captured(source: string, pattern: RegExp): string[] {
+  // A fresh RegExp per call: these are module-level and `g` makes `lastIndex` stateful, so sharing
+  // one across two files would start the second scan wherever the first one stopped.
+  return [...source.matchAll(new RegExp(pattern.source, pattern.flags))].map((match) => match[1]);
+}
+
+function sortedUnique(values: string[]): string[] {
+  return [...new Set(values)].sort();
 }
 
 function matchesSubject(testFile: string, subject: string): boolean {

--- a/packages/query/test/query.test.ts
+++ b/packages/query/test/query.test.ts
@@ -1,4 +1,4 @@
-import { mkdtemp, rm } from "node:fs/promises";
+import { mkdir, mkdtemp, rm, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { API_ROUTE_SCOPE_GLOBS, ENGINE_CERTIFIED_SCAN_CAPABILITIES, type Finding, type RepoContract } from "@drift/core";
@@ -470,6 +470,120 @@ describe("GraphQueryService", () => {
     });
     expect(result.closest_tests).toEqual([]);
     expect(result.test_intelligence_reason).toBe("no_tests_matched_change");
+  });
+
+  /** A repo with one matched test whose source carries the three things now read from it. */
+  async function repoWithTestSource(source: string): Promise<string> {
+    const dir = await mkdtemp(join(tmpdir(), "drift-test-intelligence-"));
+    tempDirs.push(dir);
+    await mkdir(join(dir, "server/services"), { recursive: true });
+    await writeFile(join(dir, "server/services/users.test.ts"), source);
+    return dir;
+  }
+
+  const SELECT_USERS = {
+    changed_files: ["server/services/users.ts"],
+    test_files: ["server/services/users.test.ts"]
+  };
+
+  it("reads snapshot, mock and fixture evidence from the matched test's source", async () => {
+    // EW-3. These three were literals - `false`, `[]`, `[]` - on every entry Drift has ever
+    // emitted, and the payload-invariants gate confirms it: identical across all 176 matrix cells.
+    // An agent asking "does my edit break a snapshot test" got a confident no from a field that
+    // had never opened the file.
+    const repoRoot = await repoWithTestSource([
+      'import { describe, expect, it, vi } from "vitest";',
+      'import { listUsers } from "./users";',
+      'import { userRows } from "../__fixtures__/users.json";',
+      'import { seed } from "./users.fixture";',
+      'vi.mock("server/repositories/users");',
+      "jest.mock('server/lib/clock');",
+      'it("renders", () => { expect(listUsers(userRows)).toMatchSnapshot(); });'
+    ].join("\n"));
+
+    const result = selectRelevantTests({ ...SELECT_USERS, repo_root: repoRoot });
+
+    expect(result.test_intelligence[0]).toMatchObject({
+      snapshot_usage: true,
+      // Both framework spellings, deduplicated and ordered so the payload is stable.
+      mocked_dependencies: ["server/lib/clock", "server/repositories/users"],
+      // A `__fixtures__` path segment and a `.fixture.` filename; `./users` and `vitest` are
+      // imports and not fixtures, and must not be swept in.
+      fixture_usage: ["../__fixtures__/users.json", "./users.fixture"]
+    });
+  });
+
+  it("answers no rather than nothing when the test genuinely has none of them", async () => {
+    // The other half, and the one that makes the field worth reading: a real `false` from a real
+    // look has to be distinguishable from the `null` below.
+    const repoRoot = await repoWithTestSource(
+      'import { listUsers } from "./users";\nit("works", () => { expect(listUsers()).toEqual([]); });\n'
+    );
+    expect(selectRelevantTests({ ...SELECT_USERS, repo_root: repoRoot }).test_intelligence[0])
+      .toMatchObject({ snapshot_usage: false, mocked_dependencies: [], fixture_usage: [] });
+  });
+
+  it("says null, not false, when it never opened the file", async () => {
+    // Two ways to have nothing to read, and neither may be reported as a measurement. Without a
+    // repo_root there is nowhere to look; with one, a path from a stale scan can name a file that
+    // has since been deleted.
+    const noRepoRoot = selectRelevantTests(SELECT_USERS);
+    expect(noRepoRoot.test_intelligence[0]).toMatchObject({
+      snapshot_usage: null,
+      mocked_dependencies: null,
+      fixture_usage: null
+    });
+
+    const emptyRepo = await mkdtemp(join(tmpdir(), "drift-test-intelligence-"));
+    tempDirs.push(emptyRepo);
+    expect(selectRelevantTests({ ...SELECT_USERS, repo_root: emptyRepo }).test_intelligence[0])
+      .toMatchObject({ snapshot_usage: null, mocked_dependencies: null, fixture_usage: null });
+  });
+
+  it("keeps the selection's missing_test_candidate after dropping the per-entry one", async () => {
+    // The drop, and the trap in it. `missing_test_candidate` names two different things one level
+    // apart: the per-entry flag was false by construction - an entry exists only because a test
+    // was FOUND - while the selection-level one carries the real signal and varies. A blind
+    // rename would have taken both.
+    const repoRoot = await repoWithTestSource('it("works", () => {});\n');
+    const found = selectRelevantTests({ ...SELECT_USERS, repo_root: repoRoot });
+    expect(found.missing_test_candidate).toBe(false);
+    expect(found.test_intelligence[0]).not.toHaveProperty("missing_test_candidate");
+
+    const missing = selectRelevantTests({
+      changed_files: ["server/services/billing.ts"],
+      test_files: ["server/services/users.test.ts"],
+      repo_root: repoRoot
+    });
+    expect(missing.missing_test_candidate).toBe(true);
+  });
+
+  it("does not let one test file's mocks leak into the next", async () => {
+    // The `g` flag makes `lastIndex` stateful, so a module-level regex shared across two files
+    // starts the second scan wherever the first one stopped - and the second test silently loses
+    // its first mock. Two matched tests in one selection is the case that exposes it.
+    const dir = await mkdtemp(join(tmpdir(), "drift-test-intelligence-"));
+    tempDirs.push(dir);
+    await mkdir(join(dir, "server/services"), { recursive: true });
+    await writeFile(
+      join(dir, "server/services/users.test.ts"),
+      'vi.mock("server/repositories/users");\nit("a", () => {});\n'
+    );
+    await writeFile(
+      join(dir, "server/services/users-admin.test.ts"),
+      'vi.mock("server/repositories/admin");\nit("b", () => {});\n'
+    );
+
+    const result = selectRelevantTests({
+      changed_files: ["server/services/users.ts"],
+      test_files: ["server/services/users-admin.test.ts", "server/services/users.test.ts"],
+      repo_root: dir
+    });
+
+    expect(result.test_intelligence.map((entry) => entry.mocked_dependencies)).toEqual([
+      ["server/repositories/admin"],
+      ["server/repositories/users"]
+    ]);
   });
 
   it("classifies a user endpoint filtering task", () => {

--- a/scripts/payload-invariants-baseline.json
+++ b/scripts/payload-invariants-baseline.json
@@ -865,19 +865,7 @@
       "reason": "The engine supports every capability these fixtures exercise, so the shortfall lists stay empty. NOT a claim that coverage is total: it is the same absence `semantic_coverage` exists to report, observed on a matrix small enough never to produce one."
     },
     {
-      "path": "repo_map.topology.areas[].external_systems",
-      "value": [],
-      "kind": "matrix_gap",
-      "reason": "Repo topology beyond the source tree. These fixtures are hand-built directories with no config files, no generated zones and no external systems to detect, so the lists naming them are empty by fixture size rather than by any property of the detector."
-    },
-    {
       "path": "repo_map.topology.configs",
-      "value": [],
-      "kind": "matrix_gap",
-      "reason": "Repo topology beyond the source tree. These fixtures are hand-built directories with no config files, no generated zones and no external systems to detect, so the lists naming them are empty by fixture size rather than by any property of the detector."
-    },
-    {
-      "path": "repo_map.topology.external_systems",
       "value": [],
       "kind": "matrix_gap",
       "reason": "Repo topology beyond the source tree. These fixtures are hand-built directories with no config files, no generated zones and no external systems to detect, so the lists naming them are empty by fixture size rather than by any property of the detector."
@@ -2074,37 +2062,13 @@
       "path": "prepare.task_preflight_packet.test_intelligence[].covered_symbols",
       "value": [],
       "kind": "unimplemented_placeholder",
-      "reason": "Hardcoded in query/src/test-intelligence.ts and never computed - nothing inspects a test for snapshots or staleness, so these are declared shape rather than measurement. Recorded as a placeholder rather than as an invariant, because `false` here reads to an agent as `checked, and no` when it means `never looked`. This is the EW-3 shape and the honest fix is to compute them or drop them, not to baseline them as properties."
-    },
-    {
-      "path": "prepare.task_preflight_packet.test_intelligence[].mocked_dependencies",
-      "value": [],
-      "kind": "unimplemented_placeholder",
-      "reason": "Hardcoded in query/src/test-intelligence.ts and never computed - nothing inspects a test for snapshots or staleness, so these are declared shape rather than measurement. Recorded as a placeholder rather than as an invariant, because `false` here reads to an agent as `checked, and no` when it means `never looked`. This is the EW-3 shape and the honest fix is to compute them or drop them, not to baseline them as properties."
-    },
-    {
-      "path": "prepare.task_preflight_packet.test_intelligence[].fixture_usage",
-      "value": [],
-      "kind": "unimplemented_placeholder",
-      "reason": "Hardcoded in query/src/test-intelligence.ts and never computed - nothing inspects a test for snapshots or staleness, so these are declared shape rather than measurement. Recorded as a placeholder rather than as an invariant, because `false` here reads to an agent as `checked, and no` when it means `never looked`. This is the EW-3 shape and the honest fix is to compute them or drop them, not to baseline them as properties."
-    },
-    {
-      "path": "prepare.task_preflight_packet.test_intelligence[].snapshot_usage",
-      "value": false,
-      "kind": "unimplemented_placeholder",
-      "reason": "Hardcoded in query/src/test-intelligence.ts and never computed - nothing inspects a test for snapshots or staleness, so these are declared shape rather than measurement. Recorded as a placeholder rather than as an invariant, because `false` here reads to an agent as `checked, and no` when it means `never looked`. This is the EW-3 shape and the honest fix is to compute them or drop them, not to baseline them as properties."
-    },
-    {
-      "path": "prepare.task_preflight_packet.test_intelligence[].missing_test_candidate",
-      "value": false,
-      "kind": "product_invariant",
-      "reason": "False by construction: an entry exists in this array only because a test was FOUND for the subject, so a per-entry `missing` flag can never be true. The real signal is the sibling `missing_test_candidate` on the selection itself, which does vary."
+      "reason": "Still hardcoded `[]` in query/src/test-intelligence.ts. Answering it means resolving the call sites inside a test file against the symbol graph - the engine emits symbol identities, but nothing links a test's calls to them - so this is engine work rather than a read of the test's source, which is why it did not land with the three fields beside it. Recorded as a placeholder, not an invariant: `[]` here reads to an agent as `this test covers nothing` when it means `never looked`."
     },
     {
       "path": "prepare.task_preflight_packet.test_intelligence[].stale_test_candidate",
       "value": false,
       "kind": "unimplemented_placeholder",
-      "reason": "Hardcoded in query/src/test-intelligence.ts and never computed - nothing inspects a test for snapshots or staleness, so these are declared shape rather than measurement. Recorded as a placeholder rather than as an invariant, because `false` here reads to an agent as `checked, and no` when it means `never looked`. This is the EW-3 shape and the honest fix is to compute them or drop them, not to baseline them as properties."
+      "reason": "Still hardcoded `false`, and deliberately so: it has no DEFINITION yet, and a wrong one is worse than an honest gap. Stale relative to what - the subject's mtime, a content hash across two scans, the last scan of the test itself? Those disagree on real repos, and each would make `stale_test_candidate: true` mean something different to an agent deciding whether to trust a passing test. Recorded as a placeholder rather than an invariant: it needs the definition settled before it needs code."
     },
     {
       "path": "prepare.test_intelligence[].test_type",
@@ -2116,37 +2080,13 @@
       "path": "prepare.test_intelligence[].covered_symbols",
       "value": [],
       "kind": "unimplemented_placeholder",
-      "reason": "Hardcoded in query/src/test-intelligence.ts and never computed - nothing inspects a test for snapshots or staleness, so these are declared shape rather than measurement. Recorded as a placeholder rather than as an invariant, because `false` here reads to an agent as `checked, and no` when it means `never looked`. This is the EW-3 shape and the honest fix is to compute them or drop them, not to baseline them as properties."
-    },
-    {
-      "path": "prepare.test_intelligence[].mocked_dependencies",
-      "value": [],
-      "kind": "unimplemented_placeholder",
-      "reason": "Hardcoded in query/src/test-intelligence.ts and never computed - nothing inspects a test for snapshots or staleness, so these are declared shape rather than measurement. Recorded as a placeholder rather than as an invariant, because `false` here reads to an agent as `checked, and no` when it means `never looked`. This is the EW-3 shape and the honest fix is to compute them or drop them, not to baseline them as properties."
-    },
-    {
-      "path": "prepare.test_intelligence[].fixture_usage",
-      "value": [],
-      "kind": "unimplemented_placeholder",
-      "reason": "Hardcoded in query/src/test-intelligence.ts and never computed - nothing inspects a test for snapshots or staleness, so these are declared shape rather than measurement. Recorded as a placeholder rather than as an invariant, because `false` here reads to an agent as `checked, and no` when it means `never looked`. This is the EW-3 shape and the honest fix is to compute them or drop them, not to baseline them as properties."
-    },
-    {
-      "path": "prepare.test_intelligence[].snapshot_usage",
-      "value": false,
-      "kind": "unimplemented_placeholder",
-      "reason": "Hardcoded in query/src/test-intelligence.ts and never computed - nothing inspects a test for snapshots or staleness, so these are declared shape rather than measurement. Recorded as a placeholder rather than as an invariant, because `false` here reads to an agent as `checked, and no` when it means `never looked`. This is the EW-3 shape and the honest fix is to compute them or drop them, not to baseline them as properties."
-    },
-    {
-      "path": "prepare.test_intelligence[].missing_test_candidate",
-      "value": false,
-      "kind": "product_invariant",
-      "reason": "False by construction: an entry exists in this array only because a test was FOUND for the subject, so a per-entry `missing` flag can never be true. The real signal is the sibling `missing_test_candidate` on the selection itself, which does vary."
+      "reason": "Still hardcoded `[]` in query/src/test-intelligence.ts. Answering it means resolving the call sites inside a test file against the symbol graph - the engine emits symbol identities, but nothing links a test's calls to them - so this is engine work rather than a read of the test's source, which is why it did not land with the three fields beside it. Recorded as a placeholder, not an invariant: `[]` here reads to an agent as `this test covers nothing` when it means `never looked`."
     },
     {
       "path": "prepare.test_intelligence[].stale_test_candidate",
       "value": false,
       "kind": "unimplemented_placeholder",
-      "reason": "Hardcoded in query/src/test-intelligence.ts and never computed - nothing inspects a test for snapshots or staleness, so these are declared shape rather than measurement. Recorded as a placeholder rather than as an invariant, because `false` here reads to an agent as `checked, and no` when it means `never looked`. This is the EW-3 shape and the honest fix is to compute them or drop them, not to baseline them as properties."
+      "reason": "Still hardcoded `false`, and deliberately so: it has no DEFINITION yet, and a wrong one is worse than an honest gap. Stale relative to what - the subject's mtime, a content hash across two scans, the last scan of the test itself? Those disagree on real repos, and each would make `stale_test_candidate: true` mean something different to an agent deciding whether to trust a passing test. Recorded as a placeholder rather than an invariant: it needs the definition settled before it needs code."
     },
     {
       "path": "preflight.task_preflight_packet.test_intelligence[].test_type",
@@ -2158,37 +2098,13 @@
       "path": "preflight.task_preflight_packet.test_intelligence[].covered_symbols",
       "value": [],
       "kind": "unimplemented_placeholder",
-      "reason": "Hardcoded in query/src/test-intelligence.ts and never computed - nothing inspects a test for snapshots or staleness, so these are declared shape rather than measurement. Recorded as a placeholder rather than as an invariant, because `false` here reads to an agent as `checked, and no` when it means `never looked`. This is the EW-3 shape and the honest fix is to compute them or drop them, not to baseline them as properties."
-    },
-    {
-      "path": "preflight.task_preflight_packet.test_intelligence[].mocked_dependencies",
-      "value": [],
-      "kind": "unimplemented_placeholder",
-      "reason": "Hardcoded in query/src/test-intelligence.ts and never computed - nothing inspects a test for snapshots or staleness, so these are declared shape rather than measurement. Recorded as a placeholder rather than as an invariant, because `false` here reads to an agent as `checked, and no` when it means `never looked`. This is the EW-3 shape and the honest fix is to compute them or drop them, not to baseline them as properties."
-    },
-    {
-      "path": "preflight.task_preflight_packet.test_intelligence[].fixture_usage",
-      "value": [],
-      "kind": "unimplemented_placeholder",
-      "reason": "Hardcoded in query/src/test-intelligence.ts and never computed - nothing inspects a test for snapshots or staleness, so these are declared shape rather than measurement. Recorded as a placeholder rather than as an invariant, because `false` here reads to an agent as `checked, and no` when it means `never looked`. This is the EW-3 shape and the honest fix is to compute them or drop them, not to baseline them as properties."
-    },
-    {
-      "path": "preflight.task_preflight_packet.test_intelligence[].snapshot_usage",
-      "value": false,
-      "kind": "unimplemented_placeholder",
-      "reason": "Hardcoded in query/src/test-intelligence.ts and never computed - nothing inspects a test for snapshots or staleness, so these are declared shape rather than measurement. Recorded as a placeholder rather than as an invariant, because `false` here reads to an agent as `checked, and no` when it means `never looked`. This is the EW-3 shape and the honest fix is to compute them or drop them, not to baseline them as properties."
-    },
-    {
-      "path": "preflight.task_preflight_packet.test_intelligence[].missing_test_candidate",
-      "value": false,
-      "kind": "product_invariant",
-      "reason": "False by construction: an entry exists in this array only because a test was FOUND for the subject, so a per-entry `missing` flag can never be true. The real signal is the sibling `missing_test_candidate` on the selection itself, which does vary."
+      "reason": "Still hardcoded `[]` in query/src/test-intelligence.ts. Answering it means resolving the call sites inside a test file against the symbol graph - the engine emits symbol identities, but nothing links a test's calls to them - so this is engine work rather than a read of the test's source, which is why it did not land with the three fields beside it. Recorded as a placeholder, not an invariant: `[]` here reads to an agent as `this test covers nothing` when it means `never looked`."
     },
     {
       "path": "preflight.task_preflight_packet.test_intelligence[].stale_test_candidate",
       "value": false,
       "kind": "unimplemented_placeholder",
-      "reason": "Hardcoded in query/src/test-intelligence.ts and never computed - nothing inspects a test for snapshots or staleness, so these are declared shape rather than measurement. Recorded as a placeholder rather than as an invariant, because `false` here reads to an agent as `checked, and no` when it means `never looked`. This is the EW-3 shape and the honest fix is to compute them or drop them, not to baseline them as properties."
+      "reason": "Still hardcoded `false`, and deliberately so: it has no DEFINITION yet, and a wrong one is worse than an honest gap. Stale relative to what - the subject's mtime, a content hash across two scans, the last scan of the test itself? Those disagree on real repos, and each would make `stale_test_candidate: true` mean something different to an agent deciding whether to trust a passing test. Recorded as a placeholder rather than an invariant: it needs the definition settled before it needs code."
     },
     {
       "path": "preflight.test_intelligence[].test_type",
@@ -2200,37 +2116,13 @@
       "path": "preflight.test_intelligence[].covered_symbols",
       "value": [],
       "kind": "unimplemented_placeholder",
-      "reason": "Hardcoded in query/src/test-intelligence.ts and never computed - nothing inspects a test for snapshots or staleness, so these are declared shape rather than measurement. Recorded as a placeholder rather than as an invariant, because `false` here reads to an agent as `checked, and no` when it means `never looked`. This is the EW-3 shape and the honest fix is to compute them or drop them, not to baseline them as properties."
-    },
-    {
-      "path": "preflight.test_intelligence[].mocked_dependencies",
-      "value": [],
-      "kind": "unimplemented_placeholder",
-      "reason": "Hardcoded in query/src/test-intelligence.ts and never computed - nothing inspects a test for snapshots or staleness, so these are declared shape rather than measurement. Recorded as a placeholder rather than as an invariant, because `false` here reads to an agent as `checked, and no` when it means `never looked`. This is the EW-3 shape and the honest fix is to compute them or drop them, not to baseline them as properties."
-    },
-    {
-      "path": "preflight.test_intelligence[].fixture_usage",
-      "value": [],
-      "kind": "unimplemented_placeholder",
-      "reason": "Hardcoded in query/src/test-intelligence.ts and never computed - nothing inspects a test for snapshots or staleness, so these are declared shape rather than measurement. Recorded as a placeholder rather than as an invariant, because `false` here reads to an agent as `checked, and no` when it means `never looked`. This is the EW-3 shape and the honest fix is to compute them or drop them, not to baseline them as properties."
-    },
-    {
-      "path": "preflight.test_intelligence[].snapshot_usage",
-      "value": false,
-      "kind": "unimplemented_placeholder",
-      "reason": "Hardcoded in query/src/test-intelligence.ts and never computed - nothing inspects a test for snapshots or staleness, so these are declared shape rather than measurement. Recorded as a placeholder rather than as an invariant, because `false` here reads to an agent as `checked, and no` when it means `never looked`. This is the EW-3 shape and the honest fix is to compute them or drop them, not to baseline them as properties."
-    },
-    {
-      "path": "preflight.test_intelligence[].missing_test_candidate",
-      "value": false,
-      "kind": "product_invariant",
-      "reason": "False by construction: an entry exists in this array only because a test was FOUND for the subject, so a per-entry `missing` flag can never be true. The real signal is the sibling `missing_test_candidate` on the selection itself, which does vary."
+      "reason": "Still hardcoded `[]` in query/src/test-intelligence.ts. Answering it means resolving the call sites inside a test file against the symbol graph - the engine emits symbol identities, but nothing links a test's calls to them - so this is engine work rather than a read of the test's source, which is why it did not land with the three fields beside it. Recorded as a placeholder, not an invariant: `[]` here reads to an agent as `this test covers nothing` when it means `never looked`."
     },
     {
       "path": "preflight.test_intelligence[].stale_test_candidate",
       "value": false,
       "kind": "unimplemented_placeholder",
-      "reason": "Hardcoded in query/src/test-intelligence.ts and never computed - nothing inspects a test for snapshots or staleness, so these are declared shape rather than measurement. Recorded as a placeholder rather than as an invariant, because `false` here reads to an agent as `checked, and no` when it means `never looked`. This is the EW-3 shape and the honest fix is to compute them or drop them, not to baseline them as properties."
+      "reason": "Still hardcoded `false`, and deliberately so: it has no DEFINITION yet, and a wrong one is worse than an honest gap. Stale relative to what - the subject's mtime, a content hash across two scans, the last scan of the test itself? Those disagree on real repos, and each would make `stale_test_candidate: true` mean something different to an agent deciding whether to trust a passing test. Recorded as a placeholder rather than an invariant: it needs the definition settled before it needs code."
     }
   ]
 }

--- a/scripts/payload-invariants-baseline.json
+++ b/scripts/payload-invariants-baseline.json
@@ -103,10 +103,46 @@
       "reason": "The capability list a surface requires is a property of that surface, not of the repo it is reporting on. Pinned so a silently narrowed requirement shows up."
     },
     {
+      "path": "prepare.readiness.missing_capabilities",
+      "value": [],
+      "kind": "matrix_gap",
+      "reason": "The engine supports every capability these fixtures exercise, so the shortfall lists stay empty. NOT a claim that coverage is total: it is the same absence `semantic_coverage` exists to report, observed on a matrix small enough never to produce one."
+    },
+    {
+      "path": "prepare.semantic_coverage.partial_capabilities",
+      "value": [],
+      "kind": "matrix_gap",
+      "reason": "The engine supports every capability these fixtures exercise, so the shortfall lists stay empty. NOT a claim that coverage is total: it is the same absence `semantic_coverage` exists to report, observed on a matrix small enough never to produce one."
+    },
+    {
+      "path": "prepare.semantic_coverage.missing_capabilities",
+      "value": [],
+      "kind": "matrix_gap",
+      "reason": "The engine supports every capability these fixtures exercise, so the shortfall lists stay empty. NOT a claim that coverage is total: it is the same absence `semantic_coverage` exists to report, observed on a matrix small enough never to produce one."
+    },
+    {
+      "path": "prepare.semantic_coverage.unsupported_capabilities",
+      "value": [],
+      "kind": "matrix_gap",
+      "reason": "The engine supports every capability these fixtures exercise, so the shortfall lists stay empty. NOT a claim that coverage is total: it is the same absence `semantic_coverage` exists to report, observed on a matrix small enough never to produce one."
+    },
+    {
+      "path": "prepare.semantic_coverage.unsupported_pattern_ids",
+      "value": [],
+      "kind": "matrix_gap",
+      "reason": "The engine supports every capability these fixtures exercise, so the shortfall lists stay empty. NOT a claim that coverage is total: it is the same absence `semantic_coverage` exists to report, observed on a matrix small enough never to produce one."
+    },
+    {
       "path": "prepare.audit_integrity.valid",
       "value": true,
       "kind": "matrix_gap",
       "reason": "The audit chain verifies in every cell because nothing tampers with it. Making this false means corrupting a hash-linked log on purpose, which the storage suite does directly; this matrix only ever builds intact ones."
+    },
+    {
+      "path": "prepare.audit_integrity.reasons",
+      "value": [],
+      "kind": "matrix_gap",
+      "reason": "Reason lists that fill only on failure. The audit chain verifies and the scan is never invalidated in this matrix, so both stay empty - the list form of the same hole recorded for `audit_integrity.valid`. Corrupting a hash-linked log on purpose is the storage suite's job, not this one's."
     },
     {
       "path": "prepare.scan_status.latest_scan.dirty",
@@ -145,6 +181,36 @@
       "reason": "The audit chain verifies in every cell because nothing tampers with it. Making this false means corrupting a hash-linked log on purpose, which the storage suite does directly; this matrix only ever builds intact ones."
     },
     {
+      "path": "prepare.scan_status.audit_integrity.reasons",
+      "value": [],
+      "kind": "matrix_gap",
+      "reason": "Reason lists that fill only on failure. The audit chain verifies and the scan is never invalidated in this matrix, so both stay empty - the list form of the same hole recorded for `audit_integrity.valid`. Corrupting a hash-linked log on purpose is the storage suite's job, not this one's."
+    },
+    {
+      "path": "prepare.scan_status.invalidation_reasons",
+      "value": [],
+      "kind": "matrix_gap",
+      "reason": "Reason lists that fill only on failure. The audit chain verifies and the scan is never invalidated in this matrix, so both stay empty - the list form of the same hole recorded for `audit_integrity.valid`. Corrupting a hash-linked log on purpose is the storage suite's job, not this one's."
+    },
+    {
+      "path": "prepare.scan_status.changes.modified",
+      "value": [],
+      "kind": "matrix_gap",
+      "reason": "Every cell scans a fresh copy of a fixture, so the first scan reports additions only and the deleted/modified deltas are structurally empty. A second scan over an edited tree would move them; this matrix edits only to make a scan STALE, then never rescans."
+    },
+    {
+      "path": "prepare.scan_status.changes.deleted",
+      "value": [],
+      "kind": "matrix_gap",
+      "reason": "Every cell scans a fresh copy of a fixture, so the first scan reports additions only and the deleted/modified deltas are structurally empty. A second scan over an edited tree would move them; this matrix edits only to make a scan STALE, then never rescans."
+    },
+    {
+      "path": "prepare.scan_status.parser_gaps.records",
+      "value": [],
+      "kind": "matrix_gap",
+      "reason": "The engine reports THAT a construct defeated the parser, not which capability or contract kind the gap costs, and attaches no evidence refs to a gap record. These are declared attribution the engine does not currently supply - adjacent to the placeholder class below, and recorded as a hole so that stays visible rather than reading as `nothing affected`."
+    },
+    {
       "path": "prepare.scan_status.readiness.schema_version",
       "value": "drift.readiness.v1",
       "kind": "payload_identity",
@@ -175,10 +241,22 @@
       "reason": "The capability list a surface requires is a property of that surface, not of the repo it is reporting on. Pinned so a silently narrowed requirement shows up."
     },
     {
+      "path": "prepare.scan_status.readiness.missing_capabilities",
+      "value": [],
+      "kind": "matrix_gap",
+      "reason": "The engine supports every capability these fixtures exercise, so the shortfall lists stay empty. NOT a claim that coverage is total: it is the same absence `semantic_coverage` exists to report, observed on a matrix small enough never to produce one."
+    },
+    {
       "path": "prepare.scan_status.capability_report.engine_source",
       "value": "rust",
       "kind": "environment",
       "reason": "Fixed by the environment this gate runs in: the engine binary is always present, so the TypeScript fallback never engages. external-eval asserts the same two fields against the real corpus, where a fallback would be a genuine regression."
+    },
+    {
+      "path": "prepare.scan_status.capability_report.missing_capabilities",
+      "value": [],
+      "kind": "matrix_gap",
+      "reason": "The engine supports every capability these fixtures exercise, so the shortfall lists stay empty. NOT a claim that coverage is total: it is the same absence `semantic_coverage` exists to report, observed on a matrix small enough never to produce one."
     },
     {
       "path": "prepare.scan_status.capability_report.completeness[].can_block",
@@ -197,6 +275,18 @@
       "value": false,
       "kind": "environment",
       "reason": "Fixed by the environment this gate runs in: the engine binary is always present, so the TypeScript fallback never engages. external-eval asserts the same two fields against the real corpus, where a fallback would be a genuine regression."
+    },
+    {
+      "path": "prepare.scan_status.security_capabilities",
+      "value": [],
+      "kind": "matrix_gap",
+      "reason": "The engine supports every capability these fixtures exercise, so the shortfall lists stay empty. NOT a claim that coverage is total: it is the same absence `semantic_coverage` exists to report, observed on a matrix small enough never to produce one."
+    },
+    {
+      "path": "prepare.freshness_requirement.invalidation_reasons",
+      "value": [],
+      "kind": "matrix_gap",
+      "reason": "Reason lists that fill only on failure. The audit chain verifies and the scan is never invalidated in this matrix, so both stay empty - the list form of the same hole recorded for `audit_integrity.valid`. Corrupting a hash-linked log on purpose is the storage suite's job, not this one's."
     },
     {
       "path": "prepare.graph_context.available",
@@ -221,6 +311,30 @@
       "value": false,
       "kind": "matrix_gap",
       "reason": "Constant at false across the matrix, and not yet explained. Either the matrix lacks the state that moves it, or the field is frozen and this gate has found one."
+    },
+    {
+      "path": "prepare.task_preflight_packet.role_layer_proof",
+      "value": [],
+      "kind": "matrix_gap",
+      "reason": "The role/layer proof is emitted only for files whose role the ontology resolves with enough confidence to defend; no fixture in this matrix produces one. Present and correct, and entirely unexercised here."
+    },
+    {
+      "path": "prepare.task_preflight_packet.change_impact.changed_symbols",
+      "value": [],
+      "kind": "matrix_gap",
+      "reason": "Change impact is computed against `relevant_files`, which this matrix derives from a task string rather than from a diff, so no cell presents a CHANGED symbol or test. Closing it needs a fixture scanned twice with an edit in between."
+    },
+    {
+      "path": "prepare.task_preflight_packet.change_impact.changed_tests",
+      "value": [],
+      "kind": "matrix_gap",
+      "reason": "Change impact is computed against `relevant_files`, which this matrix derives from a task string rather than from a diff, so no cell presents a CHANGED symbol or test. Closing it needs a fixture scanned twice with an edit in between."
+    },
+    {
+      "path": "prepare.task_preflight_packet.change_impact.affected_tests",
+      "value": [],
+      "kind": "matrix_gap",
+      "reason": "Change impact is computed against `relevant_files`, which this matrix derives from a task string rather than from a diff, so no cell presents a CHANGED symbol or test. Closing it needs a fixture scanned twice with an edit in between."
     },
     {
       "path": "prepare.task_preflight_packet.context_policy.can_read_repo_map",
@@ -283,10 +397,100 @@
       "reason": "The policy dimension is unexercised: no fixture sets a restrictive `context_egress` in its contract, so authorization is granted in every cell and the whole permission matrix reads as one value. Closing it needs a fixture whose contract denies a surface - not a bigger repo. Known hole, not a promise that policy cannot deny."
     },
     {
+      "path": "prepare.change_impact.changed_symbols",
+      "value": [],
+      "kind": "matrix_gap",
+      "reason": "Change impact is computed against `relevant_files`, which this matrix derives from a task string rather than from a diff, so no cell presents a CHANGED symbol or test. Closing it needs a fixture scanned twice with an edit in between."
+    },
+    {
+      "path": "prepare.change_impact.changed_tests",
+      "value": [],
+      "kind": "matrix_gap",
+      "reason": "Change impact is computed against `relevant_files`, which this matrix derives from a task string rather than from a diff, so no cell presents a CHANGED symbol or test. Closing it needs a fixture scanned twice with an edit in between."
+    },
+    {
+      "path": "prepare.change_impact.affected_tests",
+      "value": [],
+      "kind": "matrix_gap",
+      "reason": "Change impact is computed against `relevant_files`, which this matrix derives from a task string rather than from a diff, so no cell presents a CHANGED symbol or test. Closing it needs a fixture scanned twice with an edit in between."
+    },
+    {
+      "path": "prepare.agent_contract_packet.selected_contracts",
+      "value": [],
+      "kind": "matrix_gap",
+      "reason": "The default materialized contract declares none of these. Every fixture accepts the same generated contract, so its optional lists - waivers, exceptions, import boundaries, placement guidance, safe commands - are empty throughout. Closing it needs a fixture carrying a hand-written contract, not a bigger repo."
+    },
+    {
       "path": "prepare.agent_contract_packet.selected_contracts_reason",
       "value": "no_contracts_accepted",
       "kind": "matrix_gap",
       "reason": "`no_contracts_accepted` in every cell because no fixture carries an AGENT contract - a different object from the repo contract the accept step materializes. Closing it needs a fixture with one; until then this field's other values are unexercised here."
+    },
+    {
+      "path": "prepare.agent_contract_packet.selected_helpers",
+      "value": [],
+      "kind": "matrix_gap",
+      "reason": "The default materialized contract declares none of these. Every fixture accepts the same generated contract, so its optional lists - waivers, exceptions, import boundaries, placement guidance, safe commands - are empty throughout. Closing it needs a fixture carrying a hand-written contract, not a bigger repo."
+    },
+    {
+      "path": "prepare.agent_contract_packet.placement_guidance",
+      "value": [],
+      "kind": "matrix_gap",
+      "reason": "The default materialized contract declares none of these. Every fixture accepts the same generated contract, so its optional lists - waivers, exceptions, import boundaries, placement guidance, safe commands - are empty throughout. Closing it needs a fixture carrying a hand-written contract, not a bigger repo."
+    },
+    {
+      "path": "prepare.agent_contract_packet.import_boundaries",
+      "value": [],
+      "kind": "matrix_gap",
+      "reason": "The default materialized contract declares none of these. Every fixture accepts the same generated contract, so its optional lists - waivers, exceptions, import boundaries, placement guidance, safe commands - are empty throughout. Closing it needs a fixture carrying a hand-written contract, not a bigger repo."
+    },
+    {
+      "path": "prepare.agent_contract_packet.required_flows",
+      "value": [],
+      "kind": "matrix_gap",
+      "reason": "The default materialized contract declares none of these. Every fixture accepts the same generated contract, so its optional lists - waivers, exceptions, import boundaries, placement guidance, safe commands - are empty throughout. Closing it needs a fixture carrying a hand-written contract, not a bigger repo."
+    },
+    {
+      "path": "prepare.agent_contract_packet.required_checks",
+      "value": [],
+      "kind": "matrix_gap",
+      "reason": "The default materialized contract declares none of these. Every fixture accepts the same generated contract, so its optional lists - waivers, exceptions, import boundaries, placement guidance, safe commands - are empty throughout. Closing it needs a fixture carrying a hand-written contract, not a bigger repo."
+    },
+    {
+      "path": "prepare.agent_contract_packet.active_exceptions",
+      "value": [],
+      "kind": "matrix_gap",
+      "reason": "The default materialized contract declares none of these. Every fixture accepts the same generated contract, so its optional lists - waivers, exceptions, import boundaries, placement guidance, safe commands - are empty throughout. Closing it needs a fixture carrying a hand-written contract, not a bigger repo."
+    },
+    {
+      "path": "prepare.agent_contract_packet.active_waivers",
+      "value": [],
+      "kind": "matrix_gap",
+      "reason": "The default materialized contract declares none of these. Every fixture accepts the same generated contract, so its optional lists - waivers, exceptions, import boundaries, placement guidance, safe commands - are empty throughout. Closing it needs a fixture carrying a hand-written contract, not a bigger repo."
+    },
+    {
+      "path": "prepare.baseline.by_convention",
+      "value": [],
+      "kind": "matrix_gap",
+      "reason": "Nothing in this matrix records a finding. Conventions are accepted, but no cell runs `check`, which is what materializes violations, waivers and the per-convention baseline. Closing it needs the check step in the matrix, not a different fixture."
+    },
+    {
+      "path": "prepare.findings",
+      "value": [],
+      "kind": "matrix_gap",
+      "reason": "Nothing in this matrix records a finding. Conventions are accepted, but no cell runs `check`, which is what materializes violations, waivers and the per-convention baseline. Closing it needs the check step in the matrix, not a different fixture."
+    },
+    {
+      "path": "prepare.waivers",
+      "value": [],
+      "kind": "matrix_gap",
+      "reason": "Nothing in this matrix records a finding. Conventions are accepted, but no cell runs `check`, which is what materializes violations, waivers and the per-convention baseline. Closing it needs the check step in the matrix, not a different fixture."
+    },
+    {
+      "path": "prepare.safe_commands",
+      "value": [],
+      "kind": "matrix_gap",
+      "reason": "The default materialized contract declares none of these. Every fixture accepts the same generated contract, so its optional lists - waivers, exceptions, import boundaries, placement guidance, safe commands - are empty throughout. Closing it needs a fixture carrying a hand-written contract, not a bigger repo."
     },
     {
       "path": "prepare.governance.read_only",
@@ -451,6 +655,12 @@
       "reason": "NOT a guarantee - the matrix never truncates. Truncation needs a guidance view over the 32,768-byte budget, which takes roughly 60 realistically-sized conventions; the largest fixture here produces three. This is the exact field D-M5 found hardcoded to false, so it is recorded as a known hole rather than as a property. Closing it needs a fixture built for the budget, not a bigger repo."
     },
     {
+      "path": "repo_map.agent_envelope.diagnostics",
+      "value": [],
+      "kind": "matrix_gap",
+      "reason": "Per-node trouble lists. These fixtures parse cleanly and resolve their imports, so the route flows and reachable data access carry no diagnostics - even in the parser-gap fixture, where the gap is recorded on the scan rather than on a graph node. An unparseable route is what fills them."
+    },
+    {
       "path": "repo_map.policy.allowed",
       "value": true,
       "kind": "matrix_gap",
@@ -491,6 +701,12 @@
       "value": "fact_graph",
       "kind": "payload_identity",
       "reason": "The capability list a surface requires is a property of that surface, not of the repo it is reporting on. Pinned so a silently narrowed requirement shows up."
+    },
+    {
+      "path": "repo_map.readiness.missing_capabilities",
+      "value": [],
+      "kind": "matrix_gap",
+      "reason": "The engine supports every capability these fixtures exercise, so the shortfall lists stay empty. NOT a claim that coverage is total: it is the same absence `semantic_coverage` exists to report, observed on a matrix small enough never to produce one."
     },
     {
       "path": "repo_map.governance.read_only",
@@ -553,6 +769,30 @@
       "reason": "The audit chain verifies in every cell because nothing tampers with it. Making this false means corrupting a hash-linked log on purpose, which the storage suite does directly; this matrix only ever builds intact ones."
     },
     {
+      "path": "repo_map.scan_status.audit_integrity.reasons",
+      "value": [],
+      "kind": "matrix_gap",
+      "reason": "Reason lists that fill only on failure. The audit chain verifies and the scan is never invalidated in this matrix, so both stay empty - the list form of the same hole recorded for `audit_integrity.valid`. Corrupting a hash-linked log on purpose is the storage suite's job, not this one's."
+    },
+    {
+      "path": "repo_map.scan_status.invalidation_reasons",
+      "value": [],
+      "kind": "matrix_gap",
+      "reason": "Reason lists that fill only on failure. The audit chain verifies and the scan is never invalidated in this matrix, so both stay empty - the list form of the same hole recorded for `audit_integrity.valid`. Corrupting a hash-linked log on purpose is the storage suite's job, not this one's."
+    },
+    {
+      "path": "repo_map.scan_status.changes.modified",
+      "value": [],
+      "kind": "matrix_gap",
+      "reason": "Every cell scans a fresh copy of a fixture, so the first scan reports additions only and the deleted/modified deltas are structurally empty. A second scan over an edited tree would move them; this matrix edits only to make a scan STALE, then never rescans."
+    },
+    {
+      "path": "repo_map.scan_status.changes.deleted",
+      "value": [],
+      "kind": "matrix_gap",
+      "reason": "Every cell scans a fresh copy of a fixture, so the first scan reports additions only and the deleted/modified deltas are structurally empty. A second scan over an edited tree would move them; this matrix edits only to make a scan STALE, then never rescans."
+    },
+    {
       "path": "repo_map.scan_status.readiness.schema_version",
       "value": "drift.readiness.v1",
       "kind": "payload_identity",
@@ -583,10 +823,22 @@
       "reason": "The capability list a surface requires is a property of that surface, not of the repo it is reporting on. Pinned so a silently narrowed requirement shows up."
     },
     {
+      "path": "repo_map.scan_status.readiness.missing_capabilities",
+      "value": [],
+      "kind": "matrix_gap",
+      "reason": "The engine supports every capability these fixtures exercise, so the shortfall lists stay empty. NOT a claim that coverage is total: it is the same absence `semantic_coverage` exists to report, observed on a matrix small enough never to produce one."
+    },
+    {
       "path": "repo_map.scan_status.capability_report.engine_source",
       "value": "rust",
       "kind": "environment",
       "reason": "Fixed by the environment this gate runs in: the engine binary is always present, so the TypeScript fallback never engages. external-eval asserts the same two fields against the real corpus, where a fallback would be a genuine regression."
+    },
+    {
+      "path": "repo_map.scan_status.capability_report.missing_capabilities",
+      "value": [],
+      "kind": "matrix_gap",
+      "reason": "The engine supports every capability these fixtures exercise, so the shortfall lists stay empty. NOT a claim that coverage is total: it is the same absence `semantic_coverage` exists to report, observed on a matrix small enough never to produce one."
     },
     {
       "path": "repo_map.scan_status.capability_report.completeness[].can_block",
@@ -607,6 +859,36 @@
       "reason": "Fixed by the environment this gate runs in: the engine binary is always present, so the TypeScript fallback never engages. external-eval asserts the same two fields against the real corpus, where a fallback would be a genuine regression."
     },
     {
+      "path": "repo_map.scan_status.security_capabilities",
+      "value": [],
+      "kind": "matrix_gap",
+      "reason": "The engine supports every capability these fixtures exercise, so the shortfall lists stay empty. NOT a claim that coverage is total: it is the same absence `semantic_coverage` exists to report, observed on a matrix small enough never to produce one."
+    },
+    {
+      "path": "repo_map.topology.areas[].external_systems",
+      "value": [],
+      "kind": "matrix_gap",
+      "reason": "Repo topology beyond the source tree. These fixtures are hand-built directories with no config files, no generated zones and no external systems to detect, so the lists naming them are empty by fixture size rather than by any property of the detector."
+    },
+    {
+      "path": "repo_map.topology.configs",
+      "value": [],
+      "kind": "matrix_gap",
+      "reason": "Repo topology beyond the source tree. These fixtures are hand-built directories with no config files, no generated zones and no external systems to detect, so the lists naming them are empty by fixture size rather than by any property of the detector."
+    },
+    {
+      "path": "repo_map.topology.external_systems",
+      "value": [],
+      "kind": "matrix_gap",
+      "reason": "Repo topology beyond the source tree. These fixtures are hand-built directories with no config files, no generated zones and no external systems to detect, so the lists naming them are empty by fixture size rather than by any property of the detector."
+    },
+    {
+      "path": "repo_map.topology.generated_zones",
+      "value": [],
+      "kind": "matrix_gap",
+      "reason": "Repo topology beyond the source tree. These fixtures are hand-built directories with no config files, no generated zones and no external systems to detect, so the lists naming them are empty by fixture size rather than by any property of the detector."
+    },
+    {
       "path": "repo_map.pagination.has_more",
       "value": false,
       "kind": "matrix_gap",
@@ -619,10 +901,28 @@
       "reason": "Security boundary proofs are produced by `check`, which this matrix does not run, so route trust reports `none`/`unknown` throughout. These are exactly the D-A2 fields the CLI used to omit, so the hole is worth naming: they are present and correct, and only one of their values is exercised."
     },
     {
+      "path": "repo_map.routes[].security.parser_gap_codes",
+      "value": [],
+      "kind": "matrix_gap",
+      "reason": "Per-node trouble lists. These fixtures parse cleanly and resolve their imports, so the route flows and reachable data access carry no diagnostics - even in the parser-gap fixture, where the gap is recorded on the scan rather than on a graph node. An unparseable route is what fills them."
+    },
+    {
+      "path": "repo_map.routes[].security.finding_ids",
+      "value": [],
+      "kind": "matrix_gap",
+      "reason": "Nothing in this matrix records a finding. Conventions are accepted, but no cell runs `check`, which is what materializes violations, waivers and the per-convention baseline. Closing it needs the check step in the matrix, not a different fixture."
+    },
+    {
       "path": "repo_map.proof_freshness",
       "value": "none",
       "kind": "matrix_gap",
       "reason": "Security boundary proofs are produced by `check`, which this matrix does not run, so route trust reports `none`/`unknown` throughout. These are exactly the D-A2 fields the CLI used to omit, so the hole is worth naming: they are present and correct, and only one of their values is exercised."
+    },
+    {
+      "path": "repo_map.framework_entrypoints.entrypoints[].parser_gap_codes",
+      "value": [],
+      "kind": "matrix_gap",
+      "reason": "Per-node trouble lists. These fixtures parse cleanly and resolve their imports, so the route flows and reachable data access carry no diagnostics - even in the parser-gap fixture, where the gap is recorded on the scan rather than on a graph node. An unparseable route is what fills them."
     },
     {
       "path": "repo_map.freshness_requirement.required",
@@ -631,10 +931,22 @@
       "reason": "Constant at false across the matrix, and not yet explained. Either the matrix lacks the state that moves it, or the field is frozen and this gate has found one."
     },
     {
+      "path": "repo_map.freshness_requirement.invalidation_reasons",
+      "value": [],
+      "kind": "matrix_gap",
+      "reason": "Reason lists that fill only on failure. The audit chain verifies and the scan is never invalidated in this matrix, so both stay empty - the list form of the same hole recorded for `audit_integrity.valid`. Corrupting a hash-linked log on purpose is the storage suite's job, not this one's."
+    },
+    {
       "path": "repo_map.files[].indexed",
       "value": true,
       "kind": "matrix_gap",
       "reason": "Constant at true across the matrix, and not yet explained. Either the matrix lacks the state that moves it, or the field is frozen and this gate has found one."
+    },
+    {
+      "path": "repo_map.files[].open_finding_ids",
+      "value": [],
+      "kind": "matrix_gap",
+      "reason": "Nothing in this matrix records a finding. Conventions are accepted, but no cell runs `check`, which is what materializes violations, waivers and the per-convention baseline. Closing it needs the check step in the matrix, not a different fixture."
     },
     {
       "path": "repo_map.redactions.snippets_included",
@@ -697,6 +1009,30 @@
       "reason": "The audit chain verifies in every cell because nothing tampers with it. Making this false means corrupting a hash-linked log on purpose, which the storage suite does directly; this matrix only ever builds intact ones."
     },
     {
+      "path": "scan_status.audit_integrity.reasons",
+      "value": [],
+      "kind": "matrix_gap",
+      "reason": "Reason lists that fill only on failure. The audit chain verifies and the scan is never invalidated in this matrix, so both stay empty - the list form of the same hole recorded for `audit_integrity.valid`. Corrupting a hash-linked log on purpose is the storage suite's job, not this one's."
+    },
+    {
+      "path": "scan_status.invalidation_reasons",
+      "value": [],
+      "kind": "matrix_gap",
+      "reason": "Reason lists that fill only on failure. The audit chain verifies and the scan is never invalidated in this matrix, so both stay empty - the list form of the same hole recorded for `audit_integrity.valid`. Corrupting a hash-linked log on purpose is the storage suite's job, not this one's."
+    },
+    {
+      "path": "scan_status.changes.modified",
+      "value": [],
+      "kind": "matrix_gap",
+      "reason": "Every cell scans a fresh copy of a fixture, so the first scan reports additions only and the deleted/modified deltas are structurally empty. A second scan over an edited tree would move them; this matrix edits only to make a scan STALE, then never rescans."
+    },
+    {
+      "path": "scan_status.changes.deleted",
+      "value": [],
+      "kind": "matrix_gap",
+      "reason": "Every cell scans a fresh copy of a fixture, so the first scan reports additions only and the deleted/modified deltas are structurally empty. A second scan over an edited tree would move them; this matrix edits only to make a scan STALE, then never rescans."
+    },
+    {
       "path": "scan_status.readiness.schema_version",
       "value": "drift.readiness.v1",
       "kind": "payload_identity",
@@ -727,10 +1063,22 @@
       "reason": "The capability list a surface requires is a property of that surface, not of the repo it is reporting on. Pinned so a silently narrowed requirement shows up."
     },
     {
+      "path": "scan_status.readiness.missing_capabilities",
+      "value": [],
+      "kind": "matrix_gap",
+      "reason": "The engine supports every capability these fixtures exercise, so the shortfall lists stay empty. NOT a claim that coverage is total: it is the same absence `semantic_coverage` exists to report, observed on a matrix small enough never to produce one."
+    },
+    {
       "path": "scan_status.capability_report.engine_source",
       "value": "rust",
       "kind": "environment",
       "reason": "Fixed by the environment this gate runs in: the engine binary is always present, so the TypeScript fallback never engages. external-eval asserts the same two fields against the real corpus, where a fallback would be a genuine regression."
+    },
+    {
+      "path": "scan_status.capability_report.missing_capabilities",
+      "value": [],
+      "kind": "matrix_gap",
+      "reason": "The engine supports every capability these fixtures exercise, so the shortfall lists stay empty. NOT a claim that coverage is total: it is the same absence `semantic_coverage` exists to report, observed on a matrix small enough never to produce one."
     },
     {
       "path": "scan_status.capability_report.completeness[].can_block",
@@ -749,6 +1097,12 @@
       "value": false,
       "kind": "environment",
       "reason": "Fixed by the environment this gate runs in: the engine binary is always present, so the TypeScript fallback never engages. external-eval asserts the same two fields against the real corpus, where a fallback would be a genuine regression."
+    },
+    {
+      "path": "scan_status.security_capabilities",
+      "value": [],
+      "kind": "matrix_gap",
+      "reason": "The engine supports every capability these fixtures exercise, so the shortfall lists stay empty. NOT a claim that coverage is total: it is the same absence `semantic_coverage` exists to report, observed on a matrix small enough never to produce one."
     },
     {
       "path": "preflight.guidance.truncated.conventions",
@@ -865,10 +1219,46 @@
       "reason": "The capability list a surface requires is a property of that surface, not of the repo it is reporting on. Pinned so a silently narrowed requirement shows up."
     },
     {
+      "path": "preflight.readiness.missing_capabilities",
+      "value": [],
+      "kind": "matrix_gap",
+      "reason": "The engine supports every capability these fixtures exercise, so the shortfall lists stay empty. NOT a claim that coverage is total: it is the same absence `semantic_coverage` exists to report, observed on a matrix small enough never to produce one."
+    },
+    {
+      "path": "preflight.semantic_coverage.partial_capabilities",
+      "value": [],
+      "kind": "matrix_gap",
+      "reason": "The engine supports every capability these fixtures exercise, so the shortfall lists stay empty. NOT a claim that coverage is total: it is the same absence `semantic_coverage` exists to report, observed on a matrix small enough never to produce one."
+    },
+    {
+      "path": "preflight.semantic_coverage.missing_capabilities",
+      "value": [],
+      "kind": "matrix_gap",
+      "reason": "The engine supports every capability these fixtures exercise, so the shortfall lists stay empty. NOT a claim that coverage is total: it is the same absence `semantic_coverage` exists to report, observed on a matrix small enough never to produce one."
+    },
+    {
+      "path": "preflight.semantic_coverage.unsupported_capabilities",
+      "value": [],
+      "kind": "matrix_gap",
+      "reason": "The engine supports every capability these fixtures exercise, so the shortfall lists stay empty. NOT a claim that coverage is total: it is the same absence `semantic_coverage` exists to report, observed on a matrix small enough never to produce one."
+    },
+    {
+      "path": "preflight.semantic_coverage.unsupported_pattern_ids",
+      "value": [],
+      "kind": "matrix_gap",
+      "reason": "The engine supports every capability these fixtures exercise, so the shortfall lists stay empty. NOT a claim that coverage is total: it is the same absence `semantic_coverage` exists to report, observed on a matrix small enough never to produce one."
+    },
+    {
       "path": "preflight.audit_integrity.valid",
       "value": true,
       "kind": "matrix_gap",
       "reason": "The audit chain verifies in every cell because nothing tampers with it. Making this false means corrupting a hash-linked log on purpose, which the storage suite does directly; this matrix only ever builds intact ones."
+    },
+    {
+      "path": "preflight.audit_integrity.reasons",
+      "value": [],
+      "kind": "matrix_gap",
+      "reason": "Reason lists that fill only on failure. The audit chain verifies and the scan is never invalidated in this matrix, so both stay empty - the list form of the same hole recorded for `audit_integrity.valid`. Corrupting a hash-linked log on purpose is the storage suite's job, not this one's."
     },
     {
       "path": "preflight.scan_status.governance.read_only",
@@ -901,10 +1291,40 @@
       "reason": "The audit chain verifies in every cell because nothing tampers with it. Making this false means corrupting a hash-linked log on purpose, which the storage suite does directly; this matrix only ever builds intact ones."
     },
     {
+      "path": "preflight.scan_status.audit_integrity.reasons",
+      "value": [],
+      "kind": "matrix_gap",
+      "reason": "Reason lists that fill only on failure. The audit chain verifies and the scan is never invalidated in this matrix, so both stay empty - the list form of the same hole recorded for `audit_integrity.valid`. Corrupting a hash-linked log on purpose is the storage suite's job, not this one's."
+    },
+    {
       "path": "preflight.scan_status.summary.audit_valid",
       "value": true,
       "kind": "matrix_gap",
       "reason": "The audit chain verifies in every cell because nothing tampers with it. Making this false means corrupting a hash-linked log on purpose, which the storage suite does directly; this matrix only ever builds intact ones."
+    },
+    {
+      "path": "preflight.scan_status.invalidation_reasons",
+      "value": [],
+      "kind": "matrix_gap",
+      "reason": "Reason lists that fill only on failure. The audit chain verifies and the scan is never invalidated in this matrix, so both stay empty - the list form of the same hole recorded for `audit_integrity.valid`. Corrupting a hash-linked log on purpose is the storage suite's job, not this one's."
+    },
+    {
+      "path": "preflight.scan_status.changes.modified",
+      "value": [],
+      "kind": "matrix_gap",
+      "reason": "Every cell scans a fresh copy of a fixture, so the first scan reports additions only and the deleted/modified deltas are structurally empty. A second scan over an edited tree would move them; this matrix edits only to make a scan STALE, then never rescans."
+    },
+    {
+      "path": "preflight.scan_status.changes.deleted",
+      "value": [],
+      "kind": "matrix_gap",
+      "reason": "Every cell scans a fresh copy of a fixture, so the first scan reports additions only and the deleted/modified deltas are structurally empty. A second scan over an edited tree would move them; this matrix edits only to make a scan STALE, then never rescans."
+    },
+    {
+      "path": "preflight.scan_status.parser_gaps.records",
+      "value": [],
+      "kind": "matrix_gap",
+      "reason": "The engine reports THAT a construct defeated the parser, not which capability or contract kind the gap costs, and attaches no evidence refs to a gap record. These are declared attribution the engine does not currently supply - adjacent to the placeholder class below, and recorded as a hole so that stays visible rather than reading as `nothing affected`."
     },
     {
       "path": "preflight.scan_status.readiness.schema_version",
@@ -937,10 +1357,22 @@
       "reason": "The capability list a surface requires is a property of that surface, not of the repo it is reporting on. Pinned so a silently narrowed requirement shows up."
     },
     {
+      "path": "preflight.scan_status.readiness.missing_capabilities",
+      "value": [],
+      "kind": "matrix_gap",
+      "reason": "The engine supports every capability these fixtures exercise, so the shortfall lists stay empty. NOT a claim that coverage is total: it is the same absence `semantic_coverage` exists to report, observed on a matrix small enough never to produce one."
+    },
+    {
       "path": "preflight.scan_status.capability_report.engine_source",
       "value": "rust",
       "kind": "environment",
       "reason": "Fixed by the environment this gate runs in: the engine binary is always present, so the TypeScript fallback never engages. external-eval asserts the same two fields against the real corpus, where a fallback would be a genuine regression."
+    },
+    {
+      "path": "preflight.scan_status.capability_report.missing_capabilities",
+      "value": [],
+      "kind": "matrix_gap",
+      "reason": "The engine supports every capability these fixtures exercise, so the shortfall lists stay empty. NOT a claim that coverage is total: it is the same absence `semantic_coverage` exists to report, observed on a matrix small enough never to produce one."
     },
     {
       "path": "preflight.scan_status.capability_report.completeness[].can_block",
@@ -959,6 +1391,18 @@
       "value": false,
       "kind": "environment",
       "reason": "Fixed by the environment this gate runs in: the engine binary is always present, so the TypeScript fallback never engages. external-eval asserts the same two fields against the real corpus, where a fallback would be a genuine regression."
+    },
+    {
+      "path": "preflight.scan_status.security_capabilities",
+      "value": [],
+      "kind": "matrix_gap",
+      "reason": "The engine supports every capability these fixtures exercise, so the shortfall lists stay empty. NOT a claim that coverage is total: it is the same absence `semantic_coverage` exists to report, observed on a matrix small enough never to produce one."
+    },
+    {
+      "path": "preflight.freshness_requirement.invalidation_reasons",
+      "value": [],
+      "kind": "matrix_gap",
+      "reason": "Reason lists that fill only on failure. The audit chain verifies and the scan is never invalidated in this matrix, so both stay empty - the list form of the same hole recorded for `audit_integrity.valid`. Corrupting a hash-linked log on purpose is the storage suite's job, not this one's."
     },
     {
       "path": "preflight.graph_context.available",
@@ -983,6 +1427,30 @@
       "value": false,
       "kind": "matrix_gap",
       "reason": "Constant at false across the matrix, and not yet explained. Either the matrix lacks the state that moves it, or the field is frozen and this gate has found one."
+    },
+    {
+      "path": "preflight.task_preflight_packet.role_layer_proof",
+      "value": [],
+      "kind": "matrix_gap",
+      "reason": "The role/layer proof is emitted only for files whose role the ontology resolves with enough confidence to defend; no fixture in this matrix produces one. Present and correct, and entirely unexercised here."
+    },
+    {
+      "path": "preflight.task_preflight_packet.change_impact.changed_symbols",
+      "value": [],
+      "kind": "matrix_gap",
+      "reason": "Change impact is computed against `relevant_files`, which this matrix derives from a task string rather than from a diff, so no cell presents a CHANGED symbol or test. Closing it needs a fixture scanned twice with an edit in between."
+    },
+    {
+      "path": "preflight.task_preflight_packet.change_impact.changed_tests",
+      "value": [],
+      "kind": "matrix_gap",
+      "reason": "Change impact is computed against `relevant_files`, which this matrix derives from a task string rather than from a diff, so no cell presents a CHANGED symbol or test. Closing it needs a fixture scanned twice with an edit in between."
+    },
+    {
+      "path": "preflight.task_preflight_packet.change_impact.affected_tests",
+      "value": [],
+      "kind": "matrix_gap",
+      "reason": "Change impact is computed against `relevant_files`, which this matrix derives from a task string rather than from a diff, so no cell presents a CHANGED symbol or test. Closing it needs a fixture scanned twice with an edit in between."
     },
     {
       "path": "preflight.task_preflight_packet.context_policy.can_read_repo_map",
@@ -1045,10 +1513,100 @@
       "reason": "The policy dimension is unexercised: no fixture sets a restrictive `context_egress` in its contract, so authorization is granted in every cell and the whole permission matrix reads as one value. Closing it needs a fixture whose contract denies a surface - not a bigger repo. Known hole, not a promise that policy cannot deny."
     },
     {
+      "path": "preflight.change_impact.changed_symbols",
+      "value": [],
+      "kind": "matrix_gap",
+      "reason": "Change impact is computed against `relevant_files`, which this matrix derives from a task string rather than from a diff, so no cell presents a CHANGED symbol or test. Closing it needs a fixture scanned twice with an edit in between."
+    },
+    {
+      "path": "preflight.change_impact.changed_tests",
+      "value": [],
+      "kind": "matrix_gap",
+      "reason": "Change impact is computed against `relevant_files`, which this matrix derives from a task string rather than from a diff, so no cell presents a CHANGED symbol or test. Closing it needs a fixture scanned twice with an edit in between."
+    },
+    {
+      "path": "preflight.change_impact.affected_tests",
+      "value": [],
+      "kind": "matrix_gap",
+      "reason": "Change impact is computed against `relevant_files`, which this matrix derives from a task string rather than from a diff, so no cell presents a CHANGED symbol or test. Closing it needs a fixture scanned twice with an edit in between."
+    },
+    {
+      "path": "preflight.agent_contract_packet.selected_contracts",
+      "value": [],
+      "kind": "matrix_gap",
+      "reason": "The default materialized contract declares none of these. Every fixture accepts the same generated contract, so its optional lists - waivers, exceptions, import boundaries, placement guidance, safe commands - are empty throughout. Closing it needs a fixture carrying a hand-written contract, not a bigger repo."
+    },
+    {
       "path": "preflight.agent_contract_packet.selected_contracts_reason",
       "value": "no_contracts_accepted",
       "kind": "matrix_gap",
       "reason": "`no_contracts_accepted` in every cell because no fixture carries an AGENT contract - a different object from the repo contract the accept step materializes. Closing it needs a fixture with one; until then this field's other values are unexercised here."
+    },
+    {
+      "path": "preflight.agent_contract_packet.selected_helpers",
+      "value": [],
+      "kind": "matrix_gap",
+      "reason": "The default materialized contract declares none of these. Every fixture accepts the same generated contract, so its optional lists - waivers, exceptions, import boundaries, placement guidance, safe commands - are empty throughout. Closing it needs a fixture carrying a hand-written contract, not a bigger repo."
+    },
+    {
+      "path": "preflight.agent_contract_packet.placement_guidance",
+      "value": [],
+      "kind": "matrix_gap",
+      "reason": "The default materialized contract declares none of these. Every fixture accepts the same generated contract, so its optional lists - waivers, exceptions, import boundaries, placement guidance, safe commands - are empty throughout. Closing it needs a fixture carrying a hand-written contract, not a bigger repo."
+    },
+    {
+      "path": "preflight.agent_contract_packet.import_boundaries",
+      "value": [],
+      "kind": "matrix_gap",
+      "reason": "The default materialized contract declares none of these. Every fixture accepts the same generated contract, so its optional lists - waivers, exceptions, import boundaries, placement guidance, safe commands - are empty throughout. Closing it needs a fixture carrying a hand-written contract, not a bigger repo."
+    },
+    {
+      "path": "preflight.agent_contract_packet.required_flows",
+      "value": [],
+      "kind": "matrix_gap",
+      "reason": "The default materialized contract declares none of these. Every fixture accepts the same generated contract, so its optional lists - waivers, exceptions, import boundaries, placement guidance, safe commands - are empty throughout. Closing it needs a fixture carrying a hand-written contract, not a bigger repo."
+    },
+    {
+      "path": "preflight.agent_contract_packet.required_checks",
+      "value": [],
+      "kind": "matrix_gap",
+      "reason": "The default materialized contract declares none of these. Every fixture accepts the same generated contract, so its optional lists - waivers, exceptions, import boundaries, placement guidance, safe commands - are empty throughout. Closing it needs a fixture carrying a hand-written contract, not a bigger repo."
+    },
+    {
+      "path": "preflight.agent_contract_packet.active_exceptions",
+      "value": [],
+      "kind": "matrix_gap",
+      "reason": "The default materialized contract declares none of these. Every fixture accepts the same generated contract, so its optional lists - waivers, exceptions, import boundaries, placement guidance, safe commands - are empty throughout. Closing it needs a fixture carrying a hand-written contract, not a bigger repo."
+    },
+    {
+      "path": "preflight.agent_contract_packet.active_waivers",
+      "value": [],
+      "kind": "matrix_gap",
+      "reason": "The default materialized contract declares none of these. Every fixture accepts the same generated contract, so its optional lists - waivers, exceptions, import boundaries, placement guidance, safe commands - are empty throughout. Closing it needs a fixture carrying a hand-written contract, not a bigger repo."
+    },
+    {
+      "path": "preflight.baseline.by_convention",
+      "value": [],
+      "kind": "matrix_gap",
+      "reason": "Nothing in this matrix records a finding. Conventions are accepted, but no cell runs `check`, which is what materializes violations, waivers and the per-convention baseline. Closing it needs the check step in the matrix, not a different fixture."
+    },
+    {
+      "path": "preflight.findings",
+      "value": [],
+      "kind": "matrix_gap",
+      "reason": "Nothing in this matrix records a finding. Conventions are accepted, but no cell runs `check`, which is what materializes violations, waivers and the per-convention baseline. Closing it needs the check step in the matrix, not a different fixture."
+    },
+    {
+      "path": "preflight.waivers",
+      "value": [],
+      "kind": "matrix_gap",
+      "reason": "Nothing in this matrix records a finding. Conventions are accepted, but no cell runs `check`, which is what materializes violations, waivers and the per-convention baseline. Closing it needs the check step in the matrix, not a different fixture."
+    },
+    {
+      "path": "preflight.safe_commands",
+      "value": [],
+      "kind": "matrix_gap",
+      "reason": "The default materialized contract declares none of these. Every fixture accepts the same generated contract, so its optional lists - waivers, exceptions, import boundaries, placement guidance, safe commands - are empty throughout. Closing it needs a fixture carrying a hand-written contract, not a bigger repo."
     },
     {
       "path": "preflight.governance.read_only",
@@ -1153,10 +1711,28 @@
       "reason": "The default contract's own wording. Every fixture materializes the same default checks and risky areas, so the sentence explaining each is the same sentence. Pinned so a reworded rationale is visible rather than silent."
     },
     {
+      "path": "prepare.conventions[].exceptions",
+      "value": [],
+      "kind": "matrix_gap",
+      "reason": "The default materialized contract declares none of these. Every fixture accepts the same generated contract, so its optional lists - waivers, exceptions, import boundaries, placement guidance, safe commands - are empty throughout. Closing it needs a fixture carrying a hand-written contract, not a bigger repo."
+    },
+    {
       "path": "prepare.graph_context.route_flows[].policy.local_only",
       "value": true,
       "kind": "matrix_gap",
       "reason": "The policy dimension is unexercised: no fixture sets a restrictive `context_egress` in its contract, so authorization is granted in every cell and the whole permission matrix reads as one value. Closing it needs a fixture whose contract denies a surface - not a bigger repo. Known hole, not a promise that policy cannot deny."
+    },
+    {
+      "path": "prepare.graph_context.route_flows[].diagnostics",
+      "value": [],
+      "kind": "matrix_gap",
+      "reason": "Per-node trouble lists. These fixtures parse cleanly and resolve their imports, so the route flows and reachable data access carry no diagnostics - even in the parser-gap fixture, where the gap is recorded on the scan rather than on a graph node. An unparseable route is what fills them."
+    },
+    {
+      "path": "prepare.graph_context.route_flows[].dynamic_params",
+      "value": [],
+      "kind": "matrix_gap",
+      "reason": "Per-node trouble lists. These fixtures parse cleanly and resolve their imports, so the route flows and reachable data access carry no diagnostics - even in the parser-gap fixture, where the gap is recorded on the scan rather than on a graph node. An unparseable route is what fills them."
     },
     {
       "path": "prepare.graph_context.route_flows[].complete",
@@ -1165,10 +1741,34 @@
       "reason": "Constant at true across the matrix, and not yet explained. Either the matrix lacks the state that moves it, or the field is frozen and this gate has found one."
     },
     {
+      "path": "prepare.graph_context.route_flows[].unresolved_imports",
+      "value": [],
+      "kind": "matrix_gap",
+      "reason": "Per-node trouble lists. These fixtures parse cleanly and resolve their imports, so the route flows and reachable data access carry no diagnostics - even in the parser-gap fixture, where the gap is recorded on the scan rather than on a graph node. An unparseable route is what fills them."
+    },
+    {
+      "path": "prepare.graph_context.route_flows[].risk_reasons",
+      "value": [],
+      "kind": "matrix_gap",
+      "reason": "Per-node trouble lists. These fixtures parse cleanly and resolve their imports, so the route flows and reachable data access carry no diagnostics - even in the parser-gap fixture, where the gap is recorded on the scan rather than on a graph node. An unparseable route is what fills them."
+    },
+    {
       "path": "prepare.graph_context.reachable_data_access[].policy.local_only",
       "value": true,
       "kind": "matrix_gap",
       "reason": "The policy dimension is unexercised: no fixture sets a restrictive `context_egress` in its contract, so authorization is granted in every cell and the whole permission matrix reads as one value. Closing it needs a fixture whose contract denies a surface - not a bigger repo. Known hole, not a promise that policy cannot deny."
+    },
+    {
+      "path": "prepare.graph_context.reachable_data_access[].diagnostics",
+      "value": [],
+      "kind": "matrix_gap",
+      "reason": "Per-node trouble lists. These fixtures parse cleanly and resolve their imports, so the route flows and reachable data access carry no diagnostics - even in the parser-gap fixture, where the gap is recorded on the scan rather than on a graph node. An unparseable route is what fills them."
+    },
+    {
+      "path": "prepare.graph_context.reachable_data_access[].risk_reasons",
+      "value": [],
+      "kind": "matrix_gap",
+      "reason": "Per-node trouble lists. These fixtures parse cleanly and resolve their imports, so the route flows and reachable data access carry no diagnostics - even in the parser-gap fixture, where the gap is recorded on the scan rather than on a graph node. An unparseable route is what fills them."
     },
     {
       "path": "prepare.graph_context.affected_files[].policy.local_only",
@@ -1177,10 +1777,34 @@
       "reason": "The policy dimension is unexercised: no fixture sets a restrictive `context_egress` in its contract, so authorization is granted in every cell and the whole permission matrix reads as one value. Closing it needs a fixture whose contract denies a surface - not a bigger repo. Known hole, not a promise that policy cannot deny."
     },
     {
+      "path": "prepare.graph_context.affected_files[].diagnostics",
+      "value": [],
+      "kind": "matrix_gap",
+      "reason": "Per-node trouble lists. These fixtures parse cleanly and resolve their imports, so the route flows and reachable data access carry no diagnostics - even in the parser-gap fixture, where the gap is recorded on the scan rather than on a graph node. An unparseable route is what fills them."
+    },
+    {
+      "path": "prepare.task_preflight_packet.accepted_conventions[].exceptions",
+      "value": [],
+      "kind": "matrix_gap",
+      "reason": "The default materialized contract declares none of these. Every fixture accepts the same generated contract, so its optional lists - waivers, exceptions, import boundaries, placement guidance, safe commands - are empty throughout. Closing it needs a fixture carrying a hand-written contract, not a bigger repo."
+    },
+    {
       "path": "prepare.task_preflight_packet.required_checks[].reason",
       "value": "Block newly introduced deterministic convention violations before code is merged.",
       "kind": "payload_identity",
       "reason": "The default contract's own wording. Every fixture materializes the same default checks and risky areas, so the sentence explaining each is the same sentence. Pinned so a reworded rationale is visible rather than silent."
+    },
+    {
+      "path": "prepare.agent_contract_packet.selected_conventions[].exceptions",
+      "value": [],
+      "kind": "matrix_gap",
+      "reason": "The default materialized contract declares none of these. Every fixture accepts the same generated contract, so its optional lists - waivers, exceptions, import boundaries, placement guidance, safe commands - are empty throughout. Closing it needs a fixture carrying a hand-written contract, not a bigger repo."
+    },
+    {
+      "path": "prepare.agent_contract_packet.selected_conventions[].counterexample_ref_ids",
+      "value": [],
+      "kind": "matrix_gap",
+      "reason": "The default materialized contract declares none of these. Every fixture accepts the same generated contract, so its optional lists - waivers, exceptions, import boundaries, placement guidance, safe commands - are empty throughout. Closing it needs a fixture carrying a hand-written contract, not a bigger repo."
     },
     {
       "path": "prepare.risky_areas[].reason",
@@ -1201,10 +1825,28 @@
       "reason": "The default contract's own wording. Every fixture materializes the same default checks and risky areas, so the sentence explaining each is the same sentence. Pinned so a reworded rationale is visible rather than silent."
     },
     {
+      "path": "preflight.conventions[].exceptions",
+      "value": [],
+      "kind": "matrix_gap",
+      "reason": "The default materialized contract declares none of these. Every fixture accepts the same generated contract, so its optional lists - waivers, exceptions, import boundaries, placement guidance, safe commands - are empty throughout. Closing it needs a fixture carrying a hand-written contract, not a bigger repo."
+    },
+    {
       "path": "preflight.graph_context.route_flows[].policy.local_only",
       "value": true,
       "kind": "matrix_gap",
       "reason": "The policy dimension is unexercised: no fixture sets a restrictive `context_egress` in its contract, so authorization is granted in every cell and the whole permission matrix reads as one value. Closing it needs a fixture whose contract denies a surface - not a bigger repo. Known hole, not a promise that policy cannot deny."
+    },
+    {
+      "path": "preflight.graph_context.route_flows[].diagnostics",
+      "value": [],
+      "kind": "matrix_gap",
+      "reason": "Per-node trouble lists. These fixtures parse cleanly and resolve their imports, so the route flows and reachable data access carry no diagnostics - even in the parser-gap fixture, where the gap is recorded on the scan rather than on a graph node. An unparseable route is what fills them."
+    },
+    {
+      "path": "preflight.graph_context.route_flows[].dynamic_params",
+      "value": [],
+      "kind": "matrix_gap",
+      "reason": "Per-node trouble lists. These fixtures parse cleanly and resolve their imports, so the route flows and reachable data access carry no diagnostics - even in the parser-gap fixture, where the gap is recorded on the scan rather than on a graph node. An unparseable route is what fills them."
     },
     {
       "path": "preflight.graph_context.route_flows[].complete",
@@ -1213,10 +1855,34 @@
       "reason": "Constant at true across the matrix, and not yet explained. Either the matrix lacks the state that moves it, or the field is frozen and this gate has found one."
     },
     {
+      "path": "preflight.graph_context.route_flows[].unresolved_imports",
+      "value": [],
+      "kind": "matrix_gap",
+      "reason": "Per-node trouble lists. These fixtures parse cleanly and resolve their imports, so the route flows and reachable data access carry no diagnostics - even in the parser-gap fixture, where the gap is recorded on the scan rather than on a graph node. An unparseable route is what fills them."
+    },
+    {
+      "path": "preflight.graph_context.route_flows[].risk_reasons",
+      "value": [],
+      "kind": "matrix_gap",
+      "reason": "Per-node trouble lists. These fixtures parse cleanly and resolve their imports, so the route flows and reachable data access carry no diagnostics - even in the parser-gap fixture, where the gap is recorded on the scan rather than on a graph node. An unparseable route is what fills them."
+    },
+    {
       "path": "preflight.graph_context.reachable_data_access[].policy.local_only",
       "value": true,
       "kind": "matrix_gap",
       "reason": "The policy dimension is unexercised: no fixture sets a restrictive `context_egress` in its contract, so authorization is granted in every cell and the whole permission matrix reads as one value. Closing it needs a fixture whose contract denies a surface - not a bigger repo. Known hole, not a promise that policy cannot deny."
+    },
+    {
+      "path": "preflight.graph_context.reachable_data_access[].diagnostics",
+      "value": [],
+      "kind": "matrix_gap",
+      "reason": "Per-node trouble lists. These fixtures parse cleanly and resolve their imports, so the route flows and reachable data access carry no diagnostics - even in the parser-gap fixture, where the gap is recorded on the scan rather than on a graph node. An unparseable route is what fills them."
+    },
+    {
+      "path": "preflight.graph_context.reachable_data_access[].risk_reasons",
+      "value": [],
+      "kind": "matrix_gap",
+      "reason": "Per-node trouble lists. These fixtures parse cleanly and resolve their imports, so the route flows and reachable data access carry no diagnostics - even in the parser-gap fixture, where the gap is recorded on the scan rather than on a graph node. An unparseable route is what fills them."
     },
     {
       "path": "preflight.graph_context.affected_files[].policy.local_only",
@@ -1225,10 +1891,34 @@
       "reason": "The policy dimension is unexercised: no fixture sets a restrictive `context_egress` in its contract, so authorization is granted in every cell and the whole permission matrix reads as one value. Closing it needs a fixture whose contract denies a surface - not a bigger repo. Known hole, not a promise that policy cannot deny."
     },
     {
+      "path": "preflight.graph_context.affected_files[].diagnostics",
+      "value": [],
+      "kind": "matrix_gap",
+      "reason": "Per-node trouble lists. These fixtures parse cleanly and resolve their imports, so the route flows and reachable data access carry no diagnostics - even in the parser-gap fixture, where the gap is recorded on the scan rather than on a graph node. An unparseable route is what fills them."
+    },
+    {
+      "path": "preflight.task_preflight_packet.accepted_conventions[].exceptions",
+      "value": [],
+      "kind": "matrix_gap",
+      "reason": "The default materialized contract declares none of these. Every fixture accepts the same generated contract, so its optional lists - waivers, exceptions, import boundaries, placement guidance, safe commands - are empty throughout. Closing it needs a fixture carrying a hand-written contract, not a bigger repo."
+    },
+    {
       "path": "preflight.task_preflight_packet.required_checks[].reason",
       "value": "Block newly introduced deterministic convention violations before code is merged.",
       "kind": "payload_identity",
       "reason": "The default contract's own wording. Every fixture materializes the same default checks and risky areas, so the sentence explaining each is the same sentence. Pinned so a reworded rationale is visible rather than silent."
+    },
+    {
+      "path": "preflight.agent_contract_packet.selected_conventions[].exceptions",
+      "value": [],
+      "kind": "matrix_gap",
+      "reason": "The default materialized contract declares none of these. Every fixture accepts the same generated contract, so its optional lists - waivers, exceptions, import boundaries, placement guidance, safe commands - are empty throughout. Closing it needs a fixture carrying a hand-written contract, not a bigger repo."
+    },
+    {
+      "path": "preflight.agent_contract_packet.selected_conventions[].counterexample_ref_ids",
+      "value": [],
+      "kind": "matrix_gap",
+      "reason": "The default materialized contract declares none of these. Every fixture accepts the same generated contract, so its optional lists - waivers, exceptions, import boundaries, placement guidance, safe commands - are empty throughout. Closing it needs a fixture carrying a hand-written contract, not a bigger repo."
     },
     {
       "path": "preflight.risky_areas[].reason",
@@ -1279,10 +1969,124 @@
       "reason": "NOT a guarantee - the matrix never truncates. Truncation needs a guidance view over the 32,768-byte budget, which takes roughly 60 realistically-sized conventions; the largest fixture here produces three. This is the exact field D-M5 found hardcoded to false, so it is recorded as a known hole rather than as a property. Closing it needs a fixture built for the budget, not a bigger repo."
     },
     {
+      "path": "prepare.parser_gap_quality.sample_gaps[].affected_capabilities",
+      "value": [],
+      "kind": "matrix_gap",
+      "reason": "The engine reports THAT a construct defeated the parser, not which capability or contract kind the gap costs, and attaches no evidence refs to a gap record. These are declared attribution the engine does not currently supply - adjacent to the placeholder class below, and recorded as a hole so that stays visible rather than reading as `nothing affected`."
+    },
+    {
+      "path": "prepare.parser_gap_quality.sample_gaps[].affected_contract_kinds",
+      "value": [],
+      "kind": "matrix_gap",
+      "reason": "The engine reports THAT a construct defeated the parser, not which capability or contract kind the gap costs, and attaches no evidence refs to a gap record. These are declared attribution the engine does not currently supply - adjacent to the placeholder class below, and recorded as a hole so that stays visible rather than reading as `nothing affected`."
+    },
+    {
+      "path": "prepare.scan_status.parser_gap_quality.sample_gaps[].affected_capabilities",
+      "value": [],
+      "kind": "matrix_gap",
+      "reason": "The engine reports THAT a construct defeated the parser, not which capability or contract kind the gap costs, and attaches no evidence refs to a gap record. These are declared attribution the engine does not currently supply - adjacent to the placeholder class below, and recorded as a hole so that stays visible rather than reading as `nothing affected`."
+    },
+    {
+      "path": "prepare.scan_status.parser_gap_quality.sample_gaps[].affected_contract_kinds",
+      "value": [],
+      "kind": "matrix_gap",
+      "reason": "The engine reports THAT a construct defeated the parser, not which capability or contract kind the gap costs, and attaches no evidence refs to a gap record. These are declared attribution the engine does not currently supply - adjacent to the placeholder class below, and recorded as a hole so that stays visible rather than reading as `nothing affected`."
+    },
+    {
+      "path": "repo_map.parser_gap_quality.sample_gaps[].affected_capabilities",
+      "value": [],
+      "kind": "matrix_gap",
+      "reason": "The engine reports THAT a construct defeated the parser, not which capability or contract kind the gap costs, and attaches no evidence refs to a gap record. These are declared attribution the engine does not currently supply - adjacent to the placeholder class below, and recorded as a hole so that stays visible rather than reading as `nothing affected`."
+    },
+    {
+      "path": "repo_map.parser_gap_quality.sample_gaps[].affected_contract_kinds",
+      "value": [],
+      "kind": "matrix_gap",
+      "reason": "The engine reports THAT a construct defeated the parser, not which capability or contract kind the gap costs, and attaches no evidence refs to a gap record. These are declared attribution the engine does not currently supply - adjacent to the placeholder class below, and recorded as a hole so that stays visible rather than reading as `nothing affected`."
+    },
+    {
+      "path": "repo_map.scan_status.parser_gaps.records[].evidence_refs",
+      "value": [],
+      "kind": "matrix_gap",
+      "reason": "The engine reports THAT a construct defeated the parser, not which capability or contract kind the gap costs, and attaches no evidence refs to a gap record. These are declared attribution the engine does not currently supply - adjacent to the placeholder class below, and recorded as a hole so that stays visible rather than reading as `nothing affected`."
+    },
+    {
+      "path": "repo_map.scan_status.parser_gap_quality.sample_gaps[].affected_capabilities",
+      "value": [],
+      "kind": "matrix_gap",
+      "reason": "The engine reports THAT a construct defeated the parser, not which capability or contract kind the gap costs, and attaches no evidence refs to a gap record. These are declared attribution the engine does not currently supply - adjacent to the placeholder class below, and recorded as a hole so that stays visible rather than reading as `nothing affected`."
+    },
+    {
+      "path": "repo_map.scan_status.parser_gap_quality.sample_gaps[].affected_contract_kinds",
+      "value": [],
+      "kind": "matrix_gap",
+      "reason": "The engine reports THAT a construct defeated the parser, not which capability or contract kind the gap costs, and attaches no evidence refs to a gap record. These are declared attribution the engine does not currently supply - adjacent to the placeholder class below, and recorded as a hole so that stays visible rather than reading as `nothing affected`."
+    },
+    {
+      "path": "scan_status.parser_gaps.records[].evidence_refs",
+      "value": [],
+      "kind": "matrix_gap",
+      "reason": "The engine reports THAT a construct defeated the parser, not which capability or contract kind the gap costs, and attaches no evidence refs to a gap record. These are declared attribution the engine does not currently supply - adjacent to the placeholder class below, and recorded as a hole so that stays visible rather than reading as `nothing affected`."
+    },
+    {
+      "path": "scan_status.parser_gap_quality.sample_gaps[].affected_capabilities",
+      "value": [],
+      "kind": "matrix_gap",
+      "reason": "The engine reports THAT a construct defeated the parser, not which capability or contract kind the gap costs, and attaches no evidence refs to a gap record. These are declared attribution the engine does not currently supply - adjacent to the placeholder class below, and recorded as a hole so that stays visible rather than reading as `nothing affected`."
+    },
+    {
+      "path": "scan_status.parser_gap_quality.sample_gaps[].affected_contract_kinds",
+      "value": [],
+      "kind": "matrix_gap",
+      "reason": "The engine reports THAT a construct defeated the parser, not which capability or contract kind the gap costs, and attaches no evidence refs to a gap record. These are declared attribution the engine does not currently supply - adjacent to the placeholder class below, and recorded as a hole so that stays visible rather than reading as `nothing affected`."
+    },
+    {
+      "path": "preflight.parser_gap_quality.sample_gaps[].affected_capabilities",
+      "value": [],
+      "kind": "matrix_gap",
+      "reason": "The engine reports THAT a construct defeated the parser, not which capability or contract kind the gap costs, and attaches no evidence refs to a gap record. These are declared attribution the engine does not currently supply - adjacent to the placeholder class below, and recorded as a hole so that stays visible rather than reading as `nothing affected`."
+    },
+    {
+      "path": "preflight.parser_gap_quality.sample_gaps[].affected_contract_kinds",
+      "value": [],
+      "kind": "matrix_gap",
+      "reason": "The engine reports THAT a construct defeated the parser, not which capability or contract kind the gap costs, and attaches no evidence refs to a gap record. These are declared attribution the engine does not currently supply - adjacent to the placeholder class below, and recorded as a hole so that stays visible rather than reading as `nothing affected`."
+    },
+    {
+      "path": "preflight.scan_status.parser_gap_quality.sample_gaps[].affected_capabilities",
+      "value": [],
+      "kind": "matrix_gap",
+      "reason": "The engine reports THAT a construct defeated the parser, not which capability or contract kind the gap costs, and attaches no evidence refs to a gap record. These are declared attribution the engine does not currently supply - adjacent to the placeholder class below, and recorded as a hole so that stays visible rather than reading as `nothing affected`."
+    },
+    {
+      "path": "preflight.scan_status.parser_gap_quality.sample_gaps[].affected_contract_kinds",
+      "value": [],
+      "kind": "matrix_gap",
+      "reason": "The engine reports THAT a construct defeated the parser, not which capability or contract kind the gap costs, and attaches no evidence refs to a gap record. These are declared attribution the engine does not currently supply - adjacent to the placeholder class below, and recorded as a hole so that stays visible rather than reading as `nothing affected`."
+    },
+    {
       "path": "prepare.task_preflight_packet.test_intelligence[].test_type",
       "value": "integration",
       "kind": "matrix_gap",
       "reason": "Constant at \"integration\" across the matrix, and not yet explained. Either the matrix lacks the state that moves it, or the field is frozen and this gate has found one."
+    },
+    {
+      "path": "prepare.task_preflight_packet.test_intelligence[].covered_symbols",
+      "value": [],
+      "kind": "unimplemented_placeholder",
+      "reason": "Hardcoded in query/src/test-intelligence.ts and never computed - nothing inspects a test for snapshots or staleness, so these are declared shape rather than measurement. Recorded as a placeholder rather than as an invariant, because `false` here reads to an agent as `checked, and no` when it means `never looked`. This is the EW-3 shape and the honest fix is to compute them or drop them, not to baseline them as properties."
+    },
+    {
+      "path": "prepare.task_preflight_packet.test_intelligence[].mocked_dependencies",
+      "value": [],
+      "kind": "unimplemented_placeholder",
+      "reason": "Hardcoded in query/src/test-intelligence.ts and never computed - nothing inspects a test for snapshots or staleness, so these are declared shape rather than measurement. Recorded as a placeholder rather than as an invariant, because `false` here reads to an agent as `checked, and no` when it means `never looked`. This is the EW-3 shape and the honest fix is to compute them or drop them, not to baseline them as properties."
+    },
+    {
+      "path": "prepare.task_preflight_packet.test_intelligence[].fixture_usage",
+      "value": [],
+      "kind": "unimplemented_placeholder",
+      "reason": "Hardcoded in query/src/test-intelligence.ts and never computed - nothing inspects a test for snapshots or staleness, so these are declared shape rather than measurement. Recorded as a placeholder rather than as an invariant, because `false` here reads to an agent as `checked, and no` when it means `never looked`. This is the EW-3 shape and the honest fix is to compute them or drop them, not to baseline them as properties."
     },
     {
       "path": "prepare.task_preflight_packet.test_intelligence[].snapshot_usage",
@@ -1309,6 +2113,24 @@
       "reason": "Constant at \"integration\" across the matrix, and not yet explained. Either the matrix lacks the state that moves it, or the field is frozen and this gate has found one."
     },
     {
+      "path": "prepare.test_intelligence[].covered_symbols",
+      "value": [],
+      "kind": "unimplemented_placeholder",
+      "reason": "Hardcoded in query/src/test-intelligence.ts and never computed - nothing inspects a test for snapshots or staleness, so these are declared shape rather than measurement. Recorded as a placeholder rather than as an invariant, because `false` here reads to an agent as `checked, and no` when it means `never looked`. This is the EW-3 shape and the honest fix is to compute them or drop them, not to baseline them as properties."
+    },
+    {
+      "path": "prepare.test_intelligence[].mocked_dependencies",
+      "value": [],
+      "kind": "unimplemented_placeholder",
+      "reason": "Hardcoded in query/src/test-intelligence.ts and never computed - nothing inspects a test for snapshots or staleness, so these are declared shape rather than measurement. Recorded as a placeholder rather than as an invariant, because `false` here reads to an agent as `checked, and no` when it means `never looked`. This is the EW-3 shape and the honest fix is to compute them or drop them, not to baseline them as properties."
+    },
+    {
+      "path": "prepare.test_intelligence[].fixture_usage",
+      "value": [],
+      "kind": "unimplemented_placeholder",
+      "reason": "Hardcoded in query/src/test-intelligence.ts and never computed - nothing inspects a test for snapshots or staleness, so these are declared shape rather than measurement. Recorded as a placeholder rather than as an invariant, because `false` here reads to an agent as `checked, and no` when it means `never looked`. This is the EW-3 shape and the honest fix is to compute them or drop them, not to baseline them as properties."
+    },
+    {
       "path": "prepare.test_intelligence[].snapshot_usage",
       "value": false,
       "kind": "unimplemented_placeholder",
@@ -1333,6 +2155,24 @@
       "reason": "Constant at \"integration\" across the matrix, and not yet explained. Either the matrix lacks the state that moves it, or the field is frozen and this gate has found one."
     },
     {
+      "path": "preflight.task_preflight_packet.test_intelligence[].covered_symbols",
+      "value": [],
+      "kind": "unimplemented_placeholder",
+      "reason": "Hardcoded in query/src/test-intelligence.ts and never computed - nothing inspects a test for snapshots or staleness, so these are declared shape rather than measurement. Recorded as a placeholder rather than as an invariant, because `false` here reads to an agent as `checked, and no` when it means `never looked`. This is the EW-3 shape and the honest fix is to compute them or drop them, not to baseline them as properties."
+    },
+    {
+      "path": "preflight.task_preflight_packet.test_intelligence[].mocked_dependencies",
+      "value": [],
+      "kind": "unimplemented_placeholder",
+      "reason": "Hardcoded in query/src/test-intelligence.ts and never computed - nothing inspects a test for snapshots or staleness, so these are declared shape rather than measurement. Recorded as a placeholder rather than as an invariant, because `false` here reads to an agent as `checked, and no` when it means `never looked`. This is the EW-3 shape and the honest fix is to compute them or drop them, not to baseline them as properties."
+    },
+    {
+      "path": "preflight.task_preflight_packet.test_intelligence[].fixture_usage",
+      "value": [],
+      "kind": "unimplemented_placeholder",
+      "reason": "Hardcoded in query/src/test-intelligence.ts and never computed - nothing inspects a test for snapshots or staleness, so these are declared shape rather than measurement. Recorded as a placeholder rather than as an invariant, because `false` here reads to an agent as `checked, and no` when it means `never looked`. This is the EW-3 shape and the honest fix is to compute them or drop them, not to baseline them as properties."
+    },
+    {
       "path": "preflight.task_preflight_packet.test_intelligence[].snapshot_usage",
       "value": false,
       "kind": "unimplemented_placeholder",
@@ -1355,6 +2195,24 @@
       "value": "integration",
       "kind": "matrix_gap",
       "reason": "Constant at \"integration\" across the matrix, and not yet explained. Either the matrix lacks the state that moves it, or the field is frozen and this gate has found one."
+    },
+    {
+      "path": "preflight.test_intelligence[].covered_symbols",
+      "value": [],
+      "kind": "unimplemented_placeholder",
+      "reason": "Hardcoded in query/src/test-intelligence.ts and never computed - nothing inspects a test for snapshots or staleness, so these are declared shape rather than measurement. Recorded as a placeholder rather than as an invariant, because `false` here reads to an agent as `checked, and no` when it means `never looked`. This is the EW-3 shape and the honest fix is to compute them or drop them, not to baseline them as properties."
+    },
+    {
+      "path": "preflight.test_intelligence[].mocked_dependencies",
+      "value": [],
+      "kind": "unimplemented_placeholder",
+      "reason": "Hardcoded in query/src/test-intelligence.ts and never computed - nothing inspects a test for snapshots or staleness, so these are declared shape rather than measurement. Recorded as a placeholder rather than as an invariant, because `false` here reads to an agent as `checked, and no` when it means `never looked`. This is the EW-3 shape and the honest fix is to compute them or drop them, not to baseline them as properties."
+    },
+    {
+      "path": "preflight.test_intelligence[].fixture_usage",
+      "value": [],
+      "kind": "unimplemented_placeholder",
+      "reason": "Hardcoded in query/src/test-intelligence.ts and never computed - nothing inspects a test for snapshots or staleness, so these are declared shape rather than measurement. Recorded as a placeholder rather than as an invariant, because `false` here reads to an agent as `checked, and no` when it means `never looked`. This is the EW-3 shape and the honest fix is to compute them or drop them, not to baseline them as properties."
     },
     {
       "path": "preflight.test_intelligence[].snapshot_usage",

--- a/scripts/payload-invariants.mjs
+++ b/scripts/payload-invariants.mjs
@@ -97,6 +97,34 @@ const FIXTURES = [
   },
   {
     name: "next-api-direct-db",
+    as: "next-api-direct-db+snapshot-test",
+    // The counterpart to +matching-test, and both are needed. `snapshot_usage`,
+    // `mocked_dependencies` and `fixture_usage` are read from the matched test's own source, and
+    // the only cells that produce a `test_intelligence` entry AT ALL are the ones with a matching
+    // test. With just the plain test above, every entry in the matrix would report `false`/`[]` -
+    // correctly, having actually looked - and the fields would still read as frozen. This is the
+    // cell where the answer is yes, and it is what moves them off the baseline.
+    async seed(repoRoot) {
+      await mkdir(join(repoRoot, "apps/web/app/api/users/__fixtures__"), { recursive: true });
+      await writeFile(
+        join(repoRoot, "apps/web/app/api/users/__fixtures__/users.ts"),
+        "export const userRows = [];\n"
+      );
+      await writeFile(
+        join(repoRoot, "apps/web/app/api/users/route.test.ts"),
+        [
+          'import { expect, it, vi } from "vitest";',
+          'import { GET } from "./route";',
+          'import { userRows } from "./__fixtures__/users";',
+          'vi.mock("@/lib/db");',
+          'it("renders", () => { expect(GET(userRows)).toMatchSnapshot(); });',
+          ""
+        ].join("\n")
+      );
+    }
+  },
+  {
+    name: "next-api-direct-db",
     as: "next-api-direct-db+unrelated-test",
     // Tests exist and none of them is about the change: the `no_tests_matched_change` half.
     async seed(repoRoot) {
@@ -286,24 +314,28 @@ export function classifyConstant(path, value) {
         "same state throughout. A failed or dirty scan is a different harness."
     };
   }
-  if (/test_intelligence\[\]\.(snapshot_usage|stale_test_candidate|covered_symbols|mocked_dependencies|fixture_usage)$/.test(path)) {
+  if (/test_intelligence\[\]\.covered_symbols$/.test(path)) {
     return {
       kind: "unimplemented_placeholder",
       reason:
-        "Hardcoded in query/src/test-intelligence.ts and never computed - nothing inspects a test " +
-        "for snapshots or staleness, so these are declared shape rather than measurement. Recorded " +
-        "as a placeholder rather than as an invariant, because `false` here reads to an agent as " +
-        "`checked, and no` when it means `never looked`. This is the EW-3 shape and the honest fix " +
-        "is to compute them or drop them, not to baseline them as properties."
+        "Still hardcoded `[]` in query/src/test-intelligence.ts. Answering it means resolving the " +
+        "call sites inside a test file against the symbol graph - the engine emits symbol " +
+        "identities, but nothing links a test's calls to them - so this is engine work rather than " +
+        "a read of the test's source, which is why it did not land with the three fields beside it. " +
+        "Recorded as a placeholder, not an invariant: `[]` here reads to an agent as `this test " +
+        "covers nothing` when it means `never looked`."
     };
   }
-  if (/test_intelligence\[\]\.missing_test_candidate$/.test(path)) {
+  if (/test_intelligence\[\]\.stale_test_candidate$/.test(path)) {
     return {
-      kind: "product_invariant",
+      kind: "unimplemented_placeholder",
       reason:
-        "False by construction: an entry exists in this array only because a test was FOUND for the " +
-        "subject, so a per-entry `missing` flag can never be true. The real signal is the sibling " +
-        "`missing_test_candidate` on the selection itself, which does vary."
+        "Still hardcoded `false`, and deliberately so: it has no DEFINITION yet, and a wrong one is " +
+        "worse than an honest gap. Stale relative to what - the subject's mtime, a content hash " +
+        "across two scans, the last scan of the test itself? Those disagree on real repos, and each " +
+        "would make `stale_test_candidate: true` mean something different to an agent deciding " +
+        "whether to trust a passing test. Recorded as a placeholder rather than an invariant: it " +
+        "needs the definition settled before it needs code."
     };
   }
   if (/required_capabilities\[\]$/.test(path)) {

--- a/scripts/payload-invariants.mjs
+++ b/scripts/payload-invariants.mjs
@@ -124,6 +124,11 @@ const DISCRIMINATOR_NAMES = new Set(["decision", "reason", "status", "stale", "c
 const DISCRIMINATOR_PARENTS = new Set(["truncated", "redactions", "readiness", "capability_completeness"]);
 
 export function isTrustDiscriminator(path, value) {
+  // An EMPTY list, wherever it sits. Only empty arrays ever reach here as leaves - a populated one
+  // recurses into its elements - so this reads "this list was empty in the cell that produced it".
+  // `covered_symbols: []` in every cell is the same defect as `snapshot_usage: false` in every
+  // cell, declared shape with nothing computing it, and it is the half this gate could not see.
+  if (Array.isArray(value)) return true;
   if (typeof value === "boolean") return true;
   const segments = path.split(".");
   const name = segments.at(-1) ?? "";
@@ -145,24 +150,57 @@ export function isTrustDiscriminator(path, value) {
  * Collapsed because `conventions.0.enforcement_mode` and `conventions.1.enforcement_mode` are the
  * same field, and keeping them apart would let a field look varying because two array elements
  * differ while the field itself is a literal.
+ *
+ * An EMPTY array is a leaf in its own right, valued `[]`. Without that, an array had no path
+ * unless it had elements, so a field that is `[]` in every cell emitted nothing and this gate
+ * evaluated it zero times - reporting success over the exact shape it exists to catch. Three of
+ * `test_intelligence`'s hardcoded fields are lists, and they sat next to two hardcoded booleans
+ * the gate did catch; only the type told them apart.
  */
 export function leafFields(value, path = "", out = new Map()) {
+  const record = (leaf) => {
+    if (!path) return;
+    const existing = out.get(path);
+    if (existing) existing.push(leaf);
+    else out.set(path, [leaf]);
+  };
   if (value === null || typeof value !== "object") {
-    if (path) {
-      const existing = out.get(path);
-      if (existing) existing.push(value);
-      else out.set(path, [value]);
-    }
+    record(value);
     return out;
   }
   if (Array.isArray(value)) {
-    for (const entry of value) leafFields(entry, `${path}[]`, out);
+    // Populated arrays still RECURSE and emit no leaf of their own, which is what keeps
+    // `conventions[].mode` gathering values across elements.
+    if (value.length === 0) record([]);
+    else for (const entry of value) leafFields(entry, `${path}[]`, out);
     return out;
   }
   for (const [key, entry] of Object.entries(value)) {
     leafFields(entry, path ? `${path}.${key}` : key, out);
   }
   return out;
+}
+
+/**
+ * Every array path that some cell filled, read back off the collapsed leaf keys.
+ *
+ * A list that is empty HERE and populated THERE is working, not frozen, and the two states land
+ * under different keys: the empty cells contribute `[]` at `conventions`, the populated ones
+ * contribute `conventions[].mode`. Without this, every conditionally-populated list in the payload
+ * reads as a hardcoded literal - 208 of them on the first run of this gate, swamping the 12 real
+ * ones. The `[]` segment appearing anywhere in a key IS the proof that something filled that array.
+ *
+ * Prefix-wise, not key-wise: an array of OBJECTS never produces the bare key `conventions[]`, only
+ * `conventions[].<field>`, so an exact-match test misses precisely the populated arrays that matter.
+ */
+export function populatedArrayPaths(keys) {
+  const populated = new Set();
+  for (const key of keys) {
+    for (let index = key.indexOf("[]"); index !== -1; index = key.indexOf("[]", index + 2)) {
+      populated.add(key.slice(0, index));
+    }
+  }
+  return populated;
 }
 
 /**
@@ -310,6 +348,126 @@ export function classifyConstant(path, value) {
         "trust reports `none`/`unknown` throughout. These are exactly the D-A2 fields the CLI used " +
         "to omit, so the hole is worth naming: they are present and correct, and only one of their " +
         "values is exercised."
+    };
+  }
+  // ---- EMPTY LISTS ----
+  //
+  // Everything below is an array that was `[]` in every cell. None of it could be classified
+  // before, because none of it was visible before: an array had no leaf unless it had elements, so
+  // the gate evaluated every always-empty list exactly zero times. The first run that could see
+  // them found 143, of which 12 are the `test_intelligence` placeholders this class was opened for
+  // and the rest are lists the matrix never fills.
+  //
+  // Grouped rather than enumerated. 131 copies of "constant, and not yet explained" is the
+  // several-hundred-entry unreadable baseline the SCOPE note at the top of this file refuses, and
+  // it would bury the 12 that are a defect. Guarded on `Array.isArray` so none of these can shadow
+  // a scalar rule above.
+  if (Array.isArray(value)) {
+    if (
+      /(active_exceptions|active_waivers|import_boundaries|placement_guidance|required_flows|selected_contracts|selected_helpers|safe_commands)$/.test(path) ||
+      /(selected_conventions|conventions|accepted_conventions)\[\]\.(exceptions|counterexample_ref_ids)$/.test(path) ||
+      /agent_contract_packet\.required_checks$/.test(path)
+    ) {
+      return {
+        kind: "matrix_gap",
+        reason:
+          "The default materialized contract declares none of these. Every fixture accepts the same " +
+          "generated contract, so its optional lists - waivers, exceptions, import boundaries, " +
+          "placement guidance, safe commands - are empty throughout. Closing it needs a fixture " +
+          "carrying a hand-written contract, not a bigger repo."
+      };
+    }
+    if (/(missing_capabilities|partial_capabilities|unsupported_capabilities|unsupported_pattern_ids|security_capabilities)$/.test(path)) {
+      return {
+        kind: "matrix_gap",
+        reason:
+          "The engine supports every capability these fixtures exercise, so the shortfall lists stay " +
+          "empty. NOT a claim that coverage is total: it is the same absence `semantic_coverage` " +
+          "exists to report, observed on a matrix small enough never to produce one."
+      };
+    }
+    if (/change_impact\.(affected_tests|changed_symbols|changed_tests)$/.test(path)) {
+      return {
+        kind: "matrix_gap",
+        reason:
+          "Change impact is computed against `relevant_files`, which this matrix derives from a task " +
+          "string rather than from a diff, so no cell presents a CHANGED symbol or test. Closing it " +
+          "needs a fixture scanned twice with an edit in between."
+      };
+    }
+    if (/(audit_integrity\.reasons|invalidation_reasons)$/.test(path)) {
+      return {
+        kind: "matrix_gap",
+        reason:
+          "Reason lists that fill only on failure. The audit chain verifies and the scan is never " +
+          "invalidated in this matrix, so both stay empty - the list form of the same hole recorded " +
+          "for `audit_integrity.valid`. Corrupting a hash-linked log on purpose is the storage " +
+          "suite's job, not this one's."
+      };
+    }
+    if (/changes\.(deleted|modified)$/.test(path)) {
+      return {
+        kind: "matrix_gap",
+        reason:
+          "Every cell scans a fresh copy of a fixture, so the first scan reports additions only and " +
+          "the deleted/modified deltas are structurally empty. A second scan over an edited tree " +
+          "would move them; this matrix edits only to make a scan STALE, then never rescans."
+      };
+    }
+    if (/(sample_gaps\[\]\.(affected_capabilities|affected_contract_kinds)|parser_gaps\.records(\[\]\.evidence_refs)?)$/.test(path)) {
+      return {
+        kind: "matrix_gap",
+        reason:
+          "The engine reports THAT a construct defeated the parser, not which capability or contract " +
+          "kind the gap costs, and attaches no evidence refs to a gap record. These are declared " +
+          "attribution the engine does not currently supply - adjacent to the placeholder class " +
+          "below, and recorded as a hole so that stays visible rather than reading as `nothing " +
+          "affected`."
+      };
+    }
+    if (/(diagnostics|risk_reasons|dynamic_params|unresolved_imports|parser_gap_codes)$/.test(path)) {
+      return {
+        kind: "matrix_gap",
+        reason:
+          "Per-node trouble lists. These fixtures parse cleanly and resolve their imports, so the " +
+          "route flows and reachable data access carry no diagnostics - even in the parser-gap " +
+          "fixture, where the gap is recorded on the scan rather than on a graph node. An unparseable " +
+          "route is what fills them."
+      };
+    }
+    if (/(findings|waivers|baseline\.by_convention|open_finding_ids|finding_ids)$/.test(path)) {
+      return {
+        kind: "matrix_gap",
+        reason:
+          "Nothing in this matrix records a finding. Conventions are accepted, but no cell runs " +
+          "`check`, which is what materializes violations, waivers and the per-convention baseline. " +
+          "Closing it needs the check step in the matrix, not a different fixture."
+      };
+    }
+    if (/(topology\.(configs|external_systems|generated_zones)|topology\.areas\[\]\.external_systems)$/.test(path)) {
+      return {
+        kind: "matrix_gap",
+        reason:
+          "Repo topology beyond the source tree. These fixtures are hand-built directories with no " +
+          "config files, no generated zones and no external systems to detect, so the lists naming " +
+          "them are empty by fixture size rather than by any property of the detector."
+      };
+    }
+    if (/role_layer_proof$/.test(path)) {
+      return {
+        kind: "matrix_gap",
+        reason:
+          "The role/layer proof is emitted only for files whose role the ontology resolves with " +
+          "enough confidence to defend; no fixture in this matrix produces one. Present and correct, " +
+          "and entirely unexercised here."
+      };
+    }
+    return {
+      kind: "matrix_gap",
+      reason:
+        "An empty list in every cell, and not yet explained. Either the matrix lacks the state that " +
+        "fills it, or nothing computes it and this gate has found the list-typed form of the " +
+        "hardcoded-literal defect."
     };
   }
   if (path.includes("truncated")) {
@@ -637,11 +795,14 @@ function main({ cells, pointerResults }) {
   }
 
   // Check A.
+  const populated = populatedArrayPaths(byPayload.keys());
   const evaluated = [];
   const constants = [];
   for (const [path, values] of byPayload) {
     if (values.length < 2) continue;
     if (!isTrustDiscriminator(path, values[0])) continue;
+    // Empty in every cell, or merely empty in this one? See populatedArrayPaths.
+    if (Array.isArray(values[0]) && populated.has(path)) continue;
     evaluated.push(path);
     const distinct = new Set(values.map((value) => JSON.stringify(value)));
     if (distinct.size === 1) {

--- a/scripts/payload-invariants.test.mjs
+++ b/scripts/payload-invariants.test.mjs
@@ -9,6 +9,7 @@ import {
   isTrustDiscriminator,
   leafFields,
   pointerFields,
+  populatedArrayPaths,
   pointerIsRoutable,
   routedCommandPrefixes
 } from "./payload-invariants.mjs";
@@ -165,6 +166,51 @@ describe("leaf flattening", () => {
 
   it("keeps nulls, which are answers", () => {
     expect(leafFields({ reason: null }).get("reason")).toEqual([null]);
+  });
+
+  it("emits a leaf for an EMPTY array, which is the always-[] blind spot", () => {
+    // The hole this gate shipped with. `covered_symbols: []` produced no path at all, so a field
+    // that is an empty list in every cell - declared shape with nothing computing it - was
+    // invisible, while the `snapshot_usage: false` sitting beside it in the same object was
+    // caught. An always-empty list is the same defect wearing a different type.
+    const leaves = leafFields({ covered_symbols: [], snapshot_usage: false });
+    expect([...leaves.keys()]).toEqual(["covered_symbols", "snapshot_usage"]);
+    expect(leaves.get("covered_symbols")).toEqual([[]]);
+    expect(isTrustDiscriminator("test_intelligence[].covered_symbols", [])).toBe(true);
+  });
+
+  it("does not call a list frozen when another cell filled it", () => {
+    // The correctness half of emitting `[]`. `conventions` is empty in the no-ts fixture and
+    // populated everywhere else; the two states land under different keys, so counting only the
+    // empty ones would report a working field as a hardcoded literal.
+    //
+    // Prefix-wise, and this is the part an exact-match test gets wrong: an array of OBJECTS never
+    // produces the bare key `conventions[]`, only `conventions[].mode`. Matching on the exact key
+    // missed every populated object-array and reported 208 constants instead of 12.
+    const populated = populatedArrayPaths([
+      "prepare.conventions",
+      "prepare.conventions[].mode",
+      "prepare.safe_commands",
+      "prepare.safe_commands[]",
+      "prepare.test_intelligence[].covered_symbols",
+      "prepare.graph_context.route_flows[].diagnostics[].code"
+    ]);
+    expect(populated.has("prepare.conventions")).toBe(true);
+    expect(populated.has("prepare.safe_commands")).toBe(true);
+    // Nested: both the outer array and the inner one were filled.
+    expect(populated.has("prepare.graph_context.route_flows")).toBe(true);
+    expect(populated.has("prepare.graph_context.route_flows[].diagnostics")).toBe(true);
+    // The always-empty field itself is NOT populated - it is the one that must survive to the
+    // baseline, and a guard that swallowed it would restore the blind spot with extra steps.
+    expect(populated.has("prepare.test_intelligence[].covered_symbols")).toBe(false);
+  });
+
+  it("still recurses into a NON-empty array rather than emitting a leaf for it", () => {
+    // The collapse semantics above must survive: a populated array contributes its elements and
+    // no leaf of its own, so `conventions[].mode` keeps gathering values across elements.
+    const leaves = leafFields({ conventions: [{ mode: "warn" }, { mode: "block" }] });
+    expect([...leaves.keys()]).toEqual(["conventions[].mode"]);
+    expect(leaves.has("conventions")).toBe(false);
   });
 });
 

--- a/scripts/payload-invariants.test.mjs
+++ b/scripts/payload-invariants.test.mjs
@@ -117,9 +117,11 @@ describe("baseline honesty", () => {
   });
 
   it("records the unimplemented placeholders as placeholders", () => {
-    // `snapshot_usage` and `stale_test_candidate` are hardcoded false in test-intelligence.ts and
+    // `covered_symbols` and `stale_test_candidate` are still hardcoded in test-intelligence.ts and
     // nothing computes them. Recording them as invariants would say "checked, and no" about a
-    // field that never looked.
+    // field that never looked. Their three former neighbours - `snapshot_usage`,
+    // `mocked_dependencies`, `fixture_usage` - are read from the test's source now and vary, which
+    // is why they are absent from the baseline entirely rather than recorded here.
     const placeholders = JSON.parse(original).constants.filter(
       (entry) => entry.kind === "unimplemented_placeholder"
     );


### PR DESCRIPTION
Six `TestIntelligence` fields were declared in the type, validated by the Zod schema, and never computed — literals in the one place that builds the struct. The payload-invariants gate measured the consequence: identical across all 176 matrix cells, on both surfaces, in both the top-level `test_intelligence` and the copy inside `task_preflight_packet`.

`snapshot_usage: false` is the one that costs something. An agent deciding whether its edit breaks a snapshot test read a confident negative from a field that never opened the file.

Two commits, and the order is load-bearing.

## 1. The gate could not see an empty list

`leafFields` gave an array a path only when it had elements:

```js
leafFields({ covered_symbols: [], snapshot_usage: false })  // -> ['snapshot_usage']
```

Both fields there are hardcoded. The gate caught the boolean and evaluated the list **zero times** — and three of the six unimplemented fields are lists. Fixing the fields first would have left those three held by nothing.

An empty array is now a leaf valued `[]`. A populated array still recurses and emits no leaf, so `conventions[].mode` collapse semantics are unchanged (pinned by a test).

The first run reported 208 constants, **65 of them working fields**: a list empty in one cell and populated in another splits across two keys, so the bare path collects only `[]` and reads as frozen. `populatedArrayPaths` matches on **prefix** — an array of objects never produces the bare key `conventions[]`, only `conventions[].<field>`, so an exact-key test misses exactly the populated object-arrays that matter.

The remaining 143 are real, and 131 are not `test_intelligence` — more than the class this was opened for. They're classified in eleven groups with stated reasons rather than 131 copies of "not yet explained". Zero fall through to the generic reason.

## 2. The fields themselves

**Computed** (read from the matched test's source; only matched tests are read, and the read lives in `@drift/query` so both surfaces share one derivation):

| Field | Rule |
|---|---|
| `snapshot_usage` | `toMatchSnapshot` / `toMatchInlineSnapshot` / `toMatchFileSnapshot` / `.snap` |
| `mocked_dependencies` | `vi.mock` / `jest.mock` and `doMock` forms, deduped and sorted |
| `fixture_usage` | imports under `__fixtures__` or `fixtures/`, or named `*.fixture` |

They are `… | null` now, and the null is the point: it means the source was not read, and that is not the same answer as `false` or `[]`.

**Dropped** — `missing_test_candidate`. Not a fix; a deletion. An entry exists only because a test was *found*, so a per-entry "missing" flag was false by construction. The name appears at two levels one apart, and the selection-level one carries the real signal and varies — a blind rename would have taken the working one.

**Still placeholders**, recorded as `unimplemented_placeholder` with reasons rather than reclassified:

- `covered_symbols` — needs the test's call sites resolved against the symbol graph. Engine work.
- `stale_test_candidate` — has no *definition* yet. Stale against mtime, a content hash across two scans, or the last scan of the test? Each makes `true` mean something different.

**Schema version bumped**, `drift.test_intelligence.v1` → `v2`. A required field removed and three widened to nullable; a strict parser rejects `null` where it required a boolean. `parser_gap` and `symbol_identity` already carry v1 and v2.

**The matrix had to grow.** The only cells producing an entry are those with a matching test, and the single seeded test had no snapshot, mock or fixture — so all three fields would have read `false`/`[]` in every cell, correctly, having actually looked, and still appeared frozen. `next-api-direct-db+snapshot-test` is the cell where the answer is yes.

Baseline 229 → 372 → 354. `unimplemented_placeholder` 8 → 20 → 8.

## One thing the gate does not catch

`--update` *preserves* reasons, so `covered_symbols` and `stale_test_candidate` kept a reason reading "nothing inspects a test for snapshots or staleness" after snapshots became inspected. The entries survived, so neither the NEW nor the STALE half fired, and the baseline held a sentence that had quietly become false. Found by reading the diff; rewritten by hand.

## Validation

cli 678 · core 220 · storage 60 · mcp 67 · query 68 → **73** · harness 190 → **193** · e2e 83 · cargo 211 (no Rust touched).

All seven static gates pass; `cargo fmt --check`, `clippy -D warnings`, `git diff --check` and `beta:proof` clean. MCP stays structurally read-only (0 mutating storage calls, 0 `@drift/cli` imports) — the one line added there is a `getRepo` read.

🤖 Generated with [Claude Code](https://claude.com/claude-code)