### PR TITLE
fix(cli): R2a - a renamed file is in scope, at its new path

### DIFF
--- a/docs/decisions/control-flow-tier-rebuild.md
+++ b/docs/decisions/control-flow-tier-rebuild.md
@@ -1,0 +1,203 @@
+# Rebuilding the control-flow tier — design spike
+
+**Status:** spike, no decision made
+**Date:** 2026-08-18
+**Applies to:** `crates/drift-engine/src/security_control_flow.rs`,
+`crates/drift-engine/src/security_proof.rs` (secret taint), the `--experimental-security` gate
+
+This document exists because the standing instruction for this tier —
+`docs/internal/architecture/security-heuristic-audit.md`'s *"lift when the layer is rebuilt on AST
+analysis"* — names an outcome and no design. A TDD plan cannot be written against it: red tests
+written today would encode the current shape. This frames the decision so one can be made.
+
+---
+
+## 1. What is actually true today
+
+Verified against `origin/main @ 5e86e89a`.
+
+### 1.1 Guard dominance is a line-number comparison — **confirmed**
+
+`security_control_flow.rs:42-61`:
+
+```rust
+let first_guard_line = facts.iter()
+    .filter(|fact| fact.kind == FactKind::AuthGuardCalled)
+    .map(|fact| fact.start_line).min()?;
+
+protected_sinks(facts).into_iter()
+    .filter(|sink| first_guard_line < sink.start_line)
+```
+
+The minimum guard line versus the sink line, numerically. Anything textually above a sink
+"dominates" it: a guard inside `if (false)`, a guard in a different exported function, a guard in a
+callback that never runs on the success path, a guard in dead code after an early `return`.
+
+### 1.2 The file is 48 `.contains()` calls, and it is growing
+
+26 at the time of the heuristic audit, **48** now. Growth is not the problem by itself — the problem
+is that each new call is a new textual assumption with no shared substrate.
+
+### 1.3 It is **not** uniformly naive
+
+`safe_parse_success_guard_dominates:462-478` calls `strip_strings_and_line_comment(line)` before
+matching. So some paths already handle strings and comments correctly and some do not. **There is no
+file-wide policy** — that inconsistency is a more actionable finding than the raw count.
+
+### 1.4 One claim in `beta-claims.json` is stale — correct it before quoting it
+
+`docs/internal/architecture/beta-claims.json:115` states that `unsupported_dynamic_control_flow()`
+*"matches only Drift fixture strings, so it opens for test inputs and never for real dynamic
+dispatch."*
+
+**That is no longer true.** `security_control_flow.rs:175-197`:
+
+```rust
+if line.contains("](") || line.contains(")(") { return true; }
+if line.contains("compose(") || line.contains("applyMiddleware")
+    || ((line.contains("middleware") || line.contains("guard"))
+        && (line.contains(".forEach") || line.contains(".reduce") || line.contains(".map("))) { … }
+```
+
+It matches structural shapes of real dynamic dispatch, and it filters `//`- and `*`-leading lines at
+`:179`. The valve works in the conservative direction. **Any plan that quotes the audit's claim as
+justification is arguing from a fact that has been fixed.** The audit's other two claims in that
+sentence (line-number dominance, `line.contains("if")` branch detection) still hold.
+
+### 1.5 The blast radius is contained, and that is why this is not urgent
+
+The tier is gated: security heuristics are behind `--experimental-security`
+(`packages/cli/src/commands/conventions.ts:76`, `:122-126`; `commands/start.ts:102`) and are never
+auto-accepted. The mitigation is a product gate and it is in place. **A rebuild is a capability
+project, not an incident response.**
+
+### 1.6 The same design gap owns the secret-exposure taint problem (R5)
+
+`security_proof.rs:1630-1686` runs a whole-file textual fixpoint with no scope and no order.
+Reproduced **[CONFIRMED]**:
+
+```ts
+function loadConfig() {
+  const key = process.env.STRIPE_API_KEY;   // `key` here
+  return key.length;
+}
+export function logRequest(key: string) {   // a DIFFERENT `key`
+  console.error(key);                        // → exposed=1, status=MissingProof
+}
+```
+
+and order-blindness — a sink textually above the assignment that taints it is still reported.
+
+**These are one design problem, not two.** Both need the same missing thing: a statement-level
+notion of *where you are in the program* — scope, and reachability along the success path. Deciding
+the fact substrate twice is how the codebase ends up with two.
+
+---
+
+## 2. What the current architecture permits
+
+Three constraints, all established and not worth re-deriving:
+
+1. **Crate boundary.** `security_control_flow.rs` and `security_proof.rs` are lib-crate modules and
+   cannot see `protocol.rs`'s graph types (compile-proven: `error[E0433]`). Whatever they consume
+   must arrive as `Fact`s or as plain data.
+2. **The vocabulary generator is the house mechanism for new fact kinds.** A member added to
+   `vocabulary/vocabulary.json` becomes a Rust variant with an exhaustive `as_wire`/`from_wire` and
+   a TypeScript schema, and `scripts/vocabulary-parity.mjs` then requires it to have a producer and
+   a consumer. Any option below that adds facts gets that enforcement for free.
+3. **`facts.rs` already owns the tree-sitter walk.** It is the only place that has the syntax tree,
+   and therefore the only place that can answer "is this token inside a comment / a string / this
+   function / this branch."
+
+---
+
+## 3. Options
+
+### Option A — leave it quarantined, delete nothing
+
+**Cost:** zero. **Value:** zero. The tier keeps growing textual assumptions (26 → 48), and the
+inconsistency in §1.3 keeps widening. Legitimate only as an explicit "not now," with a date.
+
+### Option B — statement-position facts, then migrate consumers one at a time
+
+Emit from `facts.rs`, at the tree-sitter layer, a small set of structural facts that the current text
+scans are approximating:
+
+| fact | answers | replaces |
+|---|---|---|
+| enclosing function id per fact | "are these two references the same scope?" | R5's cross-scope false positive |
+| statement index within its function | "does this run before that?" | line-number dominance (§1.1) |
+| branch id + branch polarity | "are these on the same path?" | `line.contains("if")` |
+| reachability-on-success | "does this run when the handler returns normally?" | guard-in-a-catch-block |
+| token classification (code / comment / string) | "is this real?" | the §1.3 inconsistency |
+
+Then migrate consumers **one predicate at a time**, each independently shippable against the
+existing fixture corpus.
+
+**Why this is the incremental path and not a rewrite:** each fact is additive, each migration is one
+function, and the fixtures that pin today's behavior stay green or change with a named reason. It is
+the same shape as the security plan's S6, one layer deeper.
+
+**Cost:** the fact-emission work is real tree-sitter surgery in `facts.rs`. Migration is then cheap
+and parallelizable. **Risk:** the fact set is a guess until at least two consumers use it — mitigate
+by migrating R5's taint pass and guard dominance first, since they stress scope and order
+respectively.
+
+**Open question that gates the estimate:** does the current `Fact` shape have room for these, or does
+it need a structured payload? `Fact` today is flat (`kind`, `name`, `value`, `imported_name`,
+`start_line`, `end_line`, `start_column`, `end_column`), and several security facts already smuggle
+JSON through `value` (`security_facts.rs:102-121`). That smuggling is a decision that should be made
+deliberately here rather than extended by default.
+
+### Option C — a real CFG and dataflow pass
+
+Build a control-flow graph per handler and do proper reaching-definitions.
+
+**Value:** answers every question in the table correctly, permanently, and would let the tier come
+off `--experimental-security`. **Cost:** a different kind of project — this is the largest single
+piece of engineering proposed anywhere in the current plans. **Recommendation:** do not start here.
+Option B's facts are a strict subset of what a CFG would produce, so B is not wasted work if C
+happens later; C-first risks a long branch with nothing shippable in it.
+
+### Option D — delete the tier
+
+Remove guard dominance, branch bypass, and callback boundary analysis; keep only the presence tier
+(`check_command.rs:2169`), which is already documented, pinned, and honest about what it does not
+claim.
+
+**Value:** removes 807 lines of quarantined heuristics and the maintenance drag. **Cost:** gives up
+the only mechanism that could ever catch "guard called after the sink," which is the failure the
+presence tier explicitly does not catch (`check_command.rs:1810-1824`) and which
+`beta-claims.json:108` documents as a known non-catch. **This is a product decision about whether
+Drift intends to make control-flow claims at all** — not an engineering call, and it should be made
+before B or C is scheduled, because B and C are only worth doing if the answer is yes.
+
+---
+
+## 4. What I recommend deciding, and in what order
+
+1. **First, answer D's question:** does Drift intend to make control-flow claims? If no, D is cheap
+   and everything below is moot. If yes, continue.
+2. **Then B, scoped to two consumers** — R5's taint pass and guard dominance. Two consumers is the
+   minimum that tests whether the fact set generalizes; one consumer would design the facts around
+   itself.
+3. **Sequence B after the security plan's S6.** S6 already moves secret reads and response/log sinks
+   onto AST-emitted facts. B extends that substrate rather than opening a second front in
+   `facts.rs`.
+4. **Leave C unscheduled** until B has landed and its limits are measured rather than predicted.
+
+## 5. What this spike deliberately does not do
+
+- **It does not pick an option.** D's question is a product call.
+- **It does not estimate.** The `Fact`-shape question in Option B moves the estimate by more than
+  any guess would be worth.
+- **It does not propose lifting `--experimental-security`.** That gate is the reason none of this is
+  urgent, and it should be the last thing to change, not the first.
+- **It does not re-litigate the presence tier.** `check_command.rs:2169` is a documented, pinned,
+  deliberate trade and is out of scope here.
+
+## 6. Corrections this spike carries
+
+`beta-claims.json:115`'s claim about `unsupported_dynamic_control_flow()` is stale (§1.4). It should
+be corrected in place whichever option is chosen, because it currently understates the tier and
+would distort any cost/benefit argument built on it.

--- a/packages/cli/src/check/diff.ts
+++ b/packages/cli/src/check/diff.ts
@@ -166,6 +166,33 @@ export function parseUnifiedDiff(input: string): ParsedDiff {
   if (current) {
     files.push(current);
   }
+
+  // R2a: a purely renamed file is IN scope, at its new path.
+  //
+  // BB-1 recorded these so an ordinary `git mv` would stop tripping the empty-scope refusal
+  // (run-check.ts:432-441), but recording is not scoping: `filesForConvention` maps over `files`
+  // and `diffStatusFor` looks the path up in the same array, so a file that appeared only in
+  // `renamedFiles` was never examined. Renaming a violating route made it invisible and the check
+  // reported clean - an enforcement bypass reachable from the documented workflow, because
+  // `git diff --unified=0` has rename detection on by default.
+  //
+  // `isAdded: false` and no changed lines, deliberately. The content did not change, so the move
+  // classifies `touched_existing` and the baseline still shields it. Marking it added would make
+  // every moved file's pre-existing violations block, which is the punishing-a-refactor failure the
+  // rename cases above exist to prevent - and it would land before finding fingerprints can survive
+  // a path change (finding-fingerprint.ts:45 hashes the path), so the debt would return as `new`
+  // with nothing to match it against.
+  //
+  // A rename that also carries an edit already entered `files` through its own `+++` header; the
+  // guard keeps it from being counted twice and preserves the changed lines it parsed.
+  const scoped = new Set(files.map((file) => file.path));
+  for (const renamed of [...renamedFiles].sort()) {
+    if (scoped.has(renamed)) {
+      continue;
+    }
+    files.push({ path: renamed, changedLines: new Set<number>(), isAdded: false });
+  }
+
   return {
     files,
     deletedFiles: [...deletedFiles].sort(),

--- a/packages/cli/test/diff-lifecycle.test.ts
+++ b/packages/cli/test/diff-lifecycle.test.ts
@@ -69,6 +69,79 @@ describe("renamed files", () => {
       "new_in_diff"
     );
   });
+
+  /**
+   * R2a: the PURE rename - `git mv` with no edit - which the cases above do not reach.
+   *
+   * At 100% similarity git emits rename metadata and *no* `---`/`+++`/`@@` at all, so the parser
+   * produced no file entry and the moved file left the convention's scope entirely:
+   * `filesForConvention` maps over `diff.files`, and `diffStatusFor` looks the path up in the same
+   * array. A violating route that was merely renamed was therefore not examined, and the check
+   * reported clean.
+   *
+   * That is an enforcement bypass reachable from the documented workflow, because
+   * `git diff --unified=0 <range>` (run-check.ts:495) has rename detection on by default. Verified
+   * against real git output, not a hand-written patch:
+   *
+   *   $ git mv app/api/x/route.ts app/api/x/handler.ts && git diff --cached --unified=0
+   *   diff --git a/app/api/x/route.ts b/app/api/x/handler.ts
+   *   similarity index 100%
+   *   rename from app/api/x/route.ts
+   *   rename to app/api/x/handler.ts
+   *
+   * The moved file must be IN scope. It must NOT become `new_in_diff`: the content is unchanged, so
+   * treating the move as newly-written code would convert baselined debt into blocking findings -
+   * the same punishment-for-refactoring this describe block exists to prevent.
+   */
+  const pureRename = parseUnifiedDiff(
+    [
+      "diff --git a/app/api/x/route.ts b/app/api/x/handler.ts",
+      "similarity index 100%",
+      "rename from app/api/x/route.ts",
+      "rename to app/api/x/handler.ts"
+    ].join("\n")
+  );
+
+  it("puts a purely renamed file in scope at its new path", () => {
+    expect(pureRename.renamedFiles).toEqual(["app/api/x/handler.ts"]);
+    expect(pureRename.files.map((file) => file.path)).toContain("app/api/x/handler.ts");
+  });
+
+  it("does not let a purely renamed file escape the diff", () => {
+    // Was "outside_diff" in both modes, which is what made the route invisible.
+    expect(diffStatusFor("app/api/x/handler.ts", 2, pureRename, "changed-files")).toBe(
+      "touched_existing"
+    );
+    expect(diffStatusFor("app/api/x/handler.ts", 2, pureRename, "changed-hunks")).toBe(
+      "touched_existing"
+    );
+  });
+
+  it("does not treat the move itself as newly written code", () => {
+    const [file] = pureRename.files;
+    expect(file?.isAdded).toBe(false);
+    expect(file?.changedLines.size).toBe(0);
+  });
+
+  it("leaves the old path out of scope", () => {
+    // The pre-rename path no longer exists in the worktree; scanning it would report on a file
+    // that is not there (the BB-9 shape, run-check.ts:459-473).
+    expect(pureRename.files.map((file) => file.path)).not.toContain("app/api/x/route.ts");
+    expect(diffStatusFor("app/api/x/route.ts", 2, pureRename, "changed-files")).toBe("outside_diff");
+  });
+
+  it("does not double-count a rename that also carries an edit", () => {
+    // renameWithEdit already enters `files` through its `+++` header. Adding rename metadata on
+    // top of that must not produce two entries for one file.
+    expect(renameWithEdit.files.filter((file) => file.path === "app/api/me2/route.ts")).toHaveLength(
+      1
+    );
+    // And the edit's changed line must survive: this is the regression that would turn
+    // "still reports a genuinely new violation inside a moved file" green for the wrong reason.
+    expect(diffStatusFor("app/api/me2/route.ts", 9, renameWithEdit, "changed-hunks")).toBe(
+      "new_in_diff"
+    );
+  });
 });
 
 describe("deleted files", () => {

--- a/packages/cli/test/empty-diff-scope-bb1.test.ts
+++ b/packages/cli/test/empty-diff-scope-bb1.test.ts
@@ -195,7 +195,17 @@ describe("BB-1 empty diff scope", () => {
     expect(JSON.parse(result.stdout).check.status).toBe("pass");
   });
 
-  it("says a rename is why it examined nothing", async () => {
+  it("examines the renamed file rather than reporting that it examined nothing", async () => {
+    // CHANGED BY R2a, deliberately. This previously asserted
+    // `Checked 0 files (1 renamed file unchanged)`.
+    //
+    // BB-1 correctly stopped a pure rename from tripping the empty-scope refusal, but it did so by
+    // treating the moved file as outside the scope and then explaining the emptiness. The file was
+    // never examined - which is right up until the moved file is the one carrying a violation, and
+    // then it is an enforcement bypass (see "a moved violation is still examined" below).
+    //
+    // BB-1's principle is preserved and strengthened: the scope is still reported honestly, and it
+    // is no longer empty, because there is genuinely something in it.
     const { repoId, databasePath, repoRoot } = await onboardGitRepo();
     await mkdir(join(repoRoot, "apps/web/app/api/moved"), { recursive: true });
     git(repoRoot, "mv", "apps/web/app/api/status/route.ts", "apps/web/app/api/moved/route.ts");
@@ -204,9 +214,29 @@ describe("BB-1 empty diff scope", () => {
       "--db", databasePath, "check", "--repo", repoId, "--diff", "HEAD"
     ]);
 
-    // Still visible that nothing was examined, and why - which is BB-1's whole point. Silence here
-    // would be the original bug wearing a different hat.
-    expect(result.stdout).toContain("Checked 0 files (1 renamed file unchanged)");
+    expect(result.stdout).toContain("Checked 1 file");
+  });
+
+  it("a moved violation is still examined - the bypass R2a closes", async () => {
+    // The reason R2a exists. `users/route.ts` is the VIOLATING fixture. Before R2a a pure rename
+    // emitted only rename metadata, so the parser produced no file entry, `filesForConvention`
+    // never saw the route, and the check reported a clean scope of zero files - renaming a
+    // violating route made it invisible.
+    //
+    // Reachable from the documented workflow: `git diff --unified=0 <range>` (run-check.ts:495) has
+    // rename detection on by default.
+    const { repoId, databasePath, repoRoot } = await onboardGitRepo();
+    await mkdir(join(repoRoot, "apps/web/app/api/relocated"), { recursive: true });
+    git(repoRoot, "mv", "apps/web/app/api/users/route.ts", "apps/web/app/api/relocated/route.ts");
+
+    const result = await runCli([
+      "--db", databasePath, "check", "--repo", repoId, "--diff", "HEAD", "--json"
+    ]);
+
+    const payload = JSON.parse(result.stdout);
+    expect(payload.summary.affected_scope.changed_file_count).toBe(1);
+    // The moved route is in scope at its new path, not silently dropped.
+    expect(JSON.stringify(payload)).toContain("apps/web/app/api/relocated/route.ts");
   });
 
   it("refuses an entirely empty diff with exit 3 and a named cause", async () => {

--- a/test/e2e/release-hygiene.test.ts
+++ b/test/e2e/release-hygiene.test.ts
@@ -97,7 +97,13 @@ describe("release hygiene", () => {
       // W7 added `pnpm eval:breadth`, the detection-breadth ratchet. Pinned whole for the same
       // reason as verify:ci above: an eval silently dropped is indistinguishable from one that
       // never existed.
-      "pnpm eval:external && pnpm eval:breadth && pnpm eval:evasion && pnpm eval:bench && pnpm eval:determinism"
+      //
+      // CV-4 then added `pnpm eval:presence` (the presence precision/recall measurement,
+      // scripts/presence-precision-recall.mjs) to package.json without updating this pin, so the
+      // pin has been failing on every branch since. Left unfixed it inverts its own purpose: a
+      // guard that is always red stops being read, and the next eval genuinely dropped would land
+      // in a test everyone has learned to skip.
+      "pnpm eval:external && pnpm eval:breadth && pnpm eval:evasion && pnpm eval:bench && pnpm eval:presence && pnpm eval:determinism"
     );
     expect(manifest.scripts["verify:full"]).toBe("pnpm verify:ci && pnpm verify:evals");
     expect(manifest.scripts["eval:evasion"]).toBe("node scripts/evasion-matrix.mjs");


### PR DESCRIPTION
Renaming a violating route made it invisible to `drift check`. This closes that, unblocks CI, and files the spike the control-flow tier has been waiting on.

Three independent commits. They can be split or cherry-picked in any order; `d2f40f37` is the one worth landing first, because `main` is red without it.

---

## `d3b27137` — R2a: a renamed file is in scope, at its new path

**The bug.** `git mv` with unchanged content emits only rename metadata and no `---`/`+++`/`@@` at all. Verified against real git output rather than a hand-written patch:

```
$ git mv app/api/x/route.ts app/api/x/handler.ts && git diff --cached --unified=0
diff --git a/app/api/x/route.ts b/app/api/x/handler.ts
similarity index 100%
rename from app/api/x/route.ts
rename to app/api/x/handler.ts
```

BB-1 already parsed those into `renamedFiles`, so an ordinary refactor stopped tripping the empty-scope refusal. **But recording is not scoping.** `renamedFiles` has exactly two consumers — the empty-scope refusal (`run-check.ts:440`) and a telemetry count (`:2979`). Neither is scope. `filesForConvention` maps over `files`, and `diffStatusFor` looks the path up in that same array, so a file present only in `renamedFiles` classified `outside_diff` and left the convention's scope entirely.

**Rename a violating route and `drift check --scope changed-files` reported a clean scope of zero files.** Reachable from the documented workflow: `git diff --unified=0 <range>` (`run-check.ts:495`) has rename detection on by default — the user never chooses it.

**Scoped deliberately short of the fingerprint half.** The moved file enters with `isAdded: false` and no changed lines, so it classifies `touched_existing` and the baseline still shields it. Marking it added would make every moved file's pre-existing violations block — the punishing-a-refactor failure the surrounding rename cases exist to prevent — and `finding-fingerprint.ts:45` hashes the path, so that debt would return as `new` with nothing to match it against. Closing that half needs the `legacy_fingerprints` treatment (`rules.rs:71-77`) and is left as R2b.

**Tests, red first.** Five new/changed assertions, each verified non-vacuous by reverting only `diff.ts`:

```
× puts a purely renamed file in scope at its new path   → expected [] to include 'app/api/x/handler.ts'
× does not let a purely renamed file escape the diff    → expected 'outside_diff' to be 'touched_existing'
× does not treat the move itself as newly written code  → expected undefined to be false
× examines the renamed file rather than ...             → expected ... to contain 'Checked 1 file'
× a moved violation is still examined                   → expected +0 to be 1
```

Two guard tests were written to stay green and did: the old path stays out of scope, and a rename that also carries an edit is not double-counted and keeps its changed lines.

**One existing assertion changed, deliberately.** `empty-diff-scope-bb1.test.ts` asserted `Checked 0 files (1 renamed file unchanged)`; it now asserts `Checked 1 file`, and the test is renamed to say so. BB-1's principle is preserved and strengthened — the scope is still reported honestly, and it is no longer empty because there is genuinely something in it.

---

## `d2f40f37` — the `verify:evals` pin has been red since CV-4

`main` fails `pnpm verify:ci` today, and so does every branch cut from it:

```
Expected: "... && pnpm eval:bench && pnpm eval:determinism"
Received: "... && pnpm eval:bench && pnpm eval:presence && pnpm eval:determinism"
```

CV-4 added `pnpm eval:presence` to `package.json` and did not update the pin at `release-hygiene.test.ts:96`.

Two things look alike here and are not. `verify:evals` itself does **not** run in CI — `ci.yml:3-5` says so, because the evals need seven pinned repos and a release binary a hosted runner does not have. But this *test* runs, inside `test:e2e` inside `pnpm verify`, so the pin fails CI even though the thing it pins never executes there.

Left alone it inverts its own purpose: a guard that is always red stops being read, and the next eval genuinely dropped would land in a test everyone has learned to skip. The script is real and shipped; the pin is what is stale, so the pin is what moves.

---

## `a6902259` — control-flow tier rebuild spike (docs only)

The heuristic audit's standing instruction is *"lift when the layer is rebuilt on AST analysis"* — an outcome with no design, which is why no TDD plan has been writable against it. This frames the decision rather than pretending to make it.

Verified rather than carried forward: guard dominance really is a line-number comparison (`security_control_flow.rs:42-61`); the file is at 48 `.contains()` calls, up from 26; and it is **not** uniformly naive — `safe_parse_success_guard_dominates:472` already strips strings and line comments, so the absence of a file-wide policy is the more actionable finding than the raw count. The secret-exposure taint problem is the same design gap, not a second one.

**And one correction.** `beta-claims.json:115` says `unsupported_dynamic_control_flow()` *"matches only Drift fixture strings"*. That is stale — `security_control_flow.rs:175-197` is structural now and filters comment-leading lines. Any cost/benefit argument quoting that claim is arguing from a fact that has been fixed.

The spike picks no option: whether Drift intends to make control-flow claims at all is a product decision, and `--experimental-security` is why none of it is urgent.

---

## Verification

`pnpm verify:ci` — exit 0, captured directly rather than through a pipe.

| stage | result |
|---|---|
| package suites | adapters 12, core 224, factgraph 8, engine-contract 31, storage 60, query 76, mcp 67, **cli 710** |
| e2e | 33 files, 157 tests |
| gates | storage lifecycle, storage invariants, error contract, vocabulary parity (163 members), surface parity (611 CLI / 131 MCP bodies), payload invariants (242 payloads, 469 discriminators), cell ledger (18 cells) |

Built on an isolated worktree from `origin/main @ 5e86e89a`, with no file overlap with the security-convention plan in flight (`diff.ts` and `release-hygiene.test.ts` are touched by no sprint in it).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
