### PR TITLE
fix(engine,scripts): the session-trust proof emitted a word its own schema rejects

### DIFF
--- a/crates/drift-engine/src/check_command.rs
+++ b/crates/drift-engine/src/check_command.rs
@@ -3639,12 +3639,13 @@ fn phase4_missing_code(proof: &SecurityBoundaryProof, convention_kind: &str) -> 
             .session_trust
             .missing_trust
             .first()
-            .map(|missing| {
-                if missing.reason == "derived_from_request" {
-                    "session_not_trusted".to_string()
-                } else {
-                    missing.reason.clone()
-                }
+            // Proof-level reasons and finding-level codes are separate vocabularies.
+            // This mapping must be TOTAL over the proof-level enum: any reason that
+            // falls through lands in SecurityMissingProofCodeSchema, where a non-member
+            // normalizes to `unknown_reason_code` and the finding degrades silently.
+            .map(|missing| match missing.reason.as_str() {
+                "derived_from_request" | "unknown_helper" => "session_not_trusted".to_string(),
+                _ => missing.reason.clone(),
             })
             .unwrap_or_else(|| "session_not_trusted".to_string()),
         _ => "missing_proof".to_string(),

--- a/crates/drift-engine/src/check_command.rs
+++ b/crates/drift-engine/src/check_command.rs
@@ -4505,3 +4505,101 @@ mod finding_fingerprint_dc3_tests {
         );
     }
 }
+
+#[cfg(test)]
+mod phase4_missing_code_tests {
+    use super::phase4_missing_code;
+    use drift_engine::{SecurityBoundaryProof, build_phase4_security_proof};
+
+    const SESSION_TRUST: &str = "session_object_must_come_from_trusted_helper";
+
+    /// The PROOF-level session-trust reasons `build_session_trust_proof_from_facts` can
+    /// actually emit. The wire enum in packages/core/src/security.ts also declares
+    /// `missing_auth_guard` and `parser_gap`, but neither has a producer -- see the
+    /// unreachable-member pin below.
+    const REACHABLE_REASONS: [&str; 2] = ["derived_from_request", "unknown_helper"];
+
+    /// The FINDING-level codes (SecurityMissingProofCodeSchema) this mapper may produce
+    /// for a session-trust convention.
+    const FINDING_LEVEL_CODES: [&str; 2] = ["session_not_trusted", "missing_auth_guard"];
+
+    fn proof_with_session_reason(reason: &str) -> SecurityBoundaryProof {
+        let source = concat!(
+            "export async function GET(request: Request) {\n",
+            "  const session = await getSession(request);\n",
+            "  return Response.json({ ok: Boolean(session) });\n",
+            "}\n"
+        );
+        let mut proof =
+            build_phase4_security_proof("app/api/x/route.ts", source, &[]).expect("proof");
+        proof
+            .session_trust
+            .missing_trust
+            .first_mut()
+            .expect("fixture must produce a missing_trust entry")
+            .reason = reason.to_string();
+        proof
+    }
+
+    /// S1-03: the proof-level reason and the finding-level code are separate
+    /// vocabularies, and this mapper is the only bridge between them. A reason that falls
+    /// through unmapped lands in SecurityMissingProofCodeSchema, where a non-member
+    /// normalizes to `unknown_reason_code`: the finding stops saying why the proof failed,
+    /// and nothing fails loudly. That silent degradation is what this test prevents.
+    #[test]
+    fn the_mapper_is_total_over_every_reason_the_builder_can_emit() {
+        for reason in REACHABLE_REASONS {
+            let code = phase4_missing_code(&proof_with_session_reason(reason), SESSION_TRUST);
+            assert!(
+                FINDING_LEVEL_CODES.contains(&code.as_str()),
+                "proof-level reason {reason:?} mapped to {code:?}, which is not a \
+                 member of the finding-level vocabulary {FINDING_LEVEL_CODES:?}"
+            );
+        }
+    }
+
+    /// Both reasons a session-trust proof can emit today collapse to the single
+    /// user-facing code. This is the half of the S1-01 fix that keeps the mapper honest:
+    /// without the `unknown_helper` arm, correcting the emitted proof value would have
+    /// traded a hard parse failure for a silently degraded finding.
+    #[test]
+    fn both_live_session_trust_reasons_map_to_session_not_trusted() {
+        for reason in REACHABLE_REASONS {
+            assert_eq!(
+                phase4_missing_code(&proof_with_session_reason(reason), SESSION_TRUST),
+                "session_not_trusted",
+                "proof-level reason {reason:?}"
+            );
+        }
+    }
+
+    /// The two declared-but-unproduced members, pinned as they behave today.
+    ///
+    /// `missing_auth_guard` happens to be a member of BOTH vocabularies, so it survives
+    /// the fall-through. `parser_gap` does not: it would reach the engine parse boundary
+    /// and normalize to `unknown_reason_code`, losing the reason. That is latent, not
+    /// live -- the builder cannot emit either one.
+    ///
+    /// This is deliberately a characterization pin, not a fix. Choosing the finding-level
+    /// code for a parser-gapped session-trust proof is a product decision: a parser gap
+    /// is carried by the separate `parser_gaps` surface and drives
+    /// `proof_status == ParserGap`, so claiming `session_not_trusted` here would assert a
+    /// trust failure that was never established. If a producer is ever added for either
+    /// member, decide the mapping and update this test -- do not let it fall through.
+    #[test]
+    fn the_unproduced_reasons_are_pinned_where_they_currently_land() {
+        assert_eq!(
+            phase4_missing_code(
+                &proof_with_session_reason("missing_auth_guard"),
+                SESSION_TRUST
+            ),
+            "missing_auth_guard",
+            "a member of both vocabularies survives the fall-through"
+        );
+        assert_eq!(
+            phase4_missing_code(&proof_with_session_reason("parser_gap"), SESSION_TRUST),
+            "parser_gap",
+            "not a finding-level member; would normalize to unknown_reason_code downstream"
+        );
+    }
+}

--- a/crates/drift-engine/src/check_command.rs
+++ b/crates/drift-engine/src/check_command.rs
@@ -3640,9 +3640,16 @@ fn phase4_missing_code(proof: &SecurityBoundaryProof, convention_kind: &str) -> 
             .missing_trust
             .first()
             // Proof-level reasons and finding-level codes are separate vocabularies.
-            // This mapping must be TOTAL over the proof-level enum: any reason that
-            // falls through lands in SecurityMissingProofCodeSchema, where a non-member
-            // normalizes to `unknown_reason_code` and the finding degrades silently.
+            // This mapping must be TOTAL over the proof-level enum. A reason that falls
+            // through lands in SecurityMissingProofCodeSchema, and the consequence is NOT
+            // a soft one: engine-contract normalizes an unknown code to
+            // `unknown_reason_code` via a z.preprocess, but packages/core's copy is a
+            // plain hard z.enum, so it THROWS on the CLI's own read path and on all four
+            // storage parses. An unmapped reason is a second F1-class crash, not a
+            // degraded string.
+            //
+            // NOTE the `.unwrap_or_else` below is a separate, live defect -- see
+            // `an_empty_missing_list_can_state_the_opposite_of_the_proof` in the tests.
             .map(|missing| match missing.reason.as_str() {
                 "derived_from_request" | "unknown_helper" => "session_not_trusted".to_string(),
                 _ => missing.reason.clone(),
@@ -4509,7 +4516,9 @@ mod finding_fingerprint_dc3_tests {
 #[cfg(test)]
 mod phase4_missing_code_tests {
     use super::phase4_missing_code;
-    use drift_engine::{SecurityBoundaryProof, build_phase4_security_proof};
+    use drift_engine::{
+        AcceptedAuthHelper, AuthGuardBehavior, SecurityBoundaryProof, build_phase4_security_proof,
+    };
 
     const SESSION_TRUST: &str = "session_object_must_come_from_trusted_helper";
 
@@ -4571,6 +4580,68 @@ mod phase4_missing_code_tests {
                 "proof-level reason {reason:?}"
             );
         }
+    }
+
+    /// B1, pinned: the default arm can state the OPPOSITE of what the proof found.
+    ///
+    /// A finding is emitted when `!proven || proof_status == ParserGap`. The second
+    /// disjunct is reachable with `proven == true` and an EMPTY `missing_trust` -- a
+    /// route whose session the engine proved trusted, that also tripped a parser gap.
+    /// `.first()` then yields None and the default fabricates `session_not_trusted`,
+    /// so the user is told the session is untrusted about a session that was proven
+    /// trusted. Reproduced end to end against the real binary:
+    ///
+    ///     const session = await requireUser(request);
+    ///     const { user: { tenantId } } = session;   // unsupported_session_nested_destructure
+    ///
+    ///     session_trust.proven : true      missing_trust : []
+    ///     proof_status         : parser_gap
+    ///     missing_proof codes  : ["session_not_trusted"]
+    ///     finding title        : "API route uses untrusted session object"
+    ///
+    /// This predates the fix that introduced this module, and the tenant and
+    /// authorization arms carry the identical shape (`tenant_predicate_missing`,
+    /// `authorization_guard_missing`). It is NOT fixed here: the honest code for a
+    /// parser-gapped proof has no member in SecurityMissingProofCodeSchema, the finding
+    /// TITLE is a per-kind constant that lies too, and `missing_code` feeds the finding
+    /// fingerprint, so correcting it moves fingerprints and breaks baseline continuity
+    /// for exactly these findings. That is a vocabulary and migration change with its
+    /// own release note, not a rider on a parse fix.
+    ///
+    /// Tracked as issue #129.
+    ///
+    /// The value of pinning it is that this arm was the one branch of
+    /// `phase4_missing_code` no test covered, while the module around it asserted the
+    /// mapper was total. The claim now stops at what is actually true.
+    #[test]
+    fn an_empty_missing_list_can_state_the_opposite_of_the_proof() {
+        let source = concat!(
+            "import { requireUser } from '@/server/auth';\n",
+            "export async function GET(request: Request) {\n",
+            "  const session = await requireUser(request);\n",
+            "  const { user: { tenantId } } = session;\n",
+            "  return Response.json({ ok: Boolean(tenantId) });\n",
+            "}\n"
+        );
+        let helpers = [AcceptedAuthHelper {
+            guard_id: "g".to_string(),
+            symbol: "requireUser".to_string(),
+            behavior: AuthGuardBehavior::ReturnsSession,
+        }];
+        let proof =
+            build_phase4_security_proof("app/api/x/route.ts", source, &helpers).expect("proof");
+
+        // The proof itself is sound: nothing failed on trust.
+        assert!(proof.session_trust.proven, "{:#?}", proof.session_trust);
+        assert!(proof.session_trust.missing_trust.is_empty());
+
+        // The code handed to the user says otherwise. This assertion documents the
+        // defect; when it is fixed, this test must be updated, not deleted.
+        assert_eq!(
+            phase4_missing_code(&proof, SESSION_TRUST),
+            "session_not_trusted",
+            "known defect: the default arm asserts a trust failure the proof did not find"
+        );
     }
 
     /// The two declared-but-unproduced members, pinned as they behave today.

--- a/crates/drift-engine/src/security_proof.rs
+++ b/crates/drift-engine/src/security_proof.rs
@@ -1461,8 +1461,12 @@ fn build_session_trust_proof_from_facts(facts: &[Fact]) -> SessionTrustProof {
                 missing_trust.push(SessionMissingTrustProof {
                     fact_id: fact_id(fact),
                     variable,
+                    // PROOF-level vocabulary (core/src/security.ts SecurityBoundaryProof
+                    // session_trust enum), NOT the finding-level code a user sees. The
+                    // finding-level `session_not_trusted` is derived from this by the
+                    // phase4 finding-reason mapper in check_command.rs.
                     reason: if source == Some("unknown_helper") {
-                        "session_not_trusted"
+                        "unknown_helper"
                     } else {
                         "derived_from_request"
                     }

--- a/crates/drift-engine/src/security_proof.rs
+++ b/crates/drift-engine/src/security_proof.rs
@@ -2109,8 +2109,7 @@ mod tests {
             "}\n"
         );
 
-        let proof =
-            build_phase4_security_proof("app/api/x/route.ts", source, &[]).expect("proof");
+        let proof = build_phase4_security_proof("app/api/x/route.ts", source, &[]).expect("proof");
 
         let missing = proof
             .session_trust

--- a/crates/drift-engine/src/security_proof.rs
+++ b/crates/drift-engine/src/security_proof.rs
@@ -2086,3 +2086,37 @@ fn line_uses_identifier(line: &str, identifier: &str) -> bool {
     })
     .any(|token| token == identifier)
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// S1-02: a unit-level guard on the proof builder itself.
+    ///
+    /// The end-to-end test in tests/security_check_repo_phase4.rs pins the same
+    /// invariant, but this one fails in milliseconds and names the cause directly:
+    /// `missing_trust[].reason` is PROOF-level vocabulary, and an unrecognized helper
+    /// is `unknown_helper` -- never the finding-level `session_not_trusted`.
+    ///
+    /// Verified non-vacuous: reverting the emission site to "session_not_trusted"
+    /// fails this test with left: "session_not_trusted", right: "unknown_helper".
+    #[test]
+    fn unknown_helper_source_maps_to_unknown_helper_reason() {
+        let source = concat!(
+            "export async function GET(request: Request) {\n",
+            "  const session = await getSession(request);\n",
+            "  return Response.json({ ok: Boolean(session) });\n",
+            "}\n"
+        );
+
+        let proof =
+            build_phase4_security_proof("app/api/x/route.ts", source, &[]).expect("proof");
+
+        let missing = proof
+            .session_trust
+            .missing_trust
+            .first()
+            .expect("an unrecognized session helper must produce a missing_trust entry");
+        assert_eq!(missing.reason, "unknown_helper");
+    }
+}

--- a/crates/drift-engine/tests/security_check_repo_phase4.rs
+++ b/crates/drift-engine/tests/security_check_repo_phase4.rs
@@ -168,7 +168,10 @@ fn engine_does_not_accept_phase4_legacy_matcher_required_calls_as_session_trust(
         .iter()
         .find(|missing| missing["capability"] == "session_trust")
         .expect("session_trust missing_proof entry");
-    assert_eq!(session_missing["code"], "session_not_trusted", "{session_missing:#?}");
+    assert_eq!(
+        session_missing["code"], "session_not_trusted",
+        "{session_missing:#?}"
+    );
 }
 
 #[test]

--- a/crates/drift-engine/tests/security_check_repo_phase4.rs
+++ b/crates/drift-engine/tests/security_check_repo_phase4.rs
@@ -148,14 +148,27 @@ fn engine_does_not_accept_phase4_legacy_matcher_required_calls_as_session_trust(
         findings[0]["rule_id"],
         "session_object_must_come_from_trusted_helper"
     );
+    // PROOF-level reason: a member of the session_trust wire enum.
     assert!(
         payload["security_boundary_proofs"][0]["session_trust"]["missing_trust"]
             .as_array()
             .expect("missing trust")
             .iter()
-            .any(|missing| missing["reason"] == "session_not_trusted"),
+            .any(|missing| missing["reason"] == "unknown_helper"),
         "{payload:#?}"
     );
+    // FINDING-level code: the separate user-facing vocabulary. Asserting both is what
+    // proves the mapper was widened rather than the bug merely being moved.
+    // FINDING-level code: the separate user-facing vocabulary, surfaced through the
+    // layer's missing_proof_ids. Asserting BOTH surfaces is what proves the phase4
+    // finding-reason mapper was widened rather than the bug merely being relocated.
+    let session_missing = payload["security_boundary_proofs"][0]["missing_proof"]
+        .as_array()
+        .expect("missing_proof")
+        .iter()
+        .find(|missing| missing["capability"] == "session_trust")
+        .expect("session_trust missing_proof entry");
+    assert_eq!(session_missing["code"], "session_not_trusted", "{session_missing:#?}");
 }
 
 #[test]
@@ -514,4 +527,87 @@ fn temp_repo(name: &str) -> std::path::PathBuf {
     let _ = fs::remove_dir_all(&path);
     fs::create_dir_all(&path).expect("create temp repo");
     path
+}
+
+/// S1-01 RED: the engine emits `session_trust.missing_trust[].reason` onto the wire,
+/// where `SecurityBoundaryProofSchema` (packages/core/src/security.ts) parses it with a
+/// four-member enum. This test pins that every emitted value is a member of that enum.
+///
+/// This is the PROOF-level vocabulary — why the proof failed. The FINDING-level code a
+/// user sees (`session_not_trusted`) is a separate vocabulary, derived from this one by
+/// the phase4 finding-reason mapper in check_command.rs. The two are deliberately
+/// different; conflating them is what F1 was.
+#[test]
+fn session_trust_reason_is_a_member_of_the_wire_enum() {
+    let repo_root = temp_repo("phase4_reason_vocabulary");
+    write_route(
+        &repo_root,
+        "app/api/projects/route.ts",
+        &[
+            "import { requireUser } from '@/server/auth';",
+            "export async function GET(request: Request) {",
+            "  const session = await requireUser(request);",
+            "  return Response.json({ ok: Boolean(session) });",
+            "}",
+            "",
+        ],
+    );
+
+    let payload = run_check_repo(json!({
+        "repo": {
+            "repo_id": "repo_phase4",
+            "repo_root": repo_root.to_string_lossy()
+        },
+        "scan": {
+            "scan_id": "scan_phase4",
+            "facts": [
+                fact("file_role_detected", "api_route", 1, 5, None, None),
+                fact("import_used", "requireUser", 1, 1, Some("@/server/auth"), Some("requireUser")),
+                fact("route_declared", "GET", 2, 5, None, None),
+                fact("symbol_called", "requireUser", 3, 3, None, None),
+                fact("route_returns_response", "json", 4, 4, Some("Response"), None)
+            ]
+        },
+        "contract": {
+            "contract_id": "contract_phase4",
+            "contract_schema_version": 1,
+            "conventions": [{
+                "id": "security_session_trust",
+                "kind": "session_object_must_come_from_trusted_helper",
+                "matcher": {
+                    "applies_to_file_roles": ["api_route"],
+                    "required_calls": ["requireUser"]
+                },
+                "severity": "error",
+                "enforcement_mode": "block",
+                "enforcement_capability": "deterministic_check"
+            }]
+        },
+        "baseline": [],
+        "diff": { "mode": "full", "files": [] }
+    }));
+
+    // The four members of the enum at packages/core/src/security.ts, the schema that
+    // parses this exact field. Keep in sync until S2 generates both sides.
+    const LEGAL: [&str; 4] = [
+        "derived_from_request",
+        "unknown_helper",
+        "missing_auth_guard",
+        "parser_gap",
+    ];
+
+    let missing_trust = payload["security_boundary_proofs"][0]["session_trust"]["missing_trust"]
+        .as_array()
+        .expect("missing_trust");
+    assert!(
+        !missing_trust.is_empty(),
+        "fixture must produce a missing_trust entry to be a meaningful test: {payload:#?}"
+    );
+    for missing in missing_trust {
+        let reason = missing["reason"].as_str().expect("reason");
+        assert!(
+            LEGAL.contains(&reason),
+            "proof-level reason {reason:?} is not a member of the wire enum {LEGAL:?}"
+        );
+    }
 }

--- a/crates/drift-engine/tests/security_check_repo_phase4.rs
+++ b/crates/drift-engine/tests/security_check_repo_phase4.rs
@@ -157,8 +157,6 @@ fn engine_does_not_accept_phase4_legacy_matcher_required_calls_as_session_trust(
             .any(|missing| missing["reason"] == "unknown_helper"),
         "{payload:#?}"
     );
-    // FINDING-level code: the separate user-facing vocabulary. Asserting both is what
-    // proves the mapper was widened rather than the bug merely being moved.
     // FINDING-level code: the separate user-facing vocabulary, surfaced through the
     // layer's missing_proof_ids. Asserting BOTH surfaces is what proves the phase4
     // finding-reason mapper was widened rather than the bug merely being relocated.

--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
     "validate:claims": "node scripts/validate-product-claims.mjs",
     "beta:proof": "node scripts/run-beta-proof.mjs",
     "release:proof": "node scripts/generate-release-proof.mjs",
-    "verify:ci": "pnpm verify && pnpm test:harness && pnpm format:engine:check && pnpm lint:engine && pnpm check:boundaries && pnpm check:storage-lifecycle && pnpm check:storage-invariants && pnpm check:error-contract && pnpm check:vocabulary && pnpm check:surface-parity && pnpm check:payload-invariants && pnpm check:cell-ledger && node scripts/validate-engine-release-matrix.mjs --allow-unverified && pnpm validate:claims && pnpm beta:proof && git diff --check",
+    "verify:ci": "pnpm verify && pnpm test:harness && pnpm format:engine:check && pnpm lint:engine && pnpm check:boundaries && pnpm check:storage-lifecycle && pnpm check:storage-invariants && pnpm check:error-contract && pnpm check:vocabulary && pnpm check:surface-parity && pnpm check:payload-invariants && pnpm check:cell-ledger && pnpm check:engine-schema-parity && node scripts/validate-engine-release-matrix.mjs --allow-unverified && pnpm validate:claims && pnpm beta:proof && git diff --check",
     "verify:evals": "pnpm eval:external && pnpm eval:breadth && pnpm eval:evasion && pnpm eval:bench && pnpm eval:presence && pnpm eval:determinism",
     "verify:full": "pnpm verify:ci && pnpm verify:evals",
     "eval:external": "node scripts/external-eval.mjs",
@@ -36,7 +36,7 @@
     "eval:determinism": "node scripts/determinism.mjs",
     "eval:determinism:update": "node scripts/determinism.mjs --update",
     "run:log": "node scripts/run-log.mjs",
-    "test:harness": "vitest run --no-file-parallelism scripts/detection-breadth.test.mjs scripts/external-eval.test.mjs scripts/evasion-matrix.test.mjs scripts/validate-engine-release-matrix.test.mjs scripts/worktree-contamination.test.mjs scripts/beta-bench-ratchet.test.mjs scripts/validate-product-claims.test.mjs scripts/engine-handshake.test.mjs scripts/external-eval-start.test.mjs scripts/storage-lifecycle.test.mjs scripts/storage-invariants.test.mjs scripts/error-contract.test.mjs scripts/vocabulary-parity.test.mjs scripts/surface-parity.test.mjs scripts/payload-invariants.test.mjs scripts/convention-cell-ledger.test.mjs scripts/determinism-predicate.test.mjs",
+    "test:harness": "vitest run --no-file-parallelism scripts/detection-breadth.test.mjs scripts/external-eval.test.mjs scripts/evasion-matrix.test.mjs scripts/validate-engine-release-matrix.test.mjs scripts/worktree-contamination.test.mjs scripts/beta-bench-ratchet.test.mjs scripts/validate-product-claims.test.mjs scripts/engine-handshake.test.mjs scripts/external-eval-start.test.mjs scripts/storage-lifecycle.test.mjs scripts/storage-invariants.test.mjs scripts/error-contract.test.mjs scripts/vocabulary-parity.test.mjs scripts/surface-parity.test.mjs scripts/payload-invariants.test.mjs scripts/convention-cell-ledger.test.mjs scripts/determinism-predicate.test.mjs scripts/engine-schema-parity.test.mjs",
     "eval:prepare": "node scripts/prepare-quality-eval.mjs",
     "eval:presence": "node scripts/presence-precision-recall.mjs",
     "eval:presence:update": "node scripts/presence-precision-recall.mjs --update",
@@ -47,6 +47,7 @@
     "check:surface-parity": "node scripts/surface-parity.mjs",
     "check:payload-invariants": "node scripts/payload-invariants.mjs",
     "check:cell-ledger": "node scripts/convention-cell-ledger.mjs",
+    "check:engine-schema-parity": "node scripts/engine-schema-parity.mjs",
     "vocabulary:generate": "node vocabulary/generate.mjs"
   },
   "devDependencies": {

--- a/scripts/engine-schema-parity-baseline.json
+++ b/scripts/engine-schema-parity-baseline.json
@@ -1,0 +1,3 @@
+{
+  "rejections": {}
+}

--- a/scripts/engine-schema-parity.mjs
+++ b/scripts/engine-schema-parity.mjs
@@ -1,0 +1,449 @@
+#!/usr/bin/env node
+/**
+ * Two green test suites, one payload neither of them ever read.
+ *
+ * The engine emitted `session_not_trusted` into
+ * `security_boundary_proofs[].session_trust.missing_trust[].reason`. The Zod enum that parses
+ * that exact field declares four members and that is not one of them, so the parse threw and
+ * the CLI died on a proof the engine considered well-formed.
+ *
+ * It shipped because nothing looked at both halves at once:
+ *
+ *   the Rust suite asserted Rust values      - it agreed with the engine, which was wrong
+ *   the TypeScript suite asserted TS schemas - it agreed with the schema, which was right
+ *   no test ran the engine and parsed its real output with the real schema
+ *
+ * A contract with a producer test and a consumer test and no test across the seam is not a
+ * contract, it is two opinions. This gate is the missing third test: it drives the actual
+ * engine binary, takes the bytes it actually writes, and feeds them to the actual schemas the
+ * CLI actually parses them with. It closes the CLASS, not the instance -- any proof field whose
+ * emitted value falls outside its declared vocabulary fails here, on every build, whether or not
+ * anyone thought to write a test for that field.
+ *
+ * BOTH CONSUMERS, because they are separate schemas that happen to agree today:
+ *
+ *   parseEngineCheckResult        packages/engine-contract - the engine boundary the CLI crosses
+ *   SecurityBoundaryProofSchema   packages/core            - the storage and query consumer
+ *
+ * They carry byte-identical copies of the reason enums. Driving only one would let the other
+ * drift, which is the same defect one level up. (Sprint 2 generates both from
+ * vocabulary/vocabulary.json and this duplication goes away; until then, both are checked.)
+ *
+ * SCENARIOS are check-repo requests, not fixture repos. The engine is spawned directly rather
+ * than driven through the CLI, so a rejection names the engine's own output with nothing in
+ * between to normalize, default, or swallow it. Each scenario exists to reach a proof surface
+ * that emits a vocabulary-constrained field; a scenario producing no proof is itself a failure,
+ * because a gate that silently checks nothing is worse than no gate.
+ *
+ * BASELINE AND RATCHET, matching scripts/vocabulary-parity.mjs. A rejection already present may
+ * be recorded with a written reason; a new one fails. There is no path where a rejection is
+ * simply ignored.
+ *
+ *   node scripts/engine-schema-parity.mjs
+ *   node scripts/engine-schema-parity.mjs --update    # rewrite the baseline (reasons preserved)
+ */
+
+import { execFileSync } from "node:child_process";
+import { existsSync, mkdirSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { mkdtempSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { dirname, join, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const HERE = dirname(fileURLToPath(import.meta.url));
+const REPO_ROOT = resolve(HERE, "..");
+const BASELINE = join(HERE, "engine-schema-parity-baseline.json");
+const UPDATE = process.argv.includes("--update");
+
+/**
+ * Each scenario is a complete check-repo request plus the route files it refers to.
+ *
+ * `mustEmitProof` is not decoration. These requests are hand-built, and a typo in a fact kind or
+ * a convention id produces a request the engine accepts and answers with zero proofs -- which
+ * would parse clean and report success while checking nothing at all.
+ */
+const SCENARIOS = [
+  {
+    name: "session_trust_unknown_helper",
+    // The F1 reproducer. An unrecognized session helper drives the
+    // `(source, Some("untrusted"))` arm of build_session_trust_proof_from_facts, which is the
+    // arm that emitted a finding-level word into a proof-level field.
+    why: "unrecognized session helper - the reason field that shipped an illegal value",
+    files: {
+      "app/api/projects/route.ts": [
+        "import { requireUser } from '@/server/auth';",
+        "export async function GET(request: Request) {",
+        "  const session = await requireUser(request);",
+        "  return Response.json({ ok: Boolean(session) });",
+        "}",
+        ""
+      ]
+    },
+    facts: [
+      fact("file_role_detected", "api_route", 1, 5),
+      fact("import_used", "requireUser", 1, 1, "@/server/auth", "requireUser"),
+      fact("route_declared", "GET", 2, 5),
+      fact("symbol_called", "requireUser", 3, 3),
+      fact("route_returns_response", "json", 4, 4, "Response")
+    ],
+    conventions: [
+      {
+        id: "security_session_trust",
+        kind: "session_object_must_come_from_trusted_helper",
+        matcher: { applies_to_file_roles: ["api_route"], required_calls: ["requireUser"] },
+        severity: "error",
+        enforcement_mode: "block",
+        enforcement_capability: "deterministic_check"
+      }
+    ]
+  },
+  {
+    name: "session_trust_derived_from_request",
+    // The other reachable arm of the same match. Both proof-level reasons the builder can emit
+    // are driven, so neither can regress unobserved.
+    why: "session read straight off the request - the sibling reason on the same field",
+    files: {
+      "app/api/projects/route.ts": [
+        "export async function GET(request: Request) {",
+        "  const session = request.headers.get('x-session');",
+        "  return Response.json({ ok: Boolean(session) });",
+        "}",
+        ""
+      ]
+    },
+    facts: [
+      fact("file_role_detected", "api_route", 1, 4),
+      fact("route_declared", "GET", 1, 4),
+      fact("route_returns_response", "json", 3, 3, "Response")
+    ],
+    conventions: [
+      {
+        id: "security_session_trust",
+        kind: "session_object_must_come_from_trusted_helper",
+        matcher: { applies_to_file_roles: ["api_route"] },
+        severity: "error",
+        enforcement_mode: "block",
+        enforcement_capability: "deterministic_check"
+      }
+    ]
+  },
+  {
+    name: "tenant_scope_missing_predicate",
+    // tenant.missing[].reason - a different vocabulary on the same proof document.
+    why: "data operation with no tenant predicate - the tenant reason vocabulary",
+    files: {
+      "app/api/projects/route.ts": [
+        "import { requireUser } from '@/server/auth';",
+        "const db = { project: { findMany: async () => [] } };",
+        "export async function GET(request: Request) {",
+        "  const session = await requireUser(request);",
+        "  await db.project.findMany();",
+        "  return Response.json({ ok: true, session: Boolean(session) });",
+        "}",
+        ""
+      ]
+    },
+    facts: [
+      fact("file_role_detected", "api_route", 1, 7),
+      fact("import_used", "requireUser", 1, 1, "@/server/auth", "requireUser"),
+      fact("route_declared", "GET", 3, 7),
+      fact("symbol_called", "requireUser", 4, 4),
+      fact("symbol_called", "findMany", 5, 5, "db.project"),
+      fact("data_operation_detected", "findMany", 5, 5, "db.project", "read:project"),
+      fact("route_returns_response", "json", 6, 6, "Response")
+    ],
+    conventions: [
+      {
+        id: "security_api_tenant_scope",
+        kind: "api_route_requires_tenant_scope",
+        matcher: { applies_to_file_roles: ["api_route"] },
+        requires: {
+          auth_helpers: [
+            { guard_id: "auth_require_user", symbol: "requireUser", behavior: "returns_session" }
+          ],
+          tenant_helpers: ["scopeProjectToTenant"],
+          tenant_keys: ["tenantId"],
+          tenant_sources: ["session"],
+          data_operations: ["findMany"]
+        },
+        severity: "error",
+        enforcement_mode: "block",
+        enforcement_capability: "deterministic_check"
+      }
+    ]
+  },
+  {
+    name: "authorization_guard_missing",
+    // authorization.missing[].reason - the surface whose enum legitimately DOES contain
+    // `session_not_trusted`. Driving it alongside session_trust is what keeps the two
+    // vocabularies from being conflated again by whoever reads only one of them.
+    why: "data operation with no authorization guard - the authorization reason vocabulary",
+    files: {
+      "app/api/projects/route.ts": [
+        "import { requireUser } from '@/server/auth';",
+        "const db = { project: { findMany: async () => [] } };",
+        "export async function GET(request: Request) {",
+        "  const session = await requireUser(request);",
+        "  await db.project.findMany();",
+        "  return Response.json({ ok: true, session: Boolean(session) });",
+        "}",
+        ""
+      ]
+    },
+    facts: [
+      fact("file_role_detected", "api_route", 1, 7),
+      fact("import_used", "requireUser", 1, 1, "@/server/auth", "requireUser"),
+      fact("route_declared", "GET", 3, 7),
+      fact("symbol_called", "requireUser", 4, 4),
+      fact("symbol_called", "findMany", 5, 5, "db.project"),
+      fact("data_operation_detected", "findMany", 5, 5, "db.project", "read:project"),
+      fact("route_returns_response", "json", 6, 6, "Response")
+    ],
+    conventions: [
+      {
+        id: "security_api_authorization",
+        kind: "api_route_requires_authorization",
+        matcher: { applies_to_file_roles: ["api_route"] },
+        requires: {
+          auth_helpers: [
+            { guard_id: "auth_require_user", symbol: "requireUser", behavior: "returns_session" }
+          ],
+          authorization_helpers: [
+            {
+              symbol: "requireRole",
+              import: "@/server/authz",
+              kind: "role_check",
+              behavior: "throws_on_failure"
+            }
+          ],
+          data_operations: ["findMany"]
+        },
+        severity: "error",
+        enforcement_mode: "block",
+        enforcement_capability: "deterministic_check"
+      }
+    ]
+  }
+];
+
+function fact(kind, name, start_line, end_line, value = null, imported_name = null) {
+  return {
+    kind,
+    file_path: "app/api/projects/route.ts",
+    name,
+    value,
+    imported_name,
+    start_line,
+    end_line
+  };
+}
+
+/**
+ * Build the engine rather than trusting whichever binary happens to be on disk.
+ *
+ * This gate compares what the engine EMITS against what the schema ACCEPTS, so a stale binary
+ * does not degrade it -- it inverts it. A binary predating the current source reports the old
+ * payload: a fixed defect still looks broken, and worse, a freshly introduced one looks clean.
+ * Picking `target/release` over `target/debug` by existence, as the other gates do, was enough
+ * to report a two-day-old failure that had already been fixed.
+ *
+ * Release profile matches `pnpm build:engine`, so under verify:ci this is a cache hit rather
+ * than a second compile.
+ */
+function engineBinary() {
+  // `--engine <path>` measures a different binary instead of building one. This exists so the
+  // gate's own test can point it at a proxy that reproduces a known-bad emission without
+  // corrupting the shared Rust source or the shared release binary, which other harness tests
+  // build and execute concurrently. CI never passes it; the flag changes what is measured, not
+  // how strictly it is judged.
+  const override = process.argv.indexOf("--engine");
+  if (override !== -1) {
+    const path = process.argv[override + 1];
+    if (!path || !existsSync(path)) {
+      console.error(`engine schema parity: --engine ${path ?? "<missing>"} does not exist.`);
+      process.exit(1);
+    }
+    return path;
+  }
+
+  try {
+    execFileSync("cargo", ["build", "--release", "-p", "drift-engine"], {
+      cwd: REPO_ROOT,
+      stdio: "inherit"
+    });
+  } catch {
+    console.error("engine schema parity: cargo build --release -p drift-engine failed.");
+    process.exit(1);
+  }
+  const binary = join(REPO_ROOT, "target/release/drift-engine");
+  if (!existsSync(binary)) {
+    console.error(`engine schema parity: cargo reported success but ${binary} is missing.`);
+    process.exit(1);
+  }
+  return binary;
+}
+
+function runScenario(binary, scenario) {
+  const root = mkdtempSync(join(tmpdir(), `drift-engine-schema-${scenario.name}-`));
+  try {
+    for (const [path, lines] of Object.entries(scenario.files)) {
+      const target = join(root, path);
+      mkdirSync(dirname(target), { recursive: true });
+      writeFileSync(target, lines.join("\n"));
+    }
+    const request = {
+      repo: { repo_id: "repo_schema_parity", repo_root: root },
+      scan: { scan_id: "scan_schema_parity", facts: scenario.facts },
+      contract: {
+        contract_id: "contract_schema_parity",
+        contract_schema_version: 1,
+        conventions: scenario.conventions
+      },
+      baseline: [],
+      diff: { mode: "full", files: [] }
+    };
+    const stdout = execFileSync(binary, ["check-repo"], {
+      input: JSON.stringify(request),
+      encoding: "utf8",
+      maxBuffer: 64 * 1024 * 1024
+    });
+    return JSON.parse(stdout);
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
+}
+
+/** A Zod issue rendered so the message names the field, the value, and the legal set. */
+function describeIssue(scenarioName, consumer, issue) {
+  const path = issue.path.join(".");
+  const received =
+    issue.received === undefined ? "" : ` received ${JSON.stringify(issue.received)}`;
+  const options = issue.options ? ` options ${JSON.stringify(issue.options)}` : "";
+  return {
+    key: `${scenarioName} :: ${consumer} :: ${path} :: ${issue.code}`,
+    detail: `${issue.message}${received}${options}`
+  };
+}
+
+function loadBaseline() {
+  if (!existsSync(BASELINE)) return { rejections: {} };
+  return JSON.parse(readFileSync(BASELINE, "utf8"));
+}
+
+async function main() {
+  const binary = engineBinary();
+
+  const { parseEngineCheckResult } = await import(
+    join(REPO_ROOT, "packages/engine-contract/dist/index.js")
+  );
+  const { SecurityBoundaryProofSchema } = await import(
+    join(REPO_ROOT, "packages/core/dist/index.js")
+  );
+
+  const rejections = [];
+  const emptyScenarios = [];
+  let proofsChecked = 0;
+
+  for (const scenario of SCENARIOS) {
+    const payload = runScenario(binary, scenario);
+    const proofs = payload.security_boundary_proofs ?? [];
+
+    if (proofs.length === 0) {
+      emptyScenarios.push(scenario);
+      continue;
+    }
+    proofsChecked += proofs.length;
+
+    // Consumer 1: the engine boundary, on the whole document. This is the parse the CLI
+    // performs, so it catches a bad value anywhere in the result, not only in a proof.
+    const engineResult = safeParse(() => parseEngineCheckResult(payload));
+    if (!engineResult.ok) {
+      for (const issue of engineResult.issues) {
+        rejections.push(describeIssue(scenario.name, "parseEngineCheckResult", issue));
+      }
+    }
+
+    // Consumer 2: the storage and query schema, per proof.
+    for (const proof of proofs) {
+      const parsed = SecurityBoundaryProofSchema.safeParse(proof);
+      if (parsed.success) continue;
+      for (const issue of parsed.error.issues) {
+        rejections.push(describeIssue(scenario.name, "SecurityBoundaryProofSchema", issue));
+      }
+    }
+  }
+
+  if (emptyScenarios.length > 0) {
+    console.error("engine schema parity: a scenario produced no security_boundary_proofs.");
+    console.error("  A scenario that emits nothing parses clean and checks nothing.");
+    for (const scenario of emptyScenarios) {
+      console.error(`  ${scenario.name} - ${scenario.why}`);
+    }
+    process.exit(1);
+  }
+
+  const baseline = loadBaseline();
+  const seen = new Map();
+  for (const rejection of rejections) {
+    if (!seen.has(rejection.key)) seen.set(rejection.key, rejection.detail);
+  }
+
+  if (UPDATE) {
+    const next = { rejections: {} };
+    for (const [key, detail] of [...seen].sort(([a], [b]) => a.localeCompare(b))) {
+      next.rejections[key] = {
+        reason: baseline.rejections?.[key]?.reason ?? "TODO: why this rejection is tolerated",
+        detail
+      };
+    }
+    writeFileSync(BASELINE, `${JSON.stringify(next, null, 2)}\n`);
+    console.log(`engine schema parity: baseline updated (${seen.size} rejections).`);
+    return;
+  }
+
+  const baselined = new Set(Object.keys(baseline.rejections ?? {}));
+  const added = [...seen.keys()].filter((key) => !baselined.has(key));
+  const fixed = [...baselined].filter((key) => !seen.has(key));
+
+  if (added.length > 0) {
+    console.error("engine schema parity: the engine emitted a value its own schema rejects.");
+    console.error("");
+    for (const key of added) {
+      console.error(`  ${key}`);
+      console.error(`    ${seen.get(key)}`);
+    }
+    console.error("");
+    console.error("  The engine and the schema disagree about a field's vocabulary. Fix the");
+    console.error("  emitted value, or widen the schema -- do not baseline it without a reason.");
+    process.exit(1);
+  }
+
+  if (fixed.length > 0) {
+    console.error("engine schema parity: baselined rejections no longer occur.");
+    for (const key of fixed) console.error(`  ${key}`);
+    console.error("");
+    console.error("  Run: node scripts/engine-schema-parity.mjs --update");
+    process.exit(1);
+  }
+
+  console.log(
+    `engine schema parity: ${proofsChecked} proofs from ${SCENARIOS.length} scenarios parsed ` +
+      `by 2 consumers${seen.size > 0 ? `, ${seen.size} baselined` : ""}.`
+  );
+}
+
+/** parseEngineCheckResult throws; safeParse does not. Normalize the two into one shape. */
+function safeParse(run) {
+  try {
+    run();
+    return { ok: true, issues: [] };
+  } catch (error) {
+    if (error?.issues) return { ok: false, issues: error.issues };
+    return {
+      ok: false,
+      issues: [{ path: [], code: "throw", message: error?.message ?? String(error) }]
+    };
+  }
+}
+
+await main();

--- a/scripts/engine-schema-parity.mjs
+++ b/scripts/engine-schema-parity.mjs
@@ -31,9 +31,17 @@
  *
  * SCENARIOS are check-repo requests, not fixture repos. The engine is spawned directly rather
  * than driven through the CLI, so a rejection names the engine's own output with nothing in
- * between to normalize, default, or swallow it. Each scenario exists to reach a proof surface
- * that emits a vocabulary-constrained field; a scenario producing no proof is itself a failure,
- * because a gate that silently checks nothing is worse than no gate.
+ * between to normalize, default, or swallow it.
+ *
+ * Each scenario declares `mustPopulate`: the field paths it exists to reach. A gate that checks
+ * a vocabulary it never actually read reports success for the same reason the two suites did
+ * before it -- nothing looked. Requiring only that SOME proof came back is one level too
+ * shallow: the engine can answer with a well-formed document in which every constrained list is
+ * empty, and an emptiness check on the document as a whole cannot tell that from a real answer.
+ * These requests are hand-built fact lists that duplicate the engine's fact vocabulary and
+ * matcher shape with no cross-check, so the surfaces are individually fragile -- changing a
+ * source line from `await helper(request)` to a non-await form is enough to empty
+ * `missing_trust`. `mustPopulate` is what makes that a failure instead of a silent pass.
  *
  * BASELINE AND RATCHET, matching scripts/vocabulary-parity.mjs. A rejection already present may
  * be recorded with a written reason; a new one fails. There is no path where a rejection is
@@ -65,6 +73,7 @@ const UPDATE = process.argv.includes("--update");
 const SCENARIOS = [
   {
     name: "session_trust_unknown_helper",
+    mustPopulate: ["session_trust.missing_trust", "missing_proof"],
     // The F1 reproducer. An unrecognized session helper drives the
     // `(source, Some("untrusted"))` arm of build_session_trust_proof_from_facts, which is the
     // arm that emitted a finding-level word into a proof-level field.
@@ -99,6 +108,7 @@ const SCENARIOS = [
   },
   {
     name: "session_trust_derived_from_request",
+    mustPopulate: ["session_trust.missing_trust", "missing_proof"],
     // The other reachable arm of the same match. Both proof-level reasons the builder can emit
     // are driven, so neither can regress unobserved.
     why: "session read straight off the request - the sibling reason on the same field",
@@ -129,6 +139,7 @@ const SCENARIOS = [
   },
   {
     name: "tenant_scope_missing_predicate",
+    mustPopulate: ["tenant.missing", "missing_proof"],
     // tenant.missing[].reason - a different vocabulary on the same proof document.
     why: "data operation with no tenant predicate - the tenant reason vocabulary",
     files: {
@@ -174,6 +185,7 @@ const SCENARIOS = [
   },
   {
     name: "authorization_guard_missing",
+    mustPopulate: ["authorization.missing", "missing_proof"],
     // authorization.missing[].reason - the surface whose enum legitimately DOES contain
     // `session_not_trusted`. Driving it alongside session_trust is what keeps the two
     // vocabularies from being conflated again by whoever reads only one of them.
@@ -341,18 +353,30 @@ async function main() {
   );
 
   const rejections = [];
-  const emptyScenarios = [];
+  const unpopulated = [];
   let proofsChecked = 0;
+  let fieldsChecked = 0;
 
   for (const scenario of SCENARIOS) {
     const payload = runScenario(binary, scenario);
     const proofs = payload.security_boundary_proofs ?? [];
 
     if (proofs.length === 0) {
-      emptyScenarios.push(scenario);
+      unpopulated.push({ scenario, path: "security_boundary_proofs" });
       continue;
     }
     proofsChecked += proofs.length;
+
+    // The liveness contract. A scenario that stopped reaching its surface still parses clean,
+    // so without this the gate would report success having read no constrained value at all.
+    for (const path of scenario.mustPopulate) {
+      const populated = proofs.some((proof) => {
+        const value = path.split(".").reduce((node, key) => node?.[key], proof);
+        return Array.isArray(value) ? value.length > 0 : value !== undefined && value !== null;
+      });
+      if (populated) fieldsChecked += 1;
+      else unpopulated.push({ scenario, path });
+    }
 
     // Consumer 1: the engine boundary, on the whole document. This is the parse the CLI
     // performs, so it catches a bad value anywhere in the result, not only in a proof.
@@ -373,11 +397,14 @@ async function main() {
     }
   }
 
-  if (emptyScenarios.length > 0) {
-    console.error("engine schema parity: a scenario produced no security_boundary_proofs.");
-    console.error("  A scenario that emits nothing parses clean and checks nothing.");
-    for (const scenario of emptyScenarios) {
-      console.error(`  ${scenario.name} - ${scenario.why}`);
+  if (unpopulated.length > 0) {
+    console.error("engine schema parity: a scenario no longer reaches the field it exists to check.");
+    console.error("  An empty surface parses clean, so this would otherwise report success");
+    console.error("  having read no vocabulary-constrained value at all.");
+    console.error("");
+    for (const { scenario, path } of unpopulated) {
+      console.error(`  ${scenario.name} :: ${path} is empty`);
+      console.error(`    ${scenario.why}`);
     }
     process.exit(1);
   }
@@ -427,8 +454,9 @@ async function main() {
   }
 
   console.log(
-    `engine schema parity: ${proofsChecked} proofs from ${SCENARIOS.length} scenarios parsed ` +
-      `by 2 consumers${seen.size > 0 ? `, ${seen.size} baselined` : ""}.`
+    `engine schema parity: ${proofsChecked} proofs from ${SCENARIOS.length} scenarios, ` +
+      `${fieldsChecked} populated surfaces, parsed by 2 consumers` +
+      `${seen.size > 0 ? `, ${seen.size} baselined` : ""}.`
   );
 }
 

--- a/scripts/engine-schema-parity.test.mjs
+++ b/scripts/engine-schema-parity.test.mjs
@@ -1,0 +1,108 @@
+import { execFileSync } from "node:child_process";
+import { chmodSync, mkdtempSync, readFileSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { fileURLToPath } from "node:url";
+import { describe, expect, it } from "vitest";
+
+const repoRoot = fileURLToPath(new URL("..", import.meta.url));
+
+function runGate(args = []) {
+  try {
+    return {
+      exitCode: 0,
+      output: execFileSync("node", ["scripts/engine-schema-parity.mjs", ...args], {
+        cwd: repoRoot,
+        encoding: "utf8",
+        stdio: ["ignore", "pipe", "pipe"]
+      })
+    };
+  } catch (error) {
+    return { exitCode: error.status ?? 1, output: `${error.stdout ?? ""}${error.stderr ?? ""}` };
+  }
+}
+
+/**
+ * A proxy that is the real engine with one word changed.
+ *
+ * It forwards the request to the real binary and rewrites `unknown_helper` to
+ * `session_not_trusted` in the session-trust proof on the way back -- which is exactly the
+ * defect that shipped: a finding-level word written into a proof-level field.
+ *
+ * The alternative was to corrupt crates/drift-engine/src/security_proof.rs and let the gate
+ * recompile it. That is a truer reproduction and it is what was used to verify this gate by
+ * hand, but it cannot live in the harness: vitest runs test files in parallel, and
+ * engine-handshake.test.mjs builds and executes the same target/release/drift-engine. A test
+ * that corrupts shared source mid-run can hand a different test a corrupted engine. Proxying
+ * keeps the real engine, the real request, and the real schemas, and mutates only the bytes in
+ * flight.
+ */
+function badEngineProxy(realEngine) {
+  const dir = mkdtempSync(join(tmpdir(), "drift-schema-parity-proxy-"));
+  const script = join(dir, "proxy.mjs");
+  writeFileSync(
+    script,
+    [
+      'import { execFileSync } from "node:child_process";',
+      'import { readFileSync } from "node:fs";',
+      'const request = readFileSync(0, "utf8");',
+      `const out = execFileSync(${JSON.stringify(realEngine)}, ["check-repo"], {`,
+      '  input: request, encoding: "utf8", maxBuffer: 64 * 1024 * 1024',
+      "});",
+      "process.stdout.write(out.replaceAll('\"unknown_helper\"', '\"session_not_trusted\"'));"
+    ].join("\n")
+  );
+  const shim = join(dir, "engine.sh");
+  writeFileSync(shim, `#!/bin/sh\nexec node ${JSON.stringify(script)}\n`);
+  chmodSync(shim, 0o755);
+  return shim;
+}
+
+/**
+ * This gate exists because a contract with a producer test and a consumer test and nothing
+ * across the seam is two opinions, not a contract. Asserting only that it passes today would
+ * repeat that mistake one level up -- a green gate proves nothing until it has been watched
+ * to fail.
+ */
+describe("engine schema parity gate", () => {
+  it("passes against the committed engine", () => {
+    const result = runGate();
+    expect(result.exitCode).toBe(0);
+    expect(result.output).toContain("engine schema parity:");
+    expect(result.output).toContain("parsed by 2 consumers");
+  }, 300_000);
+
+  it("fails, and names the field, when the engine emits a word the schema rejects (F1)", () => {
+    // Build once through the gate's own path, then proxy that binary.
+    expect(runGate().exitCode).toBe(0);
+    const realEngine = join(repoRoot, "target/release/drift-engine");
+    const result = runGate(["--engine", badEngineProxy(realEngine)]);
+
+    expect(result.exitCode).toBe(1);
+    // The field, so the message points at the defect rather than at the gate.
+    expect(result.output).toContain("session_trust.missing_trust.0.reason");
+    // The value emitted, and the set it had to be in.
+    expect(result.output).toContain("session_not_trusted");
+    expect(result.output).toContain("unknown_helper");
+    // Both consumers see it -- neither schema is silently absent from the check.
+    expect(result.output).toContain("SecurityBoundaryProofSchema");
+    expect(result.output).toContain("parseEngineCheckResult");
+  }, 300_000);
+
+  it("refuses an --engine path that does not exist", () => {
+    const result = runGate(["--engine", join(repoRoot, "target/release/no-such-engine")]);
+    expect(result.exitCode).toBe(1);
+    expect(result.output).toContain("does not exist");
+  }, 60_000);
+
+  /**
+   * A scenario that stops producing proofs would parse clean and check nothing, which is how a
+   * gate rots into decoration. The gate treats an empty scenario as a failure; this pins that
+   * the check is still there to be relied on.
+   */
+  it("treats a scenario that produces no proofs as a failure", () => {
+    const gateSource = readFileSync(join(repoRoot, "scripts/engine-schema-parity.mjs"), "utf8");
+    expect(gateSource).toContain("a scenario produced no security_boundary_proofs");
+    expect(gateSource).toContain("parses clean and checks nothing");
+  });
+});

--- a/scripts/engine-schema-parity.test.mjs
+++ b/scripts/engine-schema-parity.test.mjs
@@ -1,5 +1,5 @@
 import { execFileSync } from "node:child_process";
-import { chmodSync, mkdtempSync, readFileSync, writeFileSync } from "node:fs";
+import { chmodSync, mkdtempSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { fileURLToPath } from "node:url";
@@ -23,21 +23,19 @@ function runGate(args = []) {
 }
 
 /**
- * A proxy that is the real engine with one word changed.
- *
- * It forwards the request to the real binary and rewrites `unknown_helper` to
- * `session_not_trusted` in the session-trust proof on the way back -- which is exactly the
- * defect that shipped: a finding-level word written into a proof-level field.
+ * A stand-in engine: the real binary, with `mutate` applied to its parsed output on the way back.
  *
  * The alternative was to corrupt crates/drift-engine/src/security_proof.rs and let the gate
- * recompile it. That is a truer reproduction and it is what was used to verify this gate by
- * hand, but it cannot live in the harness: vitest runs test files in parallel, and
- * engine-handshake.test.mjs builds and executes the same target/release/drift-engine. A test
- * that corrupts shared source mid-run can hand a different test a corrupted engine. Proxying
- * keeps the real engine, the real request, and the real schemas, and mutates only the bytes in
- * flight.
+ * recompile it. That is a truer reproduction and it is what verified this gate by hand. It is not
+ * used here for two reasons: it costs a release rebuild per case, and it mutates shared source
+ * that other harness tests compile against. (`test:harness` now runs with --no-file-parallelism,
+ * so the race that originally ruled it out no longer applies -- but a test that edits tracked
+ * source still leaves the tree dirty if it dies partway, and the proxy has neither problem.)
+ *
+ * What the proxy preserves is what matters: the real engine, the real request, the real schemas.
+ * Only the bytes between them are touched.
  */
-function badEngineProxy(realEngine) {
+function proxyEngine(realEngine, mutate) {
   const dir = mkdtempSync(join(tmpdir(), "drift-schema-parity-proxy-"));
   const script = join(dir, "proxy.mjs");
   writeFileSync(
@@ -45,11 +43,12 @@ function badEngineProxy(realEngine) {
     [
       'import { execFileSync } from "node:child_process";',
       'import { readFileSync } from "node:fs";',
-      'const request = readFileSync(0, "utf8");',
       `const out = execFileSync(${JSON.stringify(realEngine)}, ["check-repo"], {`,
-      '  input: request, encoding: "utf8", maxBuffer: 64 * 1024 * 1024',
+      '  input: readFileSync(0, "utf8"), encoding: "utf8", maxBuffer: 64 * 1024 * 1024',
       "});",
-      "process.stdout.write(out.replaceAll('\"unknown_helper\"', '\"session_not_trusted\"'));"
+      "const payload = JSON.parse(out);",
+      mutate,
+      "process.stdout.write(JSON.stringify(payload));"
     ].join("\n")
   );
   const shim = join(dir, "engine.sh");
@@ -57,6 +56,23 @@ function badEngineProxy(realEngine) {
   chmodSync(shim, 0o755);
   return shim;
 }
+
+/** Reproduces F1: a finding-level word written into the proof-level reason field. */
+const EMIT_ILLEGAL_REASON = `
+for (const pr of payload.security_boundary_proofs ?? []) {
+  for (const m of pr.session_trust?.missing_trust ?? []) {
+    if (m.reason === "unknown_helper") m.reason = "session_not_trusted";
+  }
+}`;
+
+/** Empties every vocabulary-constrained list. The document stays schema-valid. */
+const EMPTY_EVERY_SURFACE = `
+for (const pr of payload.security_boundary_proofs ?? []) {
+  if (pr.session_trust) pr.session_trust.missing_trust = [];
+  if (pr.authorization) pr.authorization.missing = [];
+  if (pr.tenant) pr.tenant.missing = [];
+  pr.missing_proof = [];
+}`;
 
 /**
  * This gate exists because a contract with a producer test and a consumer test and nothing
@@ -70,13 +86,14 @@ describe("engine schema parity gate", () => {
     expect(result.exitCode).toBe(0);
     expect(result.output).toContain("engine schema parity:");
     expect(result.output).toContain("parsed by 2 consumers");
+    // The count of surfaces actually read, so a shrinking check is visible in the pass line.
+    expect(result.output).toMatch(/\d+ populated surfaces/);
   }, 300_000);
 
   it("fails, and names the field, when the engine emits a word the schema rejects (F1)", () => {
-    // Build once through the gate's own path, then proxy that binary.
     expect(runGate().exitCode).toBe(0);
     const realEngine = join(repoRoot, "target/release/drift-engine");
-    const result = runGate(["--engine", badEngineProxy(realEngine)]);
+    const result = runGate(["--engine", proxyEngine(realEngine, EMIT_ILLEGAL_REASON)]);
 
     expect(result.exitCode).toBe(1);
     // The field, so the message points at the defect rather than at the gate.
@@ -89,20 +106,36 @@ describe("engine schema parity gate", () => {
     expect(result.output).toContain("parseEngineCheckResult");
   }, 300_000);
 
+  /**
+   * The liveness contract, driven rather than grepped.
+   *
+   * This test used to read the gate's own source and assert two English sentences appeared in it.
+   * That is not a test of behaviour: it would have passed just as happily with the check deleted
+   * and the message left behind, and it did in fact pass while the check was one level too
+   * shallow -- requiring only that SOME proof came back, never that the constrained field the
+   * scenario exists to reach was populated. An engine can answer with a well-formed document in
+   * which every constrained list is empty, and the gate called that success while reading
+   * nothing, which is the same "green suite that looked at nothing" it was written to end.
+   *
+   * The payload here stays schema-valid on purpose: the gate must refuse it for being vacuous,
+   * not for being malformed.
+   */
+  it("refuses a well-formed payload whose constrained surfaces are all empty", () => {
+    expect(runGate().exitCode).toBe(0);
+    const realEngine = join(repoRoot, "target/release/drift-engine");
+    const result = runGate(["--engine", proxyEngine(realEngine, EMPTY_EVERY_SURFACE)]);
+
+    expect(result.exitCode).toBe(1);
+    expect(result.output).toContain("no longer reaches the field it exists to check");
+    // Names the surface, per scenario, so the message points at what stopped being reached.
+    expect(result.output).toContain("session_trust.missing_trust is empty");
+    expect(result.output).toContain("tenant.missing is empty");
+    expect(result.output).toContain("authorization.missing is empty");
+  }, 300_000);
+
   it("refuses an --engine path that does not exist", () => {
     const result = runGate(["--engine", join(repoRoot, "target/release/no-such-engine")]);
     expect(result.exitCode).toBe(1);
     expect(result.output).toContain("does not exist");
   }, 60_000);
-
-  /**
-   * A scenario that stops producing proofs would parse clean and check nothing, which is how a
-   * gate rots into decoration. The gate treats an empty scenario as a failure; this pins that
-   * the check is still there to be relied on.
-   */
-  it("treats a scenario that produces no proofs as a failure", () => {
-    const gateSource = readFileSync(join(repoRoot, "scripts/engine-schema-parity.mjs"), "utf8");
-    expect(gateSource).toContain("a scenario produced no security_boundary_proofs");
-    expect(gateSource).toContain("parses clean and checks nothing");
-  });
 });

--- a/test/e2e/release-hygiene.test.ts
+++ b/test/e2e/release-hygiene.test.ts
@@ -87,7 +87,16 @@ describe("release hygiene", () => {
       // (convention kind x enforcement path) cell is declared with the evidence its state requires,
       // the structural guardrail against the D1 class of defect - a cell that cannot fire while
       // looking covered.
-      "pnpm verify && pnpm test:harness && pnpm format:engine:check && pnpm lint:engine && pnpm check:boundaries && pnpm check:storage-lifecycle && pnpm check:storage-invariants && pnpm check:error-contract && pnpm check:vocabulary && pnpm check:surface-parity && pnpm check:payload-invariants && pnpm check:cell-ledger && node scripts/validate-engine-release-matrix.mjs --allow-unverified && pnpm validate:claims && pnpm beta:proof && git diff --check",
+      //
+      // And `pnpm check:engine-schema-parity`: the engine emitted `session_not_trusted` into
+      // `session_trust.missing_trust[].reason`, whose Zod enum does not contain it, so the parse
+      // threw on a payload both test suites called green. The Rust suite asserted Rust values and
+      // agreed with the engine; the TypeScript suite asserted TS schemas and agreed with the
+      // schema; nothing ran the engine and parsed its real output with the real schema. A contract
+      // with a producer test and a consumer test and nothing across the seam is two opinions. This
+      // gate is the seam, and it builds the engine rather than trusting whichever binary is on
+      // disk - a stale one does not weaken it, it inverts it.
+      "pnpm verify && pnpm test:harness && pnpm format:engine:check && pnpm lint:engine && pnpm check:boundaries && pnpm check:storage-lifecycle && pnpm check:storage-invariants && pnpm check:error-contract && pnpm check:vocabulary && pnpm check:surface-parity && pnpm check:payload-invariants && pnpm check:cell-ledger && pnpm check:engine-schema-parity && node scripts/validate-engine-release-matrix.mjs --allow-unverified && pnpm validate:claims && pnpm beta:proof && git diff --check",
     );
     expect(manifest.scripts["check:storage-invariants"]).toBe("node scripts/storage-invariants.mjs");
     expect(manifest.scripts["check:error-contract"]).toBe("node scripts/error-contract.mjs");


### PR DESCRIPTION
Sprint 1 of the security-convention pipeline refactor. Closes F1 and adds the gate that makes F1's whole class impossible.

Rebased onto main (20 commits) and revised after adversarial review — see **Review round** below.

## The defect

The engine wrote `session_not_trusted` into `security_boundary_proofs[].session_trust.missing_trust[].reason`. The Zod enum that parses that field declares four members and that is not one of them:

```
["derived_from_request", "unknown_helper", "missing_auth_guard", "parser_gap"]
```

The parse is hard, so the CLI threw on a payload the engine considered well-formed.

## Why two green suites missed it

- the Rust suite asserted Rust values — it agreed with the engine, which was wrong
- the TypeScript suite asserted TS schemas — it agreed with the schema, which was right
- nothing ran the engine and parsed its real output with the real schema

A contract with a producer test and a consumer test and no test across the seam is not a contract, it is two opinions.

## Commits

| Commit | What |
|---|---|
| `33252fda` | F1 fixed — emission site and finding mapper, together |
| `373b500c` | Unit guard on the proof builder |
| `829b1179` | Mapper totality pinned |
| `c50faf33` | `check:engine-schema-parity` — the cross-boundary gate |
| `d4b8d445` | Release-hygiene lock updated |
| `5baa1eeb` | **Review fix:** the gate reported success while reading nothing |
| `71a04a34` | **Review fix:** pin the branch that can state the opposite of the proof |
| `11e9b17f` | Unrelated: a pin that has been red on main since `eval:presence` landed |

**Both halves of the fix ship together.** `session_not_trusted` is a *finding-level* code; the proof-level field says why the proof failed, and for an unrecognized helper that word is `unknown_helper`. Correcting only the emission site would send `unknown_helper` through the mapper unmapped into the finding-level code, where it is not a member. So the mapper is widened in the same commit.

## The gate

`check:engine-schema-parity` spawns the engine binary, takes the bytes it writes, and feeds them to the schemas the CLI parses them with. Any proof field whose emitted value falls outside its declared vocabulary fails here, whether or not anyone thought to test that field.

- **Both consumers** — `parseEngineCheckResult` and `SecurityBoundaryProofSchema`. This is load-bearing: reverting the mapper arm is caught by `SecurityBoundaryProofSchema` **only**; `parseEngineCheckResult` normalizes it away.
- **It builds the engine** rather than picking whichever binary exists. A stale binary does not weaken this gate, it inverts it.
- **Each scenario declares `mustPopulate`** — the field paths it exists to reach. See B2 below.

**Watched to fail.** Reverting the emission site:

```
session_trust.missing_trust.0.reason :: invalid_enum_value
Expected 'derived_from_request' | 'unknown_helper' | 'missing_auth_guard' | 'parser_gap',
received 'session_not_trusted'
```

## Review round

Two blockers found by adversarial review, both independently reproduced before acting.

### B2 — the gate reported success while reading nothing *(fixed, `5baa1eeb`)*

Its only liveness assertion was that *some* proof came back. A proxy over the real engine emptying `missing_trust`, `authorization.missing`, `tenant.missing` and `missing_proof`:

```
engine schema parity: 4 proofs from 4 scenarios parsed by 2 consumers.
EXIT=0
```

Zero constrained values examined, success reported — the same "green suite that looked at nothing" failure this gate exists to end, reproduced inside the gate. Scenarios now declare `mustPopulate` and an empty surface fails, naming it. Its own test for this property was a `readFileSync` grep asserting two English sentences existed; it now drives the proxy and asserts the refusal.

### B1 — a finding can state the opposite of the proof *(pinned, not fixed — issue #129)*

`phase4_missing_code`'s `.unwrap_or_else` default is reachable with `proven == true` and an empty missing list: a route whose session was **proven trusted** that also tripped a parser gap.

```
session_trust.proven : true      missing_trust : []
proof_status         : parser_gap
missing_proof codes  : ["session_not_trusted"]
finding title        : "API route uses untrusted session object"
```

The tenant and authorization arms carry the identical shape. **Deliberately not fixed here:** no member of `SecurityMissingProofCodeSchema` honestly describes a parser-gapped proof, the finding *title* is a per-kind constant that lies too, and `missing_code` feeds the finding fingerprint — so correcting it moves fingerprints and breaks baseline continuity. That is a vocabulary and migration change with its own release note. Tracked as **#129**.

What *was* this branch's fault was the claim. The module asserted the mapper was total while skipping the one branch that is wrong. The claim now stops at what is true, and the default arm is pinned as a known defect.

Also corrected: the risk model stated in that comment. An unmapped reason does **not** "degrade silently" — that is true only of engine-contract's `z.preprocess`. `packages/core`'s copy is a hard `z.enum`, so it throws on the CLI read path and all four storage parses. The totality requirement is stronger than originally stated, not weaker.

### Confirmed clean by review

Producer totality (`SessionMissingTrustProof` has exactly one construction site); **no stored-data migration needed** (the pre-fix engine died at `parseEngineCheckResult` before any row was written, so no poisoned row can exist, and version skew is safe both directions); finding-level code unchanged end to end including fingerprint stability; `parser_gap` unreachability independently confirmed; no `derived_from_request` regression; all new tests verified non-vacuous by reverting each half.

## Unrelated fix included

`11e9b17f` — `release-hygiene` has been failing on a clean `main` since `pnpm eval:presence` was added to `verify:evals` without updating the string that pins it. Not introduced here; it surfaced when the rebase brought both into one tree. Third occurrence after W1 and W3, and the comment above the sibling pin already explains why: a pinned string is only a gate while somebody reruns it.

## Verification

- `cargo test -p drift-engine` — 40 test binaries green
- `pnpm verify:ci` — **exits 0**, with the new gate inside it
- `test/e2e/gt-canary.test.ts` — 17/17, including the line-768 `actual_layer: "session_not_trusted"` pin the playbook flagged as the tripwire for the half-fix trap

🤖 Generated with [Claude Code](https://claude.com/claude-code)