### PR TITLE
fix(cli,docs): first-run honesty — what onboarding said that was not true

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -2,7 +2,7 @@
 
 Start here:
 
-- [`quickstart.md`](quickstart.md) — install through to a first blocked change
+- [`quickstart.md`](quickstart.md) — building from source through to a first check, and why it probably only warns
 - [`concepts.md`](concepts.md) — facts → contract → baseline → check
 - [`agent-integration.md`](agent-integration.md) — MCP, hooks, CI
 - [`ci-integration.md`](ci-integration.md) — wiring Drift into your own CI

--- a/docs/agent-integration.md
+++ b/docs/agent-integration.md
@@ -47,17 +47,28 @@ Tracked as T44, blocked on T45.
 
 ## CI
 
+Drift is not published to npm, so CI builds it the way the [quickstart](./quickstart.md#install)
+does — clone, `pnpm build && pnpm build:engine`, and call `packages/cli/dist/main.js`. `npx
+@drift/cli` resolves to nothing.
+
+CI adopts the committed contract; it does **not** onboard itself:
+
 ```yaml
-- run: npx @drift/cli check --diff origin/main...HEAD --scope changed-hunks --json
+- run: drift contract import drift.lock --repo "$DRIFT_REPO_ID" --confirm --json
+- run: drift check --diff origin/main...HEAD --scope changed-hunks --json
 ```
 
 Branch on the exit code: `0` pass, `2` the diff violates the contract, `3` Drift refused to
 answer, `1` Drift broke. Treat `3` as a failure — it means no enforcement claim was made.
 
-**Caveat that matters.** A committed contract cannot currently be imported by CI or by a
-teammate. Repo identity is derived from the **absolute path**, so every checkout is a different
-repo and `contract import` refuses with `repo_id_mismatch`. Until that changes, each environment
-must onboard for itself. Tracked as T19b.
+**Import, do not re-onboard.** Running `drift start` in CI produces a *different* contract from
+the one your team reviewed: convention ids are content hashes over the evidence a scan happened to
+find, so a CI checkout infers its own candidates and its own fingerprints, and enforces something
+nobody approved. The lock file is the single instruction — see
+[Sharing a contract](#sharing-a-contract-driftlock) below for exporting and committing it.
+
+Use `--scope changed-hunks`. `--scope full` classifies every finding as pre-existing, so it never
+exits `2` and a job gated on it gates on nothing.
 
 ## What an agent should be told
 
@@ -78,7 +89,8 @@ drift contract export --repo <repo_id> --output drift.lock --confirm
 git add drift.lock && git commit -m "pin drift conventions"
 ```
 
-A teammate, or CI, then adopts it:
+A teammate, or CI, then adopts it — this is the only supported way for a second environment to get
+your conventions:
 
 ```bash
 drift contract import drift.lock --repo <repo_id> --confirm

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -3,10 +3,25 @@
 Drift learns one convention from your repository, records the code that already violates it, and
 blocks new violations in changed code. It runs entirely on your machine.
 
-## Install and onboard
+## Install
+
+**Nothing is published to npm yet.** `npm install -g @drift/cli` fails with `E404`, and the
+`driftdetect` package on npm is an unrelated v1 from January. Until a release exists, the install
+is a build from source, which needs a Rust toolchain ([rustup](https://rustup.rs)) because the scan
+engine is Rust.
 
 ```bash
-npm install -g @drift/cli
+git clone https://github.com/dadbodgeoff/drift.git && cd drift
+pnpm install --frozen-lockfile
+pnpm build && pnpm build:engine
+
+# There is no `drift` binary yet; the entry point is the built CLI.
+alias drift="node $PWD/packages/cli/dist/main.js"
+```
+
+## Onboard
+
+```bash
 cd your-repo
 drift doctor --repo-root .
 ```
@@ -22,16 +37,24 @@ drift start --repo-root . --accept-defaults
 On a 5,000-file monorepo this takes around 35 seconds. It scans, infers a candidate convention,
 accepts the strongest one, and baselines every existing violation.
 
-The output tells you three things worth reading:
+The output tells you what was decided, in the mode it was decided in:
 
 ```
 Stored 107276 facts.
-Accepted default convention.
-Baselined 417 existing violations.
+Found 21 convention candidates.
+
+Accepted "api_route_no_direct_data_access" in WARN mode (417 existing violations baselined —
+new violations will be reported but will NOT block).
+To make this a gate: drift conventions accept convention_… --repo repo_… --severity error --mode block --confirm
 ```
 
 **417 baselined violations is not a backlog.** It is the code Drift will *not* complain about.
 New code is held to the convention; existing code is grandfathered until you choose otherwise.
+
+**Read the mode word.** In `WARN` mode nothing blocks: a new violation is reported and `drift
+check` still exits `0`. Onboarding says so rather than announcing readiness, because the two are
+different states and only one of them stops an agent. Why your repo probably lands in warn mode is
+[below](#why-your-repo-might-only-warn).
 
 ## Check a change
 
@@ -90,5 +113,17 @@ thing to run. [reference/errors.md](./reference/errors.md) lists every code.
 
 It enforces **one** convention kind well — API routes not importing data-access clients directly,
 in TypeScript and JavaScript. It does not review code generally, support other languages, or
-modify your source. The security heuristics are behind `--experimental-security` and are not
+modify your source.
+
+**Routes mean Next.js routes.** Route detection recognises app-router
+`**/app/**/route.{ts,tsx,js,jsx}` and pages-router `**/pages/api/**`, and nothing else. On an
+Express, Fastify, NestJS or SvelteKit repo the scan still indexes files and stores facts, but no
+file is recognised as a route, so onboarding proposes zero candidates and there is nothing to
+accept. `drift start` says so; rescanning does not change it.
+
+The security heuristics are behind `--experimental-security` and are not
 proofs; see [architecture/security-heuristic-audit.md](../internal/architecture/security-heuristic-audit.md).
+
+`drift conventions list` also hides candidates below a coverage floor by default. It reports how
+many it withheld and prints the command that shows them — `--include-low-confidence` for the
+floor, `--experimental-security` for the quarantined security kinds.

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -1,7 +1,8 @@
 # Quickstart
 
 Drift learns one convention from your repository, records the code that already violates it, and
-blocks new violations in changed code. It runs entirely on your machine.
+reports new violations in changed code — blocking them once the convention is in block mode, which
+[most repos have to opt into](#why-your-repo-might-only-warn). It runs entirely on your machine.
 
 ## Install
 

--- a/packages/cli/src/args/help.ts
+++ b/packages/cli/src/args/help.ts
@@ -236,6 +236,14 @@ export function helpText(parsed: ParsedArgs): string {
       "  --scope changed-files  Check findings anywhere in changed files.",
       "  --scope full           Classify all evaluated findings as full-scope.",
       "  --json                 Emit machine-readable JSON.",
+      "",
+      "Notes:",
+      // Phrased around what full scope classifies rather than around an exit code, because that is
+      // the mechanism and it does not move: every finding it produces is `touched_existing`, and
+      // only `new_in_diff` findings are counted as blocking. So full scope cannot exit 2 under any
+      // convention or mode, and a pipeline that gates on it gates on nothing.
+      "  --scope full does not gate. It classifies every finding as pre-existing, so it never",
+      "  exits 2 no matter what the contract enforces. Use --scope changed-hunks in CI.",
       ""
     ].join("\n");
   }
@@ -255,6 +263,21 @@ export function helpText(parsed: ParsedArgs): string {
       "  drift --db <path> conventions exception add <convention_id> --repo <repo_id> --path <glob> --reason \"...\" --confirm --json",
       "  drift --db <path> conventions exception add <convention_id> --repo <repo_id> --endpoint /api/health --method GET --reason \"...\" --confirm --json",
       "  drift --db <path> conventions exception add <convention_id> --repo <repo_id> --operation-kind read --reason \"...\" --confirm --json",
+      "",
+      // Both flags existed and neither appeared anywhere in help, so the only way to learn that a
+      // listing was withholding candidates - or what to type to see them - was to read the JSON
+      // payload. `conventions list` now names its withheld counts in human output too; these are
+      // the flags those lines point at.
+      "Options for conventions list:",
+      "  --include-low-confidence  Also list candidates below the coverage floor. Hidden by default:",
+      "                            secondary heuristics promote any repeated helper name, and on a large",
+      "                            repo they bury the enforceable candidates.",
+      "  --experimental-security   Also list candidates from the experimental security heuristics.",
+      "                            Hidden by default: that layer's own audit found it cannot prove what",
+      "                            it claims, so its candidates are inventory, not findings.",
+      "",
+      "Notes:",
+      "  conventions list reports how many candidates each of those defaults withheld, and the command that shows them.",
       ""
     ].join("\n");
   }

--- a/packages/cli/src/commands/start.ts
+++ b/packages/cli/src/commands/start.ts
@@ -462,12 +462,6 @@ function selfContainedCommand(command: string, databasePath: string): string {
 }
 
 /**
- * Exported for tests: every command onboarding prints has to run verbatim, and the property is
- * about the printer rather than about any one command string.
- */
-export const selfContainedCommandForTest = selfContainedCommand;
-
-/**
  * What to say when inference produced no enforceable data-access convention.
  *
  * "No enforceable convention candidates found yet." was indistinguishable from "this

--- a/packages/cli/src/commands/start.ts
+++ b/packages/cli/src/commands/start.ts
@@ -427,6 +427,9 @@ function readinessLine(acceptance: AcceptanceDisclosure): string {
       "breaking them until a convention is in block mode.";
 }
 
+/** Exported for tests - see packages/cli/test/start-readiness-line.test.ts. */
+export const readinessLineForTest = readinessLine;
+
 /**
  * A printed command, made runnable exactly as printed.
  *

--- a/packages/cli/src/commands/start.ts
+++ b/packages/cli/src/commands/start.ts
@@ -4,16 +4,18 @@ import type { SqliteDriftStorage } from "@drift/storage";
 import { CommandPayload,ParsedArgs } from "../app/command-types.js";
 import { doctorCommand } from "../args/doctor-commands.js";
 import { actorFlag,stringFlag } from "../args/flag-readers.js";
+import { parseArgs } from "../args/parse-args.js";
 import { requiredDatabasePath,resolveRepoRoot } from "../args/repo-flags.js";
 import { runCheck } from "../check/run-check.js";
 import { createBaselineForFindings } from "../domain/baselines.js";
 import { betaStartResponse } from "../domain/beta-surfaces.js";
 import { materializeRepoContract } from "../domain/contract-materialization.js";
-import { acceptanceDisclosure,acceptanceDisclosureLines } from "../domain/acceptance-disclosure.js";
+import { acceptanceDisclosure,acceptanceDisclosureLines,type AcceptanceDisclosure } from "../domain/acceptance-disclosure.js";
 import { acceptDefaultCandidate,declaredDataModulesCandidate } from "../domain/convention-candidates.js";
 import { engineProvenance } from "../domain/engine-provenance.js";
 import { discoverDataLayer,packageManifestPathsFromFiles } from "../domain/data-layer-discovery.js";
 import { contractIdForRepo } from "../domain/identifiers.js";
+import { isApiRoutePath } from "../domain/repo-paths.js";
 import { checkDiskSpace,checkHeadroom,insufficientDiskMessage,insufficientHeapMessage } from "../domain/disk-space.js";
 import { walkIndexableFiles } from "../engine/ts-fallback-scanner.js";
 import { workingTreeChangedFiles } from "../io/git.js";
@@ -191,17 +193,27 @@ export async function startRepo(storage: SqliteDriftStorage, parsed: ParsedArgs)
   const inferredDataAccess = result.candidates.some(
     (candidate) => candidate.kind === "api_route_no_direct_data_access"
   );
+  // Read once and shared: the discovery pass and the route-boundary message both need the scanned
+  // file list, and on a large repo this is the expensive half of building either message.
+  let cachedScannedPaths: string[] | undefined;
+  const scannedFilePaths = (): string[] =>
+    (cachedScannedPaths ??= storage
+      .listFileSnapshots(result.repo.id, result.scan.id)
+      .map((snapshot) => snapshot.file_path));
   const dataLayerDiscovery = inferredDataAccess
     ? undefined
     : discoverDataLayer(
         result.repo.root_path,
-        packageManifestPathsFromFiles(
-          storage.listFileSnapshots(result.repo.id, result.scan.id).map((snapshot) => snapshot.file_path)
-        ),
+        packageManifestPathsFromFiles(scannedFilePaths()),
         storage
           .listFacts(result.scan.id, { kind: "import_used" })
           .map((fact) => ({ file_path: fact.file_path, value: fact.value, name: fact.name }))
       );
+
+  // How many indexed files Drift recognises as API routes, by the same predicate the check path
+  // uses to decide scope. Zero is the whole explanation on a non-Next repo, and it is the one
+  // thing the output never said.
+  const apiRouteFileCount = (): number => scannedFilePaths().filter(isApiRoutePath).length;
 
   // T-07: ready means ENFORCEABLE, not "a row exists".
   //
@@ -268,7 +280,7 @@ export async function startRepo(storage: SqliteDriftStorage, parsed: ParsedArgs)
         nonBlockableConventionIds: acceptedPresenceFamilies.map((entry) => entry.id)
       })
     : undefined;
-  const nextCommands = contractReady
+  const nextCommands = (contractReady
     ? [
         doctorCommand(result.repo.root_path, parsed),
         `drift scan status --repo ${result.repo.id}`,
@@ -284,7 +296,8 @@ export async function startRepo(storage: SqliteDriftStorage, parsed: ParsedArgs)
           ? `drift conventions accept ${candidate.id} --severity error --mode block --confirm`
           : "drift scan",
         `drift check --diff main...HEAD --repo ${result.repo.id} --scope changed-hunks`
-      ];
+      ]
+  ).map((command) => selfContainedCommand(command, result.database_path));
   const onboardingPayload = {
     response_schema: BETA_START_RESPONSE_SCHEMA,
     ...result,
@@ -357,7 +370,7 @@ export async function startRepo(storage: SqliteDriftStorage, parsed: ParsedArgs)
       // BB-3: replaces "Accepted default convention." - a line that was identical for dub (warn,
       // enforces nothing new by itself) and cal.com (block, exits 2).
       ...acceptanceDisclosureLines(acceptance),
-      "Ready for AI-assisted work."
+      readinessLine(acceptance)
     ] : []),
     "",
     candidate
@@ -367,7 +380,7 @@ export async function startRepo(storage: SqliteDriftStorage, parsed: ParsedArgs)
           `  ${candidate.statement}`,
           `  Evidence: ${candidate.scoring.supporting_examples_count} matching import${candidate.scoring.supporting_examples_count === 1 ? "" : "s"}.`
         ].join("\n")
-      : noCandidateText(dataLayerDiscovery),
+      : noCandidateText(dataLayerDiscovery, { apiRouteFileCount: apiRouteFileCount() }),
     // Surface the data-layer gap even when some *other* convention was inferred. Gating
     // this on "no candidates at all" hid it on every real repo that infers an auth-helper
     // or validation candidate, which is most of them - the F4 gap stayed silent exactly
@@ -392,6 +405,66 @@ function betaStartEngineSource(engineSource: "rust" | "typescript"): "rust" | "t
 }
 
 /**
+ * The closing line of an acceptance, which must not contradict the disclosure above it.
+ *
+ * "Ready for AI-assisted work." printed unconditionally, including directly beneath BB-3's own
+ * warn-mode sentence - `new violations will be reported but will NOT block`. Measured on the
+ * warn-shaped fixture, onboarding said both things four lines apart. BB-3 exists because ten agent
+ * trials (Q9/Q19) showed agents read warn mode as "not a real rule" and defect from it; a closing
+ * line that announces readiness is the same overstatement BB-3 removed, put back after it.
+ *
+ * `blocks_new_violations` across every accepted convention, not just the primary: from CV-5 on a
+ * repo can onboard with several, and one blocking convention is enough for the check to gate.
+ */
+function readinessLine(acceptance: AcceptanceDisclosure): string {
+  const gates =
+    acceptance.blocks_new_violations ||
+    acceptance.also_accepted.some((also) => also.blocks_new_violations);
+  return gates
+    ? "Ready for AI-assisted work."
+    : "Nothing accepted here blocks yet, so `drift check` will report a new violation and still " +
+      "exit 0. Drift can give an agent this repo's conventions; it will not stop one from " +
+      "breaking them until a convention is in block mode.";
+}
+
+/**
+ * A printed command, made runnable exactly as printed.
+ *
+ * `resolveDatabasePath` derives the default state path only for the commands that create it
+ * (`init`, `scan`, `start`), for the two readers the quickstart runs (`check`, `prepare`), and for
+ * anything carrying `--repo-root`/`--state-root`. Onboarding printed seven commands and three of
+ * them - `contract show`, `baseline status`, `backup create` - sat outside every one of those
+ * cases, so pasting them back answered `Missing --db <path> or DRIFT_DB. Run drift --help.` and
+ * exited 1, while the database was sitting exactly where `start` had just said it was. The
+ * candidate-review list is worse: 2 of its 3 commands are `conventions ...`, which is the entire
+ * point of that branch.
+ *
+ * Fixed here rather than by widening the derivation, deliberately. The comment on
+ * `resolveDatabasePath` records what widening it costs: a command like `contract show --repo <id>`
+ * would resolve to whatever state happens to exist for the current directory, turning a
+ * well-formed `missing_database` failure - which carries a user action and recovery commands -
+ * into a generic `cli_error` about an unknown repo. Naming the path in the printed command buys
+ * the same result with none of that, and it makes the commands work from any directory rather
+ * than only from the repo root.
+ *
+ * `--repo-root` commands are left alone: they already locate their own state from the repo root,
+ * so they are directory-independent, and `--db` beside `--repo-root` would say the same thing
+ * twice.
+ */
+function selfContainedCommand(command: string, databasePath: string): string {
+  const parsed = parseArgs(command.split(" ").slice(1));
+  return parsed.flags.has("db") || parsed.flags.has("repo-root")
+    ? command
+    : `${command} --db ${databasePath}`;
+}
+
+/**
+ * Exported for tests: every command onboarding prints has to run verbatim, and the property is
+ * about the printer rather than about any one command string.
+ */
+export const selfContainedCommandForTest = selfContainedCommand;
+
+/**
  * What to say when inference produced no enforceable data-access convention.
  *
  * "No enforceable convention candidates found yet." was indistinguishable from "this
@@ -399,10 +472,37 @@ function betaStartEngineSource(engineSource: "rust" | "typescript"): "rust" | "t
  * with a route calling the database directly got the same message as a perfectly layered
  * one. If a data layer was found structurally, name it and give the command to declare it.
  */
-function noCandidateText(discovery?: {
-  declaredPackages: string[];
-  suggestions: Array<{ filePath: string; packageName: string; importedAs: string[]; routeImporterCount: number }>;
-}): string {
+function noCandidateText(
+  discovery?: {
+    declaredPackages: string[];
+    suggestions: Array<{ filePath: string; packageName: string; importedAs: string[]; routeImporterCount: number }>;
+  },
+  routeScope?: { apiRouteFileCount: number }
+): string {
+  // Checked first, and ahead of the data-layer branch on purpose.
+  //
+  // Every message below this point tells the user to try something: declare your data modules,
+  // rescan, review candidates. On a repo with no recognised routes none of them can work, because
+  // the convention families onboarding proposes are all scoped to API routes and the scope is
+  // empty. An Express repo with Prisma hits the discovery branch and is handed
+  // `--data-modules "db"`, which reruns the scan and produces zero candidates again - advice that
+  // costs the user a scan to learn nothing. The JSON says `needs_more_signal`, which reads as
+  // "scan harder", and scanning harder is exactly what does not help.
+  //
+  // Route detection is `isNextApiRoutePath`, shared with the engine (crates/drift-engine/src/
+  // next_routes.rs) and with `conventionScopeFiles`, so this boundary is the real one rather than
+  // a restatement of it.
+  if (routeScope?.apiRouteFileCount === 0) {
+    return [
+      "No API routes were found, so there was nothing to propose a route convention about.",
+      "",
+      "Route-convention proposals currently recognise Next.js API routes only: app-router",
+      "`**/app/**/route.{ts,tsx,js,jsx}` and pages-router `**/pages/api/**`. Routes declared by",
+      "Express, Fastify, NestJS or SvelteKit are indexed and their facts stored, but they are not",
+      "recognised as routes - so this repo will keep producing zero candidates however often it is",
+      "rescanned. That is a scope limit, not a property of your repo."
+    ].join("\n");
+  }
   if (!discovery) {
     return "No enforceable convention candidates found yet.";
   }

--- a/packages/cli/src/formatters/conventions.ts
+++ b/packages/cli/src/formatters/conventions.ts
@@ -16,6 +16,19 @@ export function formatConventionCandidatesText(payload: {
     next_offset: number | null;
   };
   next_commands: string[];
+  // A7/T25: the two withholding decisions, rendered rather than reported only in JSON.
+  low_confidence: {
+    hidden_count: number;
+    included: boolean;
+    floor: { min_coverage_ratio: number };
+    reveal_command: string;
+  };
+  experimental_security: {
+    hidden_count: number;
+    included: boolean;
+    reason: string;
+    reveal_command: string;
+  };
   candidates: ConventionCandidate[];
 }): string {
   const rows = payload.candidates.length > 0
@@ -42,6 +55,7 @@ export function formatConventionCandidatesText(payload: {
     `Kind: ${payload.filters.kind ?? "all"}`,
     `Capability: ${payload.filters.capability ?? "all"}`,
     `Candidates: ${payload.summary.listed_count} returned, ${payload.summary.filtered_count} filtered, ${payload.summary.total_count} total`,
+    ...withheldCandidateLines(payload),
     `Page: offset ${payload.pagination.offset}, returned ${payload.pagination.returned_count}, next offset ${payload.pagination.next_offset ?? "none"}`,
     `Governance: ${payload.governance.read_only ? "read-only" : "mutable"}; human approval required for mutations`,
     "",
@@ -51,6 +65,45 @@ export function formatConventionCandidatesText(payload: {
     "",
     ""
   ].join("\n");
+}
+
+/**
+ * The candidates this listing withheld, and how to see them.
+ *
+ * A7 gave `conventions list` a coverage floor and T25 quarantined the experimental security kinds.
+ * Both wrote their count and their exact reveal command into the JSON payload and neither reached
+ * the human formatter, so on a real repo the text surface printed
+ * `Candidates: 0 returned, 0 filtered, 35 total` and stopped - a reader could see that 35 existed
+ * and had no way to learn why none of them were shown or what to type next. The withholding is
+ * defensible; withholding it silently is not, and "never truncate silently" was A7's own rule.
+ *
+ * Printed directly under the counts rather than at the end, because the line it explains is the
+ * count, and an explanation a page away from the number it explains is one a reader has to go
+ * looking for.
+ */
+function withheldCandidateLines(payload: {
+  low_confidence: { hidden_count: number; floor: { min_coverage_ratio: number }; reveal_command: string };
+  experimental_security: { hidden_count: number; reveal_command: string };
+}): string[] {
+  const lines: string[] = [];
+  const lowConfidence = payload.low_confidence.hidden_count;
+  if (lowConfidence > 0) {
+    const floor = `${Math.round(payload.low_confidence.floor.min_coverage_ratio * 100)}%`;
+    lines.push(
+      `Hidden: ${lowConfidence} low-confidence candidate${lowConfidence === 1 ? "" : "s"} ` +
+        `below the ${floor} coverage floor.`,
+      `  Show them: ${payload.low_confidence.reveal_command}`
+    );
+  }
+  const security = payload.experimental_security.hidden_count;
+  if (security > 0) {
+    lines.push(
+      `Hidden: ${security} experimental security candidate${security === 1 ? "" : "s"}; ` +
+        "the security heuristics are experimental and are not proofs.",
+      `  Show them: ${payload.experimental_security.reveal_command}`
+    );
+  }
+  return lines;
 }
 
 export function formatConventionCandidateText(payload: {

--- a/packages/cli/test/cli.test.ts
+++ b/packages/cli/test/cli.test.ts
@@ -2428,7 +2428,11 @@ supported_sqlite_schema_version: MIGRATIONS.length,
     expect(result.stdout).toContain("new violations will be reported but will NOT block");
     expect(result.stdout).toContain("To make this a gate: drift conventions accept");
     expect(result.stdout).toContain("--mode block --confirm");
-    expect(result.stdout).toContain("Ready for AI-assisted work.");
+    // And does NOT close by announcing readiness. This is the warn-shaped fixture: the line above
+    // says new violations will not block, and "Ready for AI-assisted work." printed underneath it
+    // unconditionally. See start-readiness-line.test.ts for both directions.
+    expect(result.stdout).not.toContain("Ready for AI-assisted work.");
+    expect(result.stdout).toContain("Nothing accepted here blocks yet");
     expect(result.stdout).toContain("drift scan status");
     expect(result.stdout).toContain("drift backup create");
 
@@ -2870,14 +2874,19 @@ supported_sqlite_schema_version: MIGRATIONS.length,
       repo_root: repoRoot
     });
     expect(payload.state.database_path).toContain("drift.sqlite");
+    // Every printed command names the database it needs. `contract show`, `baseline status` and
+    // `backup create` fall outside every case `resolveDatabasePath` derives, so without `--db`
+    // three of these seven answered `Missing --db <path> or DRIFT_DB` and exited 1. The
+    // `--repo-root` command is exempt: it locates its own state from the repo root.
+    const database = payload.state.database_path;
     expect(payload.next_commands).toEqual([
       `drift doctor --repo-root ${repoRoot} --state-root ${stateRoot} --json`,
-      `drift scan status --repo ${payload.repo.id}`,
-      `drift contract show --repo ${payload.repo.id}`,
-      `drift baseline status --repo ${payload.repo.id}`,
-      `drift prepare "task" --repo ${payload.repo.id} --json`,
-      `drift check --diff main...HEAD --repo ${payload.repo.id} --scope changed-hunks`,
-      `drift backup create --repo ${payload.repo.id} --confirm`
+      `drift scan status --repo ${payload.repo.id} --db ${database}`,
+      `drift contract show --repo ${payload.repo.id} --db ${database}`,
+      `drift baseline status --repo ${payload.repo.id} --db ${database}`,
+      `drift prepare "task" --repo ${payload.repo.id} --json --db ${database}`,
+      `drift check --diff main...HEAD --repo ${payload.repo.id} --scope changed-hunks --db ${database}`,
+      `drift backup create --repo ${payload.repo.id} --confirm --db ${database}`
     ]);
   });
 

--- a/packages/cli/test/hidden-candidates-human-output.test.ts
+++ b/packages/cli/test/hidden-candidates-human-output.test.ts
@@ -1,0 +1,195 @@
+import { execFileSync } from "node:child_process";
+import { mkdir, mkdtemp, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, describe, expect, it } from "vitest";
+import { runCli } from "../src/index.js";
+import { formatConventionCandidatesText } from "../src/formatters/conventions.js";
+
+/**
+ * `conventions list` withholds candidates, and until now only the JSON surface said so.
+ *
+ * A7 added a coverage floor and T25 quarantined the experimental security kinds. Both wrote a
+ * count and an exact reveal command into the payload, and the human formatter rendered neither -
+ * so on a real repo the text surface printed `Candidates: 0 returned, 0 filtered, 35 total` and
+ * stopped. A reader could see 35 candidates existed, could not learn why none were shown, and had
+ * no way to find the flags: `--include-low-confidence` and `--experimental-security` appeared zero
+ * times in the CLI's help text.
+ *
+ * The count and the command are asserted against the JSON payload rather than against literals,
+ * because the failure being prevented is the two surfaces disagreeing.
+ */
+
+const tempDirs: string[] = [];
+afterEach(async () => {
+  await Promise.all(tempDirs.splice(0).map((dir) => rm(dir, { recursive: true, force: true })));
+});
+
+function git(cwd: string, ...args: string[]): void {
+  execFileSync("git", args, { cwd, stdio: "ignore" });
+}
+
+/** Two interchangeable auth wrappers over several routes, plus one bare route. */
+const wrapped = (wrapper: string) =>
+  [
+    `import { ${wrapper} } from "@/lib/auth";`,
+    `export const POST = ${wrapper}(async () => {`,
+    "  return Response.json({ ok: true });",
+    "});",
+    ""
+  ].join("\n");
+
+async function onboard(): Promise<{ repoId: string; databasePath: string }> {
+  const dir = await mkdtemp(join(tmpdir(), "drift-hidden-candidates-"));
+  tempDirs.push(dir);
+  const repoRoot = join(dir, "repo");
+  const stateRoot = join(dir, "state");
+
+  await mkdir(join(repoRoot, "lib"), { recursive: true });
+  await writeFile(
+    join(repoRoot, "lib/auth.ts"),
+    [
+      "export const withSession = (handler: unknown) => handler;",
+      "export const withWorkspace = (handler: unknown) => handler;",
+      ""
+    ].join("\n")
+  );
+  for (const [index, wrapper] of ["withSession", "withWorkspace", "withSession", "withWorkspace"].entries()) {
+    await mkdir(join(repoRoot, `app/api/r${index}`), { recursive: true });
+    await writeFile(join(repoRoot, `app/api/r${index}/route.ts`), wrapped(wrapper));
+  }
+  await mkdir(join(repoRoot, "app/api/public"), { recursive: true });
+  await writeFile(
+    join(repoRoot, "app/api/public/route.ts"),
+    ["export const GET = async () => Response.json({ ok: true });", ""].join("\n")
+  );
+  await writeFile(join(repoRoot, "package.json"), '{"name":"hidden-candidates","version":"1.0.0"}\n');
+  git(repoRoot, "init");
+  git(repoRoot, "add", ".");
+  git(repoRoot, "-c", "user.email=t@t", "-c", "user.name=t", "commit", "-m", "init");
+
+  const started = await runCli([
+    "start",
+    "--repo-root", repoRoot,
+    "--state-root", stateRoot,
+    "--now", "2026-05-10T00:00:00.000Z",
+    "--json"
+  ]);
+  expect(started.exitCode).toBe(0);
+  const payload = JSON.parse(started.stdout);
+  return { repoId: payload.repo.id, databasePath: payload.state.database_path };
+}
+
+describe("conventions list says what it withheld, in human output", () => {
+  it("names the experimental-security count and the exact command that reveals it", async () => {
+    const { repoId, databasePath } = await onboard();
+
+    const asJson = await runCli(["--db", databasePath, "conventions", "list", "--repo", repoId, "--json"]);
+    const payload = JSON.parse(asJson.stdout);
+    // The fixture has to actually hide something, or this test passes by describing nothing.
+    expect(payload.experimental_security.hidden_count).toBeGreaterThan(0);
+
+    const asText = await runCli(["--db", databasePath, "conventions", "list", "--repo", repoId]);
+    expect(asText.exitCode).toBe(0);
+    expect(asText.stdout).toContain(
+      `Hidden: ${payload.experimental_security.hidden_count} experimental security candidate`
+    );
+    // Exact, not paraphrased. A reveal command a reader has to reconstruct is one they will get
+    // wrong, and it is already in the payload verbatim.
+    expect(asText.stdout).toContain(`Show them: ${payload.experimental_security.reveal_command}`);
+    expect(payload.experimental_security.reveal_command).toContain("--experimental-security");
+  }, 60_000);
+
+  it("says nothing when nothing was withheld", async () => {
+    // The counterpart failure: a listing that claims to be hiding things it is not. With both
+    // flags passed, every hidden_count is zero and neither line may appear.
+    const { repoId, databasePath } = await onboard();
+    const asText = await runCli([
+      "--db", databasePath, "conventions", "list", "--repo", repoId,
+      "--include-low-confidence", "--experimental-security"
+    ]);
+    expect(asText.exitCode).toBe(0);
+    expect(asText.stdout).not.toContain("Hidden:");
+    expect(asText.stdout).not.toContain("Show them:");
+  }, 60_000);
+});
+
+describe("the candidates formatter", () => {
+  const payloadWith = (lowConfidenceHidden: number, securityHidden: number) => ({
+    repo_id: "repo_abc",
+    status: "candidate" as const,
+    filters: { status: "candidate" as const, kind: null, capability: null },
+    governance: { read_only: true } as never,
+    summary: {
+      total_count: 35,
+      filtered_count: 0,
+      listed_count: 0,
+      by_status: {},
+      by_capability: {},
+      by_kind: {}
+    },
+    pagination: { limit: null, offset: 0, returned_count: 0, has_more: false, next_offset: null },
+    next_commands: [],
+    low_confidence: {
+      hidden_count: lowConfidenceHidden,
+      included: false,
+      floor: { min_coverage_ratio: 0.2 },
+      reveal_command: "drift conventions list --repo repo_abc --include-low-confidence"
+    },
+    experimental_security: {
+      hidden_count: securityHidden,
+      included: false,
+      reason: "security heuristics are experimental",
+      reveal_command: "drift conventions list --repo repo_abc --experimental-security"
+    },
+    candidates: []
+  });
+
+  it("renders the shape a real repo produced: 0 of 35, with the reason and the way out", () => {
+    const text = formatConventionCandidatesText(payloadWith(33, 2));
+    expect(text).toMatchInlineSnapshot(`
+      "Drift convention candidates
+
+      Repo: repo_abc
+      Status: candidate
+      Kind: all
+      Capability: all
+      Candidates: 0 returned, 0 filtered, 35 total
+      Hidden: 33 low-confidence candidates below the 20% coverage floor.
+        Show them: drift conventions list --repo repo_abc --include-low-confidence
+      Hidden: 2 experimental security candidates; the security heuristics are experimental and are not proofs.
+        Show them: drift conventions list --repo repo_abc --experimental-security
+      Page: offset 0, returned 0, next offset none
+      Governance: read-only; human approval required for mutations
+
+        none
+      Next commands:
+
+      "
+    `);
+  });
+
+  it("counts one candidate in the singular", () => {
+    const text = formatConventionCandidatesText(payloadWith(1, 1));
+    expect(text).toContain("Hidden: 1 low-confidence candidate below the 20% coverage floor.");
+    expect(text).toContain("Hidden: 1 experimental security candidate;");
+  });
+});
+
+describe("help text names the flags the listing points at", () => {
+  it("documents --include-low-confidence and --experimental-security", async () => {
+    const help = await runCli(["conventions", "--help"]);
+    expect(help.exitCode).toBe(0);
+    expect(help.stdout).toContain("--include-low-confidence");
+    expect(help.stdout).toContain("--experimental-security");
+  });
+
+  it("says that --scope full does not gate", async () => {
+    // Handoff-safe wording: full scope classifies every finding as pre-existing, so it cannot
+    // reach the blocking count. True whether or not the refusal being added elsewhere has landed.
+    const help = await runCli(["check", "--help"]);
+    expect(help.exitCode).toBe(0);
+    expect(help.stdout).toContain("--scope full does not gate");
+    expect(help.stdout).toContain("--scope changed-hunks in CI");
+  });
+});

--- a/packages/cli/test/route-scope-boundary.test.ts
+++ b/packages/cli/test/route-scope-boundary.test.ts
@@ -1,0 +1,144 @@
+import { execFileSync } from "node:child_process";
+import { mkdir, mkdtemp, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, describe, expect, it } from "vitest";
+import { runCli } from "../src/index.js";
+import { noCandidateTextForTest } from "../src/commands/start.js";
+
+/**
+ * Drift's route detection is Next.js-only, and the CLI said so nowhere.
+ *
+ * `isNextApiRoutePath` recognises app-router `**\/app/**\/route.*` and pages-router
+ * `**\/pages/api/**`, and nothing else - it is the same predicate `conventionScopeFiles` and the
+ * engine use, so it decides what can be enforced at all. On an Express, Fastify, NestJS or
+ * SvelteKit repo the scan indexes files and stores facts normally, then proposes zero candidates,
+ * and the only thing reported was `onboarding.status: "needs_more_signal"` - which reads as "scan
+ * harder". Scanning harder is exactly what cannot help.
+ *
+ * Worse in the common case: an Express repo that also uses Prisma reaches the F4 data-layer
+ * discovery branch and is handed `drift start ... --data-modules "db"`, an instruction that costs
+ * a full rescan and produces zero candidates again.
+ */
+
+const tempDirs: string[] = [];
+afterEach(async () => {
+  await Promise.all(tempDirs.splice(0).map((dir) => rm(dir, { recursive: true, force: true })));
+});
+
+function git(cwd: string, ...args: string[]): void {
+  execFileSync("git", args, { cwd, stdio: "ignore" });
+}
+
+async function expressRepo(): Promise<string> {
+  const dir = await mkdtemp(join(tmpdir(), "drift-express-"));
+  tempDirs.push(dir);
+  const repoRoot = join(dir, "repo");
+
+  await mkdir(join(repoRoot, "src/routes"), { recursive: true });
+  await mkdir(join(repoRoot, "src/db"), { recursive: true });
+  await writeFile(
+    join(repoRoot, "src/db/client.ts"),
+    ['import { PrismaClient } from "@prisma/client";', "export const db = new PrismaClient();", ""].join("\n")
+  );
+  // The shape the boundary hides: a router handler reaching the database directly. Drift would
+  // have an opinion about this file if it recognised it as a route. It does not.
+  await writeFile(
+    join(repoRoot, "src/routes/users.ts"),
+    [
+      'import { Router } from "express";',
+      'import { db } from "../db/client";',
+      "export const users = Router();",
+      'users.get("/users", async (_req, res) => res.json(await db.user.findMany()));',
+      ""
+    ].join("\n")
+  );
+  await writeFile(
+    join(repoRoot, "src/server.ts"),
+    ['import express from "express";', 'import { users } from "./routes/users";', "express().use(users).listen(3000);", ""].join("\n")
+  );
+  await writeFile(
+    join(repoRoot, "package.json"),
+    JSON.stringify(
+      { name: "express-api", version: "1.0.0", dependencies: { express: "^4.19.0", "@prisma/client": "^5.0.0" } },
+      null,
+      2
+    ) + "\n"
+  );
+  git(repoRoot, "init");
+  git(repoRoot, "add", ".");
+  git(repoRoot, "-c", "user.email=t@t", "-c", "user.name=t", "commit", "-m", "init");
+  return repoRoot;
+}
+
+describe("onboarding an Express-shaped repo", () => {
+  it("names the Next.js route boundary instead of asking for more signal", async () => {
+    const repoRoot = await expressRepo();
+    const dir = join(repoRoot, "..");
+
+    const started = await runCli([
+      "start",
+      "--repo-root", repoRoot,
+      "--state-root", join(dir, "state"),
+      "--accept-defaults",
+      "--now", "2026-05-10T00:00:00.000Z"
+    ]);
+    expect(started.exitCode).toBe(0);
+
+    // The premise: files were indexed and facts were stored, and still nothing was proposed.
+    expect(started.stdout).toContain("Found 0 convention candidates.");
+    expect(started.stdout).not.toContain("Stored 0 facts.");
+
+    // The boundary, named: what is supported, and that this is a scope limit rather than a
+    // property of the user's repo.
+    expect(started.stdout).toContain("No API routes were found");
+    expect(started.stdout).toContain("Next.js API routes only");
+    expect(started.stdout).toContain("**/app/**/route.{ts,tsx,js,jsx}");
+    expect(started.stdout).toContain("**/pages/api/**");
+    expect(started.stdout).toContain("Express");
+    expect(started.stdout).toContain("That is a scope limit, not a property of your repo.");
+
+    // And does NOT hand the user the data-modules instruction. This repo declares Prisma and wraps
+    // it in `src/db/client.ts`, which is exactly the F4 discovery shape - the suggestion is
+    // well-formed and useless, because the rescan it asks for still has no route to enforce on.
+    expect(started.stdout).not.toContain("--data-modules");
+  }, 120_000);
+
+  it("still reports needs_more_signal in JSON, so the human text is where the boundary is said", async () => {
+    const repoRoot = await expressRepo();
+    const started = await runCli([
+      "start",
+      "--repo-root", repoRoot,
+      "--state-root", join(repoRoot, "..", "state"),
+      "--accept-defaults",
+      "--now", "2026-05-10T00:00:00.000Z",
+      "--json"
+    ]);
+    expect(started.exitCode).toBe(0);
+    const payload = JSON.parse(started.stdout);
+    expect(payload.onboarding.status).toBe("needs_more_signal");
+    expect(payload.onboarding.candidate_count).toBe(0);
+    expect(payload.summary.files_indexed).toBeGreaterThan(0);
+    expect(payload.summary.facts_count).toBeGreaterThan(0);
+  }, 120_000);
+});
+
+describe("noCandidateText", () => {
+  it("checks the route boundary before the data-layer suggestion", () => {
+    const discovery = {
+      declaredPackages: ["@prisma/client"],
+      suggestions: [
+        { filePath: "src/db/client.ts", packageName: "@prisma/client", importedAs: ["db"], routeImporterCount: 0 }
+      ]
+    };
+    expect(noCandidateTextForTest(discovery, { apiRouteFileCount: 0 })).toContain("No API routes were found");
+    // With routes present the F4 message is the right one and must be untouched.
+    expect(noCandidateTextForTest(discovery, { apiRouteFileCount: 3 })).toContain("--data-modules");
+  });
+
+  it("leaves the message alone when the caller says nothing about route scope", () => {
+    // The second call site - the data-layer gap printed alongside an inferred candidate - passes no
+    // route scope, and must keep behaving as it did.
+    expect(noCandidateTextForTest()).toBe("No enforceable convention candidates found yet.");
+  });
+});

--- a/packages/cli/test/start-readiness-line.test.ts
+++ b/packages/cli/test/start-readiness-line.test.ts
@@ -1,0 +1,149 @@
+import { execFileSync } from "node:child_process";
+import { mkdir, mkdtemp, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, describe, expect, it } from "vitest";
+import { runCli } from "../src/index.js";
+import { readinessLineForTest } from "../src/commands/start.js";
+import { acceptanceDisclosure } from "../src/domain/acceptance-disclosure.js";
+import type { AcceptedConvention } from "@drift/core";
+
+/**
+ * `Ready for AI-assisted work.` printed after every acceptance, including warn-mode ones.
+ *
+ * Four lines above it, BB-3's disclosure says `new violations will be reported but will NOT
+ * block`. Both sentences printed on the same onboarding, and only one of them was true about what
+ * the tool would do next. BB-3 exists because ten agent trials (Q9/Q19, 2026-08-03) showed agents
+ * treat warn mode as "not a real rule"; a closing line announcing readiness re-states exactly the
+ * belief BB-3 was written to remove.
+ *
+ * Asserted in both directions. A test that only checked the warn case would pass against a build
+ * that had deleted the line outright, which loses a true statement rather than fixing a false one.
+ */
+
+const tempDirs: string[] = [];
+afterEach(async () => {
+  await Promise.all(tempDirs.splice(0).map((dir) => rm(dir, { recursive: true, force: true })));
+});
+
+function git(cwd: string, ...args: string[]): void {
+  execFileSync("git", args, { cwd, stdio: "ignore" });
+}
+
+const viaService = [
+  'import { listUsers } from "@/services/users";',
+  "export async function GET() {",
+  "  return Response.json(await listUsers());",
+  "}",
+  ""
+].join("\n");
+
+const viaPrisma = [
+  'import { prisma } from "@/lib/prisma";',
+  "export async function GET() {",
+  "  return Response.json(await prisma.user.findMany());",
+  "}",
+  ""
+].join("\n");
+
+/**
+ * @param violatingRoutes how many of `totalRoutes` import the data layer directly. The ratio is
+ *   what `baseline_coverage_direction` reads: a minority violating means the convention is real
+ *   and lands `block`, a majority means it is an aspiration and lands `warn`.
+ */
+async function onboard(totalRoutes: number, violatingRoutes: number): Promise<string> {
+  const dir = await mkdtemp(join(tmpdir(), "drift-readiness-"));
+  tempDirs.push(dir);
+  const repoRoot = join(dir, "repo");
+  const stateRoot = join(dir, "state");
+
+  await mkdir(join(repoRoot, "lib"), { recursive: true });
+  await mkdir(join(repoRoot, "services"), { recursive: true });
+  await writeFile(join(repoRoot, "lib/prisma.ts"), "export const prisma = {} as never;\n");
+  await writeFile(join(repoRoot, "services/users.ts"), "export const listUsers = async () => [];\n");
+  for (let index = 0; index < totalRoutes; index += 1) {
+    await mkdir(join(repoRoot, `app/api/r${index}`), { recursive: true });
+    await writeFile(
+      join(repoRoot, `app/api/r${index}/route.ts`),
+      index < violatingRoutes ? viaPrisma : viaService
+    );
+  }
+  await writeFile(join(repoRoot, "package.json"), '{"name":"readiness","version":"1.0.0"}\n');
+  git(repoRoot, "init");
+  git(repoRoot, "add", ".");
+  git(repoRoot, "-c", "user.email=t@t", "-c", "user.name=t", "commit", "-m", "init");
+
+  const started = await runCli([
+    "start",
+    "--repo-root", repoRoot,
+    "--state-root", stateRoot,
+    "--accept-defaults",
+    "--now", "2026-05-10T00:00:00.000Z"
+  ]);
+  expect(started.exitCode).toBe(0);
+  return started.stdout;
+}
+
+describe("the line that closes an acceptance", () => {
+  it("does not announce readiness in warn mode", async () => {
+    // Every route violates, so the convention is read as an aspiration and lands warn.
+    const stdout = await onboard(4, 4);
+    expect(stdout).toContain("in WARN mode");
+    expect(stdout).toContain("will NOT block");
+    expect(stdout).not.toContain("Ready for AI-assisted work.");
+    // And says what warn mode means for the thing the user came here for.
+    expect(stdout).toContain("Nothing accepted here blocks yet");
+    expect(stdout).toContain("exit 0");
+  }, 120_000);
+
+  it("announces readiness in block mode", async () => {
+    // One route of six violates, so the convention is real and lands block.
+    const stdout = await onboard(6, 1);
+    expect(stdout).toContain("in BLOCK mode");
+    expect(stdout).toContain("Ready for AI-assisted work.");
+    expect(stdout).not.toContain("Nothing accepted here blocks yet");
+  }, 120_000);
+});
+
+describe("readinessLine", () => {
+  const convention = (mode: AcceptedConvention["enforcement_mode"], id: string): AcceptedConvention => ({
+    id,
+    contract_id: "contract_repo_abc",
+    kind: id,
+    statement: "…",
+    scope: { include: [], exclude: [] } as AcceptedConvention["scope"],
+    matcher: { kind: "forbidden_imports", forbidden_imports: [] } as AcceptedConvention["matcher"],
+    severity: "error",
+    enforcement_mode: mode,
+    enforcement_capability: "deterministic_check",
+    exceptions: [],
+    evidence_refs: [],
+    counterexample_refs: [],
+    accepted_by: "cli",
+    accepted_at: "2026-05-10T00:00:00.000Z",
+    updated_at: "2026-05-10T00:00:00.000Z"
+  });
+
+  it("reads every accepted convention, not just the primary", () => {
+    // CV-5 lets onboarding accept several at once. One blocking convention is enough for the
+    // check to gate, so a warn primary beside a blocking family is still ready - and reporting
+    // "nothing blocks" there would be the same class of error in the other direction.
+    const disclosure = acceptanceDisclosure({
+      accepted: convention("warn", "api_route_no_direct_data_access"),
+      alsoAccepted: [convention("block", "api_route_requires_auth_helper")],
+      repoId: "repo_abc",
+      baselinedCount: 0
+    });
+    expect(readinessLineForTest(disclosure)).toBe("Ready for AI-assisted work.");
+  });
+
+  it("does not announce readiness when nothing accepted blocks", () => {
+    const disclosure = acceptanceDisclosure({
+      accepted: convention("warn", "api_route_no_direct_data_access"),
+      alsoAccepted: [convention("warn", "api_route_requires_auth_helper")],
+      repoId: "repo_abc",
+      baselinedCount: 0
+    });
+    expect(readinessLineForTest(disclosure)).toContain("Nothing accepted here blocks yet");
+  });
+});

--- a/test/e2e/start-paste-back.test.ts
+++ b/test/e2e/start-paste-back.test.ts
@@ -1,0 +1,176 @@
+import { execFileSync } from "node:child_process";
+import { mkdir, mkdtemp, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, describe, expect, it } from "vitest";
+import { runCli } from "../../packages/cli/src/index.js";
+
+/**
+ * Paste the block `drift start` prints, and every line has to work.
+ *
+ * It did not. `resolveDatabasePath` derives the default state path for the commands that create it
+ * (`init`, `scan`, `start`), for the two readers the quickstart runs (`check`, `prepare`), and for
+ * anything carrying `--repo-root`/`--state-root`. Onboarding printed seven commands, and
+ * `contract show`, `baseline status` and `backup create` matched none of those cases: three of
+ * seven answered `Missing --db <path> or DRIFT_DB. Run drift --help.` and exited 1, with the
+ * database sitting exactly where the two lines above them said it was.
+ *
+ * This is the first thing a new user does with Drift, so it is tested the way they do it: run
+ * `start`, take the printed lines verbatim, run them, require exit 0 from every one.
+ */
+
+const tempDirs: string[] = [];
+afterEach(async () => {
+  await Promise.all(tempDirs.splice(0).map((dir) => rm(dir, { recursive: true, force: true })));
+});
+
+function git(cwd: string, ...args: string[]): void {
+  execFileSync("git", args, { cwd, stdio: "ignore" });
+}
+
+/**
+ * Split a printed command the way a shell would: whitespace separates, double quotes group.
+ *
+ * `drift prepare "task" ...` is printed with the quotes, and a reader pasting it into a terminal
+ * gets one argument. Splitting on whitespace alone would hand the CLI a different argv than the
+ * user's shell does, which would make this test agree with a build that is broken for humans.
+ */
+function shellTokens(command: string): string[] {
+  return (command.match(/"[^"]*"|\S+/g) ?? []).map((token) =>
+    token.startsWith('"') && token.endsWith('"') ? token.slice(1, -1) : token
+  );
+}
+
+function printedCommands(stdout: string): string[] {
+  const lines = stdout.split("\n");
+  const heading = lines.indexOf("Next commands:");
+  expect(heading).toBeGreaterThan(-1);
+  return lines
+    .slice(heading + 1)
+    .filter((line) => line.startsWith("  ") && line.trim().length > 0)
+    .map((line) => line.trim());
+}
+
+async function onboardedRepo(): Promise<{ repoRoot: string; stateRoot: string; home: string }> {
+  const dir = await mkdtemp(join(tmpdir(), "drift-paste-back-"));
+  tempDirs.push(dir);
+  const repoRoot = join(dir, "repo");
+  const stateRoot = join(dir, "state");
+  const home = join(dir, "home");
+  await mkdir(home, { recursive: true });
+
+  await mkdir(join(repoRoot, "lib"), { recursive: true });
+  await mkdir(join(repoRoot, "services"), { recursive: true });
+  await writeFile(join(repoRoot, "lib/prisma.ts"), "export const prisma = {} as never;\n");
+  await writeFile(join(repoRoot, "services/users.ts"), "export const listUsers = async () => [];\n");
+  await mkdir(join(repoRoot, "app/api/legacy"), { recursive: true });
+  await writeFile(
+    join(repoRoot, "app/api/legacy/route.ts"),
+    [
+      'import { prisma } from "@/lib/prisma";',
+      "export async function GET() {",
+      "  return Response.json(await prisma.user.findMany());",
+      "}",
+      ""
+    ].join("\n")
+  );
+  await writeFile(join(repoRoot, "package.json"), '{"name":"paste-back","version":"1.0.0"}\n');
+
+  git(repoRoot, "init", "--initial-branch=main");
+  git(repoRoot, "add", ".");
+  git(repoRoot, "-c", "user.email=t@t", "-c", "user.name=t", "commit", "-m", "init");
+
+  // A branch with a commit on it, because `--diff main...HEAD` is one of the printed commands and
+  // an empty range is a refusal (exit 3) by design - BB-1. The added route conforms, so the check
+  // passes whether the accepted convention landed warn or block.
+  git(repoRoot, "checkout", "-b", "feature");
+  await mkdir(join(repoRoot, "app/api/new"), { recursive: true });
+  await writeFile(
+    join(repoRoot, "app/api/new/route.ts"),
+    [
+      'import { listUsers } from "@/services/users";',
+      "export async function GET() {",
+      "  return Response.json(await listUsers());",
+      "}",
+      ""
+    ].join("\n")
+  );
+  git(repoRoot, "add", ".");
+  git(repoRoot, "-c", "user.email=t@t", "-c", "user.name=t", "commit", "-m", "add a conforming route");
+
+  return { repoRoot, stateRoot, home };
+}
+
+async function withHome<T>(home: string, body: () => Promise<T>): Promise<T> {
+  // `backup create` writes under `~/.drift/backups`. Pointing HOME at the fixture keeps the test
+  // from depositing artifacts in the developer's own state directory.
+  const previous = process.env.HOME;
+  process.env.HOME = home;
+  try {
+    return await body();
+  } finally {
+    if (previous === undefined) {
+      delete process.env.HOME;
+    } else {
+      process.env.HOME = previous;
+    }
+  }
+}
+
+describe("the command block drift start prints", () => {
+  it("runs verbatim, every line, exit 0", async () => {
+    const { repoRoot, stateRoot, home } = await onboardedRepo();
+
+    await withHome(home, async () => {
+      const started = await runCli([
+        "start",
+        "--repo-root", repoRoot,
+        "--state-root", stateRoot,
+        "--accept-defaults",
+        "--now", "2026-05-10T00:00:00.000Z"
+      ]);
+      expect(started.exitCode).toBe(0);
+
+      const commands = printedCommands(started.stdout);
+      // Guard against the block silently emptying out - a paste-back test over zero commands is a
+      // test that passes by describing nothing.
+      expect(commands.length).toBe(7);
+
+      for (const command of commands) {
+        const tokens = shellTokens(command);
+        expect(tokens[0]).toBe("drift");
+        const result = await runCli(tokens.slice(1));
+        expect(result.exitCode, `${command}\n${result.stdout}${result.stderr}`).toBe(0);
+      }
+    });
+  }, 300_000);
+
+  it("fails the way it used to when the database is not named", async () => {
+    // The control. Without `--db` these commands match no case `resolveDatabasePath` derives, and
+    // the failure they produce - `missing_database`, exit 1 - is the one users hit. If this ever
+    // starts passing, the derivation changed and the test above is no longer measuring anything.
+    const { repoRoot, stateRoot, home } = await onboardedRepo();
+
+    await withHome(home, async () => {
+      const started = await runCli([
+        "start",
+        "--repo-root", repoRoot,
+        "--state-root", stateRoot,
+        "--accept-defaults",
+        "--now", "2026-05-10T00:00:00.000Z"
+      ]);
+      const repoId = started.stdout.match(/--repo (repo_[a-f0-9]+)/)?.[1];
+      expect(repoId).toBeTruthy();
+
+      for (const argv of [
+        ["contract", "show", "--repo", repoId!],
+        ["baseline", "status", "--repo", repoId!],
+        ["backup", "create", "--repo", repoId!, "--confirm"]
+      ]) {
+        const result = await runCli([...argv, "--json"]);
+        expect(result.exitCode, argv.join(" ")).toBe(1);
+        expect(JSON.parse(result.stdout).failure.code, argv.join(" ")).toBe("missing_database");
+      }
+    });
+  }, 300_000);
+});


### PR DESCRIPTION
Seven verified findings about what a stranger's first run of Drift tells them. Each one is a place where the tool said something it could not support, or withheld something it already knew.

## What changed

**1. `conventions list` hid candidates in silence.** A7's coverage floor and T25's security quarantine both wrote a hidden count and an exact reveal command into the JSON payload, and the human formatter rendered neither — so on a real repo the text surface printed `Candidates: 0 returned, 0 filtered, 35 total` and stopped. `--include-low-confidence` and `--experimental-security` appeared **zero** times in `help.ts`, so there was no way to find the flags either. Both counts and both commands now print directly under the count they explain, and both flags are documented.

**2. `start` printed seven commands and three failed verbatim.** `contract show`, `baseline status` and `backup create` match no case `resolveDatabasePath` derives, so pasting them back answered `Missing --db <path> or DRIFT_DB` and exited 1 — with the database sitting where the two lines above them said it was. The candidate-review branch was worse: 2 of its 3 commands are `conventions ...`, which is the entire point of that branch.

Fixed at the printer rather than by widening the derivation. `resolveDatabasePath`'s own comment records what widening costs: `contract show --repo <id>` would resolve to whatever state happens to exist for the current directory, turning a well-formed `missing_database` failure — which carries a user action and recovery commands — into a generic `cli_error` about an unknown repo. Naming the path in the printed command buys the same result with none of that, and makes the commands work from any directory.

**3. `Ready for AI-assisted work.` printed after every acceptance**, four lines under BB-3's own sentence saying new violations will NOT block. BB-3 exists because ten agent trials (Q9/Q19) showed agents read warn mode as "not a real rule"; a closing line announcing readiness restores exactly the belief it removed. Now gated on whether anything accepted blocks — across every accepted convention, since CV-5 lets a repo onboard with several.

**4. Route detection is Next.js-only and nothing said so.** An Express, Fastify, NestJS or SvelteKit repo indexes files, stores facts, proposes zero candidates, and reported only `needs_more_signal` — which reads as "scan harder". Worse with Prisma present: the F4 discovery branch hands the user `--data-modules`, an instruction costing a rescan that produces zero candidates again. With no recognised routes, onboarding now names the boundary and says it is a scope limit rather than a property of the repo.

**5. `docs/quickstart.md` step 1 was `npm install -g @drift/cli`** → `E404`. Rewritten to the build-from-source path the README already carried, with the Rust prerequisite. The sample output in the same doc had gone stale with BB-3 (`Accepted default convention.` / `Baselined 417 existing violations.` are lines the CLI stopped printing), and the opening sentence promised block mode to readers who mostly get warn.

**6. `agent-integration.md` contradicted itself.** Lines 57-60 told CI a committed contract cannot be imported and each environment must onboard for itself; lines 88-96 — added later, when T120 made identity portable — told it to commit and import `drift.lock`. Following the first is worse than doing nothing: convention ids are content hashes over whatever evidence a scan found, so a CI checkout that onboards itself enforces a contract nobody reviewed. Lock-import is now the single instruction.

**7. `--scope full` cannot gate**, and `check --help` now says so: it classifies every finding as `touched_existing`, and only `new_in_diff` findings reach the blocking count, so it never exits 2 under any convention or mode. Phrased around the classification mechanism rather than an exit code, so it stays true alongside the explicit refusal being added separately.

## Verification

`pnpm verify:ci` green, `validate:claims` included. Every behavior change mutation-proofed by reverting the fix and confirming the new test fails.

- `test/e2e/start-paste-back.test.ts` — fresh git fixture, run `start`, shell-tokenize every printed line, run it: all 7 exit 0. Plus a control asserting the old `missing_database` failure without `--db`.
- `packages/cli/test/hidden-candidates-human-output.test.ts` — inline snapshot of the real "0 of 35" shape; printed count and command asserted equal to the JSON payload's, because the failure being prevented is the two surfaces disagreeing.
- `packages/cli/test/start-readiness-line.test.ts` — both directions: 4-of-4 violating routes lands warn and the string is absent; 1-of-6 lands block and it is present.
- `packages/cli/test/route-scope-boundary.test.ts` — Express fixture asserts the boundary text and asserts `--data-modules` is *not* offered.

Two existing assertions in `packages/cli/test/cli.test.ts` changed as direct consequences of items 2 and 3.

## Known follow-up

`doctorNextCommands` has the identical bug to item 2 — `doctor` prints `scan status`, `prepare`, `audit verify`, `backup list`, `backup create` with no `--db`, so 3 of 5 fail the same way. Left alone because this item is scoped to `start`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)