### PR TITLE
fix(ci,docs): the dogfooding gate could not fail, because it never ran

### DIFF
--- a/.github/workflows/drift-check-self.yml
+++ b/.github/workflows/drift-check-self.yml
@@ -44,28 +44,62 @@ jobs:
           pnpm install --frozen-lockfile
           pnpm build
 
-      - name: Adopt the committed contract
-        env:
-          DRIFT_ENGINE_BIN: ${{ github.workspace }}/target/release/drift-engine
+      # drift.lock is a precondition, not an option. Inference finds nothing to propose on this repo
+      # - it is a TS/Rust monorepo with no routes and no data layer, so `start` yields zero
+      # candidates - and without a committed contract `check` correctly refuses with empty_contract.
+      # That refusal was read as a Drift failure and went red on every PR from #108 onward while the
+      # actual cause was a missing file. Fail where the message can say so, rather than letting it
+      # surface as an unexplained refusal one step later.
+      #
+      # Checked before `start` rather than after it: the precondition does not depend on anything
+      # `start` does, and failing in a second beats failing after a full scan of the repo.
+      - name: Require the committed contract
         run: |
-          # Identity is derived from the git remote and root commit, so the contract committed by a
-          # developer imports here even though CI checks out to a path nobody shares.
-          node packages/cli/dist/main.js start --repo-root . --accept-defaults --json
-          REPO_ID=$(ls "$HOME/.drift/repos" | head -1)
-          echo "DRIFT_REPO_ID=$REPO_ID" >> "$GITHUB_ENV"
-          echo "DRIFT_DB=$HOME/.drift/repos/$REPO_ID/drift.sqlite" >> "$GITHUB_ENV"
-          # drift.lock is a precondition, not an option. Inference finds nothing to propose on this
-          # repo - it is a TS/Rust monorepo with no routes and no data layer, so `start` yields zero
-          # candidates - and without a committed contract `check` correctly refuses with
-          # empty_contract. That refusal was read as a Drift failure and went red on every PR from
-          # #108 onward while the actual cause was a missing file. Fail here, where the message can
-          # say so, rather than letting it surface as an unexplained refusal one step later.
           if [ ! -f drift.lock ]; then
             echo "::error::drift.lock is missing. This gate enforces the committed contract; without it Drift has nothing to check and will refuse. Export one with 'drift contract export --output drift.lock --confirm'."
             exit 1
           fi
+
+      - name: Adopt the committed contract
+        env:
+          DRIFT_ENGINE_BIN: ${{ github.workspace }}/target/release/drift-engine
+        run: |
+          set -euo pipefail
+
+          # Identity is derived from the git remote and root commit, so the contract committed by a
+          # developer imports here even though CI checks out to a path nobody shares.
+          # `tee`, not `>`: this payload was printed to the job log before, and it is what you read
+          # when `start` is the thing that broke. Capturing it to a file without also printing it
+          # would trade one blind spot for another. `pipefail` above keeps node's exit code.
+          node packages/cli/dist/main.js start --repo-root . --accept-defaults --json \
+            | tee "$RUNNER_TEMP/drift-start.json"
+
+          # Read identity and the state path out of `start`'s own payload instead of guessing at
+          # $HOME/.drift's layout. `ls "$HOME/.drift/repos" | head -1` picks an arbitrary repo the
+          # day a second one exists, and a hand-assembled `$HOME/.drift/repos/$ID/drift.sqlite` is a
+          # second copy of an internal layout that nothing updates when that layout moves. `start
+          # --json` reports both authoritatively, and is the same payload a consumer would read.
+          DRIFT_REPO_ID=$(python3 -c 'import json,os;print(json.load(open(os.environ["RUNNER_TEMP"]+"/drift-start.json"))["repo"]["id"])')
+          DRIFT_DB=$(python3 -c 'import json,os;print(json.load(open(os.environ["RUNNER_TEMP"]+"/drift-start.json"))["state"]["database_path"])')
+
+          # Exported for THIS step and appended to $GITHUB_ENV for the next one. Both halves matter,
+          # and only the second was here before:
+          #
+          # `$GITHUB_ENV` does not affect the step that writes it, so `contract import` below ran
+          # with no --db and no DRIFT_DB and refused with "Missing --db <path> or DRIFT_DB. Run drift
+          # --help." - exit 1, on every pull request, since this gate was added. The job died here
+          # and never reached "Check the diff", which is why the dogfooding gate has never actually
+          # checked a diff: a guardrail that cannot fail because it never runs.
+          #
+          # `--db` is also passed explicitly to the import. The export makes the environment right;
+          # the flag makes the command correct on its own, so the failure cannot come back the next
+          # time these lines are reordered.
+          export DRIFT_REPO_ID DRIFT_DB
+          echo "DRIFT_REPO_ID=$DRIFT_REPO_ID" >> "$GITHUB_ENV"
+          echo "DRIFT_DB=$DRIFT_DB" >> "$GITHUB_ENV"
+
           node packages/cli/dist/main.js contract import drift.lock \
-            --repo "$REPO_ID" --confirm --json
+            --db "$DRIFT_DB" --repo "$DRIFT_REPO_ID" --confirm --json
 
       - name: Check the diff
         env:
@@ -102,7 +136,22 @@ jobs:
               # than throws, because those payloads carried `summary.blocked_reasons` and no
               # `failure` object - so the one field this step reads was absent on exactly the
               # refusals a working gate produces. Each code below now arrives from run-check.ts.
+              # The arms below are a dispatch table over the refusal vocabulary in
+              # docs/reference/enforcement.md, not over the subset this step happens to reach today.
+              # `full_scope_cannot_block` and `contract_stale_under_strict` cannot fire while this
+              # step hardcodes `--scope changed-hunks` and omits `--strict-contract`; they are kept
+              # because those two flags are the likeliest edit anyone will ever make to this file,
+              # and the alternative is that the edit silently degrades to the bare-code arm below.
               case "$REFUSAL" in
+                empty_diff_scope)
+                  echo "::error::Drift refused because the diff scope is empty - no file was examined, so there is no verdict to report. Check that origin/${{ github.base_ref }}...HEAD names two different commits; an empty pull request reaches this."
+                  ;;
+                stale_diff_scope)
+                  echo "::error::Drift refused because every file named by the diff is missing from this checkout, so nothing could be examined. The diff range and the working tree disagree about what exists - check that actions/checkout fetched the base ref (this workflow needs fetch-depth: 0)."
+                  ;;
+                unindexed_contract_target)
+                  echo "::error::Drift refused because the contract names a target the scan never indexed, so the rule could not be evaluated and a pass would not mean it held. summary.blocked_reasons names the target."
+                  ;;
                 empty_contract|missing_contract)
                   echo "::error::Drift refused because the contract is empty - a configuration problem in this workflow, not a problem with this diff. Check that drift.lock imported."
                   ;;

--- a/.gitignore
+++ b/.gitignore
@@ -21,3 +21,6 @@ main-*.js
 # scripts/build-engine-artifacts.mjs writes them; engine-manifest.json records the checksum
 # and is committed so the release job can verify what CI produced.
 packages/engine-*/bin/drift-engine
+
+# Written by the drift-check-self workflow (and by anyone simulating it locally).
+drift-check.json

--- a/docs/ci-integration.md
+++ b/docs/ci-integration.md
@@ -7,6 +7,15 @@ infix stopped it from running. That was wrong — GitHub runs every `.yml` under
 this pnpm workspace. Treat the requirements below as verified on `ubuntu-latest` only from the
 first green run of that workflow onward.
 
+That first green run had still not happened as of 2026-08-17, for a second reason with the same
+shape as the first. The "Adopt the committed contract" step wrote `DRIFT_DB` to `$GITHUB_ENV` and
+then, in that same step, ran `contract import` without `--db`. `$GITHUB_ENV` takes effect only in
+*subsequent* steps, so the import always refused with `Missing --db <path> or DRIFT_DB`, and the job
+exited 1 before reaching "Check the diff". The gate was red on every pull request and had never
+checked a diff: the exact failure this page exists to argue against, in the file meant to
+demonstrate the opposite. The step now exports both variables for its own use *and* passes `--db`
+explicitly, so the fault cannot return if those lines are reordered.
+
 The self-check builds the engine from this workspace with `cargo build --release`, so it is not
 directly copyable into a consumer repository; there is still no published Linux engine binary (see
 `docs/architecture/engine-release.md`). The requirements below are what any consumer workflow has

--- a/docs/reference/enforcement.md
+++ b/docs/reference/enforcement.md
@@ -42,6 +42,13 @@ is the supported way to tell them apart:
 | `contract_stale_under_strict` | `--strict-contract`, and the contract's forbidden specifiers match nothing in the repo |
 | `typescript_fallback_used` | The Rust engine was unavailable; the degraded scanner cannot make an enforcement claim |
 | `engine_timeout` | The engine exceeded `DRIFT_ENGINE_TIMEOUT_MS` (default 15 minutes) and was killed, so no scan completed |
+| `empty_diff_scope` | A diff-derived scope named no file, so nothing was examined and there is no verdict to report |
+| `stale_diff_scope` | Every file the diff named is absent from the working tree: the diff and the checkout disagree about what exists |
+| `unindexed_contract_target` | An agent contract named a file the scan does not index (today, any non-TypeScript path), so the rule could not be evaluated |
+
+The three above reach `failure.code` by being thrown rather than returned, which is not a distinction
+a consumer can see: `run-cli.ts` puts `failure` beside `error` in the JSON envelope, so one field
+answers "why did this refuse?" on both paths.
 
 The key is **absent on a pass and on a block**: its presence is the signal. `summary.blocked_reasons`
 still carries the per-file detail — the code says what class of thing happened, the reasons name the


### PR DESCRIPTION
`Drift check (self)` has been red on every pull request since it was added, and never once for the reason a gate is supposed to be red. It died in **Adopt the committed contract** with `Missing --db <path> or DRIFT_DB. Run drift --help.`, exit 1, before **Check the diff** ever started. Drift's own dogfooding gate has never checked a diff.

## Root cause

Two lines apart, in one step:

```yaml
echo "DRIFT_DB=$HOME/.drift/repos/$REPO_ID/drift.sqlite" >> "$GITHUB_ENV"
...
node packages/cli/dist/main.js contract import drift.lock \
  --repo "$REPO_ID" --confirm --json          # <-- no --db
```

`$GITHUB_ENV` publishes to *subsequent* steps and never to the step that writes it, so the import ran with neither the flag nor the variable, and refused — correctly. A guardrail that cannot fail because it never runs is the same defect class as one that cannot fail because its scope cannot block (#121); this one just sat upstream of the check instead of inside it.

Fixed on **both** axes deliberately: the step now `export`s both variables for its own use *and* passes `--db` explicitly. The export makes the environment right; the flag makes the command correct standing alone, so reordering these lines cannot bring the fault back.

## Verification

Each `run:` block was extracted from the real workflow file and executed as its own `bash -e` process, with `$GITHUB_ENV` propagated between steps the way the runner does it — written by one step, visible only to the next. A simulator that exported eagerly would pass here and fail in CI, which is the whole bug.

| Scenario | Result |
|---|---|
| **before** (current `main`) | adopt step exits 1, `Missing --db <path> or DRIFT_DB` — byte-identical to the CI log |
| **after**, clean diff | exit 0, `Drift: no blocking violations` |
| **after**, violating diff | exit 1, `::error::Drift found a new violation in this diff` — one blocking finding on `packages/mcp/src/index.ts` |
| **after**, `drift.lock` deleted | exit 1 at the precondition, with its own message, before `start` runs |

The violating case adds an `@drift/cli` import to an MCP module, which is what this repo's contract actually forbids.

**That measurement is the reason this PR is not one line.** `drift.lock` carries **zero conventions** — it passes `assertEnforceableContract` solely on one `import_boundary` agent contract (`drift_mcp_must_not_import_cli`). Had it carried no agent contract either, fixing `--db` would have converted a gate that dies into a gate that passes vacuously: strictly worse, because it looks healthy. The exit-2 run above is what rules that out.

## Everything else the audit turned up

- **Identity and DB path now come from `start --json`** (`repo.id`, `state.database_path`) instead of `ls "$HOME/.drift/repos" | head -1` plus a hand-assembled sqlite path. The old form picks an arbitrary repo the day a second one exists, and duplicates Drift's internal state layout somewhere nothing updates when that layout moves.
- **`tee`, not `>`.** Capturing `start`'s payload to a file initially cost the job log the payload you need when `start` is what broke — one blind spot traded for another. It is now both printed and captured; `pipefail` keeps node's exit code.
- **The `drift.lock` precondition moved ahead of `start`.** It depends on nothing `start` does, so it can fail in a second instead of after a full repo scan.
- **Three refusal arms added** — `empty_diff_scope`, `stale_diff_scope`, `unindexed_contract_target`. All three are reachable here and all three landed on the bare-code fallback. `unindexed_contract_target` is the pointed one: it fires when an agent contract names a file the scan does not index, and an agent contract is the *only* rule this repo's contract carries.
- **Two arms are deliberately unreachable and now say so.** `full_scope_cannot_block` and `contract_stale_under_strict` cannot fire while this step hardcodes `--scope changed-hunks` and omits `--strict-contract`. Kept, because those two flags are the likeliest edit anyone will ever make to this file and the alternative is that the edit silently degrades to the bare-code arm. Flagging as a judgment call, not an oversight.
- **`docs/reference/enforcement.md`** was missing rows for those three codes, so the workflow's claim to mirror that table was not true. Added, with a note that thrown-vs-returned is not a distinction a consumer can see (`run-cli.ts` puts `failure` beside `error`).
- **`docs/ci-integration.md`** told readers to treat its requirements as verified "from the first green run of that workflow onward" — a run that had never happened. It now records why.
- **`.gitignore`** now covers `drift-check.json`, which the workflow writes into the workspace.
- **Swept every workflow for the same pattern**: `drift-check-self.yml` was the only `$GITHUB_ENV` user. `engine-binary-release.yml` uses `$GITHUB_OUTPUT` correctly, across steps.

## Not caused by this PR — `CI / Verify` is red on `main` right now

`test/e2e/release-hygiene.test.ts:96` pins the root `verify:evals` script whole, and `package.json` has since gained `pnpm eval:presence` without that pin being updated:

```
package.json:  pnpm eval:external && pnpm eval:breadth && pnpm eval:evasion && pnpm eval:bench && pnpm eval:presence && pnpm eval:determinism
test expects:  pnpm eval:external && pnpm eval:breadth && pnpm eval:evasion && pnpm eval:bench && pnpm eval:determinism
```

Measured failing at `c1738b14` (current `main`) and at `1617a99b`, in a clean worktree, so it is not from this branch. Left alone on purpose: the fix is one line, but *which* line depends on the intent of the PR that added `eval:presence` — either the pin gains the step, or `verify:evals` should not have it. Whoever owns that change should pick.

Everything else on this branch is green: 1171 unit tests (692 CLI), harness 202/202, e2e 29/30 files with the one failure above, plus every gate (rustfmt, clippy, boundaries, storage-lifecycle, storage-invariants, error-contract, vocabulary, surface-parity, payload-invariants, cell-ledger, release-matrix, validate:claims, beta:proof, `git diff --check`). `installed-flow.test.ts` failed once under load on a concurrent `pnpm pack` and passes on re-run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)