### PR TITLE
feat(cli,engine): resolve what an accepted security helper actually points at

### DIFF
--- a/crates/drift-engine/src/protocol.rs
+++ b/crates/drift-engine/src/protocol.rs
@@ -549,6 +549,30 @@ pub struct CheckMatcher {
     /// re-export of the same module through (T93).
     #[serde(default)]
     pub forbidden_module_files: Option<Vec<String>>,
+    /// What each accepted security helper's import specifier actually resolves to.
+    ///
+    /// S3-03: computed CLI-side for the same structural reason as `forbidden_module_files` above -
+    /// the engine's graph is scoped to the changed files, so it cannot resolve a specifier whose
+    /// meaning is established by imports outside the diff. The CLI has the whole graph.
+    ///
+    /// It arrives on the matcher rather than inside `requires` deliberately. `requires` is the
+    /// stored contract - what a human accepted - and it crosses this boundary as an untyped
+    /// `Option<Value>`, so a CLI derivation placed there would both blur contract with derivation
+    /// and lose its shape on the way. Typed here, a rename fails the build instead of shipping.
+    ///
+    /// Accepted and ignored as of this sprint: nothing reads it, and no engine behaviour depends on
+    /// it. It exists so the next sprint can replace name-only and specifier-string helper matching
+    /// with resolved module identity.
+    ///
+    /// `allow(dead_code)` is load-bearing rather than lazy, and it is temporary. `lint:engine` runs
+    /// clippy with `-D warnings`, so an unread field fails the build - correctly, in general. Here
+    /// the field is deliberately inert for exactly one sprint: shipping the wire shape first means
+    /// the consumer lands against a field the CLI is already populating and the round trip is
+    /// already proven, rather than both arriving together untested. Delete this attribute when
+    /// helper matching starts reading it; if it is still here after that, the consumer never landed.
+    #[serde(default)]
+    #[allow(dead_code)]
+    pub accepted_helper_module_files: Option<Vec<AcceptedHelperModuleFiles>>,
     // `allowed_delegate_imports` was here, read by nothing. It was the only configurable field
     // of api_route_requires_service_delegation's matcher, and that kind's evaluator took it as
     // `_allowed_delegate_imports` and never looked at it - so an author who narrowed their
@@ -569,6 +593,36 @@ pub struct CheckMatcher {
     /// CV-2: the route flavours this convention is about. Absent or empty means all of them.
     #[serde(default)]
     pub applies_to_route_flavors: Option<Vec<String>>,
+}
+
+/// One accepted security helper's resolved module identity, and how that answer was reached.
+///
+/// `mode` carries as much of the answer as `files` does, and a consumer that reads one without the
+/// other will be wrong in the common case:
+///
+///   - `repo_resolved` - the specifier resolved inside the repo; `files` is the identity, re-export
+///     chains already followed. Match on resolved file.
+///   - `external` - a bare package specifier that resolved to nothing, which is not a failure:
+///     `resolve_import` filters to paths inside the scan snapshot, so `next-auth` and everything
+///     else under `node_modules` never produces an edge. `files` is empty and always will be.
+///     Match on the exact specifier, plus a local-shadow check.
+///   - `unresolved` - a repo-relative specifier that resolved to nothing. Also empty `files`, but
+///     this one is a degradation and belongs in the proof as one.
+///
+/// Reading an empty `files` as "this helper matches nothing" would therefore flag every route that
+/// correctly uses an external auth helper - the most common real-world contract there is.
+/// Inert for one sprint by design - see `CheckMatcher::accepted_helper_module_files`.
+#[derive(Debug, Deserialize)]
+#[allow(dead_code)]
+pub struct AcceptedHelperModuleFiles {
+    pub symbol: String,
+    pub mode: String,
+    #[serde(default)]
+    pub files: Vec<String>,
+    /// The tsconfig-paths hijack shape: the contract names a package and the repo has pointed that
+    /// name at a file it controls. Present only when true, and never to be silently accepted.
+    #[serde(default)]
+    pub external_specifier_resolves_in_repo: Option<bool>,
 }
 
 #[derive(Debug, Deserialize)]

--- a/crates/drift-engine/src/protocol.rs
+++ b/crates/drift-engine/src/protocol.rs
@@ -619,7 +619,16 @@ pub struct CheckMatcher {
 #[derive(Debug, Deserialize)]
 #[allow(dead_code)]
 pub struct AcceptedHelperModuleFiles {
+    /// Which `requires` list this helper came from - `auth_helpers`, `csrf_helpers`, and so on.
+    ///
+    /// Part of the identity. `symbol` is unique WITHIN a list and not across them, and this engine
+    /// already reads the lists separately (`accepted_auth_helpers_for_convention`,
+    /// `phase6_helpers_from_requires`, `security_helpers_from_requires` each build their own map),
+    /// so a name reused by an auth helper and a response serializer is two helpers here too.
+    pub requires_key: String,
     pub symbol: String,
+    /// The specifier as the contract typed it. `external` and `unresolved` match on this.
+    pub specifier: String,
     pub mode: String,
     #[serde(default)]
     pub files: Vec<String>,

--- a/crates/drift-engine/src/protocol.rs
+++ b/crates/drift-engine/src/protocol.rs
@@ -605,7 +605,11 @@ pub struct CheckMatcher {
 /// other will be wrong in the common case:
 ///
 ///   - `repo_resolved` - the specifier resolved inside the repo; `files` is the identity, re-export
-///     chains already followed. Match on resolved file.
+///     chains already followed. Match on resolved file. The chain is filtered by the helper's
+///     symbol, so a barrel that re-exports both the helper and an unrelated module contributes only
+///     the module that exports the symbol - but the filter compares symbol NAMES, so a barrel
+///     re-exporting one name from two modules yields both. `files` means "modules that plausibly
+///     supply this helper", not "modules proven to be it".
 ///   - `external` - a bare package specifier that resolved to nothing, which is not a failure:
 ///     `resolve_import` filters to paths inside the scan snapshot, so `next-auth` and everything
 ///     else under `node_modules` never produces an edge. `files` is empty and always will be.

--- a/crates/drift-engine/src/protocol.rs
+++ b/crates/drift-engine/src/protocol.rs
@@ -567,9 +567,13 @@ pub struct CheckMatcher {
     /// `allow(dead_code)` is load-bearing rather than lazy, and it is temporary. `lint:engine` runs
     /// clippy with `-D warnings`, so an unread field fails the build - correctly, in general. Here
     /// the field is deliberately inert for exactly one sprint: shipping the wire shape first means
-    /// the consumer lands against a field the CLI is already populating and the round trip is
-    /// already proven, rather than both arriving together untested. Delete this attribute when
-    /// helper matching starts reading it; if it is still here after that, the consumer never landed.
+    /// the consumer lands against a field the CLI already populates over a round trip that is
+    /// already exercised, rather than both arriving together untested. That the CLI really does
+    /// populate it on a real run is pinned by `accepted-helper-identity-dispatch.test.ts`, which
+    /// reads the JSON that actually crossed this boundary - the first wiring of this field went to
+    /// a dispatch loop whose only kind carries no helpers, so it was never emitted at all, and no
+    /// unit test of the request builder could see that. Delete this attribute when helper matching
+    /// starts reading the field; if it is still here after that, the consumer never landed.
     #[serde(default)]
     #[allow(dead_code)]
     pub accepted_helper_module_files: Option<Vec<AcceptedHelperModuleFiles>>,

--- a/crates/drift-engine/src/protocol.rs
+++ b/crates/drift-engine/src/protocol.rs
@@ -633,13 +633,33 @@ pub struct AcceptedHelperModuleFiles {
     pub symbol: String,
     /// The specifier as the contract typed it. `external` and `unresolved` match on this.
     pub specifier: String,
-    pub mode: String,
+    /// Typed, so that a mode this engine does not know fails the request instead of being read as
+    /// some default. The placement rationale above promises that a rename fails the build rather
+    /// than shipping; that promise is worth nothing if the VALUES stay free-form strings.
+    pub mode: AcceptedHelperResolutionMode,
     #[serde(default)]
     pub files: Vec<String>,
-    /// The tsconfig-paths hijack shape: the contract names a package and the repo has pointed that
-    /// name at a file it controls. Present only when true, and never to be silently accepted.
+    /// A package-shaped specifier that resolves to a repo file.
+    ///
+    /// A fact, not a verdict. It is the tsconfig-paths hijack shape, and equally the shape of a
+    /// pnpm workspace package or a scoped path alias (`"@app/*": ["src/*"]`) - the same mechanism,
+    /// different intent, and nothing available here separates them. Input to the local-shadow check
+    /// the `External` mode calls for, never a finding on its own.
     #[serde(default)]
-    pub external_specifier_resolves_in_repo: Option<bool>,
+    pub package_specifier_resolves_in_repo: Option<bool>,
+}
+
+/// How a helper's module identity was arrived at. See `AcceptedHelperModuleFiles::mode`.
+#[derive(Debug, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "snake_case")]
+#[allow(dead_code)]
+pub enum AcceptedHelperResolutionMode {
+    /// Resolved inside the repo; `files` is the identity.
+    RepoResolved,
+    /// A bare package specifier that resolved to nothing - by design, not by failure.
+    External,
+    /// A repo-relative specifier that resolved to nothing. A degradation, and belongs in the proof.
+    Unresolved,
 }
 
 #[derive(Debug, Deserialize)]

--- a/packages/adapters/src/index.ts
+++ b/packages/adapters/src/index.ts
@@ -116,6 +116,25 @@ export const AdapterGraphNodeSchema = z.object({
 
 export const AdapterGraphEdgeSchema = z.object({
   id: z.string().min(1),
+  /**
+   * S3-05, latent: this is any non-empty string, NOT the `graph_edge_kind` vocabulary.
+   *
+   * Harmless today only because `@drift/adapters` has zero dependents - nothing can inject an edge
+   * into a scan through this schema, so the looseness costs nothing yet.
+   *
+   * It stops being harmless the moment adapters are wired into the scan path. The check path treats
+   * `IMPORT_RESOLVES_TO_MODULE` as ground truth about what an import specifier MEANS: accepted
+   * security helper identity reports `mode: "repo_resolved"` on the strength of one
+   * (`resolvedHelperIdentities` in `packages/cli/src/check/run-check.ts`), and forbidden-import
+   * matching decides violations on them. That trust rests on those edges coming from the Rust
+   * resolver, which the TypeScript-fallback refusal is what guarantees. An adapter free to emit a
+   * string spelled `IMPORT_RESOLVES_TO_MODULE` would route around that guarantee entirely, and
+   * would be choosing what the pipeline believes a specifier resolves to.
+   *
+   * So: whoever wires adapters into the scan path types this against the generated vocabulary
+   * (`GraphEdgeKindSchema`) FIRST, before the first adapter-sourced edge reaches a check. Same for
+   * `AdapterGraphNodeSchema.kind` above.
+   */
   kind: z.string().min(1),
   from: z.string().min(1),
   to: z.string().min(1),

--- a/packages/cli/src/check/contract-liveness.ts
+++ b/packages/cli/src/check/contract-liveness.ts
@@ -6,7 +6,7 @@ import { isForbiddenImport } from "./rule-evaluation.js";
 /**
  * BB-4: is this contract's trigger still connected to anything?
  *
- * `forbiddenModuleFiles_` derives a forbidden module's identity from the repo's own resolved import
+ * `resolvedModuleFilesFor` derives a forbidden module's identity from the repo's own resolved import
  * edges, falling back to specifier-string matching when resolution yields nothing. That is the right
  * design - it is what closed the `../../../lib/prisma` and barrel-re-export bypasses (T93) - but it
  * has a silent failure mode. Rename `apps/web/lib/prisma` to `apps/web/lib/database` and update every

--- a/packages/cli/src/check/run-check.ts
+++ b/packages/cli/src/check/run-check.ts
@@ -3823,8 +3823,8 @@ interface GraphIndex {
   endpointNodesByFile: Map<string, ScanData["graph_nodes"]>;
   dataOperationNodesByFile: Map<string, ScanData["graph_nodes"]>;
   reexportTargets: Map<string, string[]>;
-  /** Forbidden specifiers joined by NUL -> the files they resolve to. */
-  forbiddenModuleFilesByKey: Map<string, Set<string>>;
+  /** Specifiers joined by NUL -> the files they resolve to. Shared by every specifier list. */
+  resolvedModuleFilesByKey: Map<string, Set<string>>;
 }
 
 const graphIndexes = new WeakMap<ScanData, GraphIndex>();
@@ -3893,7 +3893,7 @@ function graphIndexFor(checkData: ScanData): GraphIndex {
     endpointNodesByFile,
     dataOperationNodesByFile,
     reexportTargets: moduleReexportTargets(checkData),
-    forbiddenModuleFilesByKey: new Map()
+    resolvedModuleFilesByKey: new Map()
   };
   graphIndexes.set(checkData, index);
   return index;
@@ -3947,22 +3947,37 @@ function graphImportResolvesToForbidden(
 }
 
 /**
- * Files that the convention's forbidden specifiers actually resolve to.
+ * Repo files that a set of import specifiers actually resolve to.
  *
  * Derived from the repo's own resolved imports rather than by re-resolving, so it needs no second
- * resolver and cannot disagree with the one that built the graph. Empty when nothing imports a
- * forbidden specifier resolvably, in which case matching falls back to specifiers exactly as
- * before - a repo that never exercised the resolver cannot regress.
+ * resolver and cannot disagree with the one that built the graph.
+ *
+ * This is the general form of what `forbiddenModuleFiles_` used to be on its own. The question -
+ * "what does this specifier MEAN, as opposed to how is it spelled" - is not specific to forbidden
+ * imports; the accepted-security-helper side needs the identical answer about a different specifier
+ * list. A second walk over `IMPORT_RESOLVES_TO_MODULE` written for that caller could drift out of
+ * agreement with this one, and two resolvers that disagree about module identity is precisely the
+ * defect this pipeline already has at the string level.
+ *
+ * Empty is a real and common answer, not a failure: the Rust `resolve_import` filters to paths
+ * inside the scan snapshot, so a bare package name (`next-auth`, anything under `node_modules`)
+ * produces no edge by design. Callers must classify that emptiness themselves rather than read it
+ * as "no such module" - see `resolvedHelperIdentities`.
  *
  * A lookalike module (`@/lib/prisma-legacy`) resolves to its own distinct file and never lands
  * here, which is what keeps the T03 negative control green.
+ *
+ * `isForbiddenImport` is the specifier-match predicate, kept under its original name: it is exact
+ * match plus a `/`-bounded subpath match, which is the right relation for a module specifier
+ * regardless of whether the list it came from is a forbidden one or an accepted one.
  */
-function forbiddenModuleFiles_(checkData: ScanData, forbiddenImports: string[]): Set<string> {
+export function resolvedModuleFilesFor(checkData: ScanData, specifiers: string[]): Set<string> {
   const index = graphIndexFor(checkData);
-  // Memoised per specifier set: called once per import via graphImportResolvesToForbidden, and
-  // again per convention at :2575, always with the same forbidden list within one convention.
-  const cacheKey = forbiddenImports.join("\0");
-  const cached = index.forbiddenModuleFilesByKey.get(cacheKey);
+  // Memoised per specifier set: called once per import via graphImportResolvesToForbidden, once per
+  // convention when building the engine request, and once per accepted helper. Same specifier set
+  // means same answer, so forbidden and accepted callers can share one cache without interfering.
+  const cacheKey = specifiers.join("\0");
+  const cached = index.resolvedModuleFilesByKey.get(cacheKey);
   if (cached) {
     return cached;
   }
@@ -3974,7 +3989,7 @@ function forbiddenModuleFiles_(checkData: ScanData, forbiddenImports: string[]):
     }
     const importNode = nodesById.get(edge.from);
     const source = importNode ? stringMetadata(importNode.metadata, "source") : undefined;
-    if (!source || !isForbiddenImport(source, forbiddenImports)) {
+    if (!source || !isForbiddenImport(source, specifiers)) {
       continue;
     }
     const target = nodesById.get(edge.to);
@@ -3983,8 +3998,18 @@ function forbiddenModuleFiles_(checkData: ScanData, forbiddenImports: string[]):
       files.add(targetPath);
     }
   }
-  index.forbiddenModuleFilesByKey.set(cacheKey, files);
+  index.resolvedModuleFilesByKey.set(cacheKey, files);
   return files;
+}
+
+/**
+ * Files that the convention's forbidden specifiers actually resolve to.
+ *
+ * Exported for the S3-01 characterization lock, which pins that generalising the resolver did not
+ * move the answer the T93 bypass closures ride on.
+ */
+export function forbiddenModuleFiles_(checkData: ScanData, forbiddenImports: string[]): Set<string> {
+  return resolvedModuleFilesFor(checkData, forbiddenImports);
 }
 
 /** module id -> modules it re-exports, for chain walking. */

--- a/packages/cli/src/check/run-check.ts
+++ b/packages/cli/src/check/run-check.ts
@@ -3188,10 +3188,8 @@ async function runEngineOwnedDirectDataAccessCheck(input: {
     const forbiddenModuleFiles = [
       ...resolvedModuleFilesFor(input.checkData, convention.matcher.forbidden_imports ?? [])
     ];
-    const acceptedHelperModuleFiles = resolvedHelperIdentities(input.checkData, convention);
     const result = await runEngineCheck({
       forbiddenModuleFiles,
-      acceptedHelperModuleFiles,
       repoId: input.repoId,
       repoRoot: input.repoRoot,
       scanId: input.checkData.snapshots[0]?.scan_id ?? input.checkScanId,
@@ -3372,6 +3370,15 @@ async function runEngineOwnedAuthCheck(input: {
       contractWaivers: input.contract.waivers,
       facts: input.checkData.facts.filter((fact) => fileSet.has(fact.file_path)),
       snapshots: input.checkData.snapshots.filter((snapshot) => fileSet.has(snapshot.file_path)),
+      // Computed from `input.checkData` - the WHOLE graph - not from the per-convention file set
+      // just narrowed above. The imports that establish what an accepted helper's specifier means
+      // live in the helper's own module, which is virtually never one of the routes in scope.
+      //
+      // This is the loop that dispatches all twelve helper-bearing security kinds, and therefore
+      // the only loop where this field is ever non-empty. It was first wired into the
+      // direct-data-access loop, which evaluates one kind that carries no `requires` helpers at
+      // all - so it was computed where there was nothing to compute and omitted where there was.
+      acceptedHelperModuleFiles: resolvedHelperIdentities(input.checkData, convention),
       conventions: [convention],
       baseline: input.baseline,
       diff: input.parsedDiff,

--- a/packages/cli/src/check/run-check.ts
+++ b/packages/cli/src/check/run-check.ts
@@ -4004,7 +4004,12 @@ export function resolvedModuleFilesFor(
   // convention when building the engine request, and once per accepted helper. Same specifier set
   // means same answer, so forbidden and accepted callers can share one cache without interfering -
   // as long as the relation is part of the key, because the two relations give different answers.
-  const cacheKey = `${match}\0${specifiers.join("\0")}`;
+  //
+  // Encoded structurally rather than joined. A NUL join is ambiguous: `["a", "b"]` and the single
+  // specifier `"a\0b"` produce one key, and the second caller silently receives the first one's
+  // answer. No real specifier contains a NUL, but the key is built from caller-supplied contract
+  // data and a wrong answer here is a wrong verdict about an import.
+  const cacheKey = cacheKeyFor(match, specifiers);
   const cached = index.resolvedModuleFilesByKey.get(cacheKey);
   if (cached) {
     return cached;
@@ -4030,6 +4035,11 @@ export function resolvedModuleFilesFor(
  */
 export type SpecifierMatch = "specifier_or_subpath" | "exact_specifier";
 
+/** An encoding no specifier list can forge, unlike a separator join. */
+function cacheKeyFor(match: SpecifierMatch, specifiers: string[]): string {
+  return JSON.stringify([match, specifiers]);
+}
+
 function specifierMatches(source: string, specifiers: string[], match: SpecifierMatch): boolean {
   return match === "exact_specifier"
     ? specifiers.includes(source)
@@ -4050,7 +4060,7 @@ function resolvedModuleNodeIdsFor(
   match: SpecifierMatch
 ): Set<string> {
   const index = graphIndexFor(checkData);
-  const cacheKey = `${match}\0${specifiers.join("\0")}`;
+  const cacheKey = cacheKeyFor(match, specifiers);
   const cached = index.resolvedModuleNodesByKey.get(cacheKey);
   if (cached) {
     return cached;
@@ -4128,12 +4138,19 @@ export interface AcceptedHelperIdentity {
    */
   files: string[];
   /**
-   * The tsconfig-paths hijack shape: the contract names what looks like a package, and the repo has
-   * quietly pointed that name at a file it controls. Present only when true, and never silently
-   * accepted - a resolution-based matcher that swallowed this would be worse than the string one it
-   * replaces.
+   * The contract names something package-shaped, and it resolves to a file in this repo.
+   *
+   * A FACT, not a verdict, and deliberately not named for one. This is the tsconfig-paths hijack
+   * shape - a package name quietly pointed at a file the repo controls - but it is equally the
+   * shape of a pnpm workspace package and of an ordinary scoped path alias like
+   * `"@app/*": ["src/*"]`. Nothing here can tell those apart, because they are the same mechanism
+   * used with different intent. Naming this after the attack would have fired an "attack" alarm on
+   * routine configurations, and an alarm that cries wolf is one nobody reads when it is right.
+   *
+   * Present only when true. It is the input to the local-shadow check the matching rule for
+   * `external` calls for - not a finding on its own.
    */
-  external_specifier_resolves_in_repo?: true;
+  package_specifier_resolves_in_repo?: true;
 }
 
 /**
@@ -4276,7 +4293,7 @@ function helperIdentityFor(
     specifier,
     mode: "repo_resolved",
     files: [...files].sort(),
-    ...(bare ? { external_specifier_resolves_in_repo: true as const } : {})
+    ...(bare ? { package_specifier_resolves_in_repo: true as const } : {})
   };
 }
 

--- a/packages/cli/src/check/run-check.ts
+++ b/packages/cli/src/check/run-check.ts
@@ -7,6 +7,7 @@ import {
   type FactRecord,
   type FileRole,
   type Finding,
+  type AcceptedConvention,
   type MachineContractVersions,
   type RequiredCheckExecution,
   type RepoContract,
@@ -3825,6 +3826,8 @@ interface GraphIndex {
   reexportTargets: Map<string, string[]>;
   /** Specifiers joined by NUL -> the files they resolve to. Shared by every specifier list. */
   resolvedModuleFilesByKey: Map<string, Set<string>>;
+  /** Specifiers joined by NUL -> the module NODES they resolve to, before re-export walking. */
+  resolvedModuleNodesByKey: Map<string, Set<string>>;
 }
 
 const graphIndexes = new WeakMap<ScanData, GraphIndex>();
@@ -3893,7 +3896,8 @@ function graphIndexFor(checkData: ScanData): GraphIndex {
     endpointNodesByFile,
     dataOperationNodesByFile,
     reexportTargets: moduleReexportTargets(checkData),
-    resolvedModuleFilesByKey: new Map()
+    resolvedModuleFilesByKey: new Map(),
+    resolvedModuleNodesByKey: new Map()
   };
   graphIndexes.set(checkData, index);
   return index;
@@ -3967,21 +3971,70 @@ function graphImportResolvesToForbidden(
  * A lookalike module (`@/lib/prisma-legacy`) resolves to its own distinct file and never lands
  * here, which is what keeps the T03 negative control green.
  *
- * `isForbiddenImport` is the specifier-match predicate, kept under its original name: it is exact
- * match plus a `/`-bounded subpath match, which is the right relation for a module specifier
- * regardless of whether the list it came from is a forbidden one or an accepted one.
+ * Two specifier relations, and they are NOT interchangeable - see `SpecifierMatch`.
  */
-export function resolvedModuleFilesFor(checkData: ScanData, specifiers: string[]): Set<string> {
+export function resolvedModuleFilesFor(
+  checkData: ScanData,
+  specifiers: string[],
+  match: SpecifierMatch = "specifier_or_subpath"
+): Set<string> {
   const index = graphIndexFor(checkData);
   // Memoised per specifier set: called once per import via graphImportResolvesToForbidden, once per
   // convention when building the engine request, and once per accepted helper. Same specifier set
-  // means same answer, so forbidden and accepted callers can share one cache without interfering.
-  const cacheKey = specifiers.join("\0");
+  // means same answer, so forbidden and accepted callers can share one cache without interfering -
+  // as long as the relation is part of the key, because the two relations give different answers.
+  const cacheKey = `${match}\0${specifiers.join("\0")}`;
   const cached = index.resolvedModuleFilesByKey.get(cacheKey);
   if (cached) {
     return cached;
   }
-  const files = new Set<string>();
+  const files = moduleFilesForNodeIds(resolvedModuleNodeIdsFor(checkData, specifiers, match), index);
+  index.resolvedModuleFilesByKey.set(cacheKey, files);
+  return files;
+}
+
+/**
+ * How a resolved import's specifier is compared against a convention's specifier list.
+ *
+ * `specifier_or_subpath` is `isForbiddenImport`: the specifier, or anything beneath it at a `/`
+ *   boundary. Right for a PROHIBITION, where `@/lib/prisma` is meant to cover `@/lib/prisma/edge`
+ *   as well - broadening a ban only ever bans more.
+ * `exact_specifier` is equality. Right for an ACCEPTANCE, where the specifier names one module.
+ *
+ * Using the first relation on an accepted-helper list is a laundering bug, not a nuance. A helper
+ * accepted at `@/lib` would silently absorb `@/lib/attacker-controlled`, so any module a caller can
+ * add under that prefix becomes the accepted helper's module and produces a passing auth proof.
+ * Broadening a ban is safe; broadening an acceptance is the exact failure this sprint exists to
+ * stop shipping.
+ */
+export type SpecifierMatch = "specifier_or_subpath" | "exact_specifier";
+
+function specifierMatches(source: string, specifiers: string[], match: SpecifierMatch): boolean {
+  return match === "exact_specifier"
+    ? specifiers.includes(source)
+    : isForbiddenImport(source, specifiers);
+}
+
+/**
+ * The same resolution, stopped one step earlier: the module NODES the specifiers reach.
+ *
+ * `resolvedModuleFilesFor` is the answer nearly every caller wants, but a re-export chain is walked
+ * over node ids, and a file path cannot be walked back to a node without a second index. Splitting
+ * here keeps one walk over `IMPORT_RESOLVES_TO_MODULE` behind both answers - the S3-01
+ * characterization lock is what says the split did not move the file-level answer.
+ */
+function resolvedModuleNodeIdsFor(
+  checkData: ScanData,
+  specifiers: string[],
+  match: SpecifierMatch
+): Set<string> {
+  const index = graphIndexFor(checkData);
+  const cacheKey = `${match}\0${specifiers.join("\0")}`;
+  const cached = index.resolvedModuleNodesByKey.get(cacheKey);
+  if (cached) {
+    return cached;
+  }
+  const nodeIds = new Set<string>();
   const { nodesById } = index;
   for (const edge of checkData.graph_edges) {
     if (edge.kind !== "IMPORT_RESOLVES_TO_MODULE") {
@@ -3989,16 +4042,24 @@ export function resolvedModuleFilesFor(checkData: ScanData, specifiers: string[]
     }
     const importNode = nodesById.get(edge.from);
     const source = importNode ? stringMetadata(importNode.metadata, "source") : undefined;
-    if (!source || !isForbiddenImport(source, specifiers)) {
+    if (!source || !specifierMatches(source, specifiers, match)) {
       continue;
     }
-    const target = nodesById.get(edge.to);
-    const targetPath = target ? stringMetadata(target.metadata, "file_path") : undefined;
-    if (targetPath) {
-      files.add(targetPath);
+    nodeIds.add(edge.to);
+  }
+  index.resolvedModuleNodesByKey.set(cacheKey, nodeIds);
+  return nodeIds;
+}
+
+function moduleFilesForNodeIds(nodeIds: Set<string>, index: GraphIndex): Set<string> {
+  const files = new Set<string>();
+  for (const nodeId of nodeIds) {
+    const node = index.nodesById.get(nodeId);
+    const filePath = node ? stringMetadata(node.metadata, "file_path") : undefined;
+    if (filePath) {
+      files.add(filePath);
     }
   }
-  index.resolvedModuleFilesByKey.set(cacheKey, files);
   return files;
 }
 
@@ -4010,6 +4071,209 @@ export function resolvedModuleFilesFor(checkData: ScanData, specifiers: string[]
  */
 export function forbiddenModuleFiles_(checkData: ScanData, forbiddenImports: string[]): Set<string> {
   return resolvedModuleFilesFor(checkData, forbiddenImports);
+}
+
+/**
+ * How the answer about a helper's module was arrived at - which is as much of the answer as the
+ * files are.
+ *
+ * `repo_resolved` - the specifier produced resolution edges, so the helper has a file identity and
+ *   matching can compare resolved files, re-export chains included.
+ * `external` - a bare package specifier that resolved to nothing. NOT a failure: the Rust
+ *   `resolve_import` filters to paths inside the scan snapshot, so anything in `node_modules`
+ *   resolves to nothing by design. Matching stays on the specifier, plus a local-shadow check.
+ * `unresolved` - a repo-relative specifier that resolved to nothing. Matching stays on the
+ *   specifier too, but this one is a degradation and has to be recorded as one, because a repo
+ *   specifier that resolves to nothing means the graph could not answer.
+ */
+export type AcceptedHelperResolutionMode = "repo_resolved" | "external" | "unresolved";
+
+export interface AcceptedHelperIdentity {
+  symbol: string;
+  mode: AcceptedHelperResolutionMode;
+  /** Repo-relative, sorted, deduped. Empty for every mode but `repo_resolved`. */
+  files: string[];
+  /**
+   * The tsconfig-paths hijack shape: the contract names what looks like a package, and the repo has
+   * quietly pointed that name at a file it controls. Present only when true, and never silently
+   * accepted - a resolution-based matcher that swallowed this would be worse than the string one it
+   * replaces.
+   */
+  external_specifier_resolves_in_repo?: true;
+}
+
+/**
+ * The `requires` keys that carry accepted security helpers, and the three different names the
+ * module field goes by underneath them.
+ *
+ * `auth_helpers` and `validators` spell it `import`; the Phase 6 kinds (`csrf_helpers`,
+ * `rate_limit_helpers`, `outbound_url_allowlist_helpers`) spell it `module`; `response_serializers`
+ * spells it `import_source`. Those are the spellings `check_command.rs` emits and reads back -
+ * `phase6_helpers_from_requires` and `security_helpers_from_requires` take `module`,
+ * `accepted_auth_helpers_for_convention` takes the auth shape. A resolver that knew only one
+ * spelling would return a confident, silently partial answer, which is the failure mode this whole
+ * sprint exists to stop reproducing.
+ */
+const ACCEPTED_HELPER_REQUIRES_KEYS = [
+  "auth_helpers",
+  "validators",
+  "csrf_helpers",
+  "rate_limit_helpers",
+  "outbound_url_allowlist_helpers",
+  "response_serializers"
+] as const;
+
+const HELPER_SYMBOL_KEYS = ["symbol", "name", "imported_name", "local_name"] as const;
+const HELPER_MODULE_KEYS = ["import", "module", "import_source"] as const;
+
+/**
+ * What each accepted security helper's import specifier actually resolves to, and how we know.
+ *
+ * This is tier-2 identity: resolved module, not imported name (tier 0, which accepts any module
+ * exporting the right symbol - the laundering shape) and not the specifier as typed (tier 1, which
+ * makes `../../lib/auth` and `@/lib/auth` disagree about one file and fails every barrel and every
+ * renamed import). Tier 1 is not a stronger tier 0; only this dominates both.
+ *
+ * It lives in TypeScript because it structurally cannot live in Rust. The engine receives a graph
+ * scoped to the CHANGED FILES, so it cannot derive what a specifier means - the imports that
+ * establish the meaning live in files outside the diff. The CLI has the whole graph.
+ *
+ * The mode is per HELPER, never per convention, and that is the load-bearing decision. A
+ * per-convention "the table came back empty, fall back to strings" would permanently and silently
+ * retain tier-1 semantics for every external auth helper - `next-auth`, `@clerk/nextjs`, the most
+ * common real-world contract there is - because those resolve to nothing by design and always will.
+ * Recording the mode is what makes that degradation visible instead of assumed.
+ *
+ * Helpers with no module specifier at all (the engine accepts a bare string in `auth_helpers`) are
+ * absent from the result rather than reported as `unresolved`. There is no specifier to resolve, so
+ * there is no tier-2 answer to give, and saying `unresolved` would misrepresent "never asked" as
+ * "asked and got nothing".
+ *
+ * `files` is sorted and deduped here. The repo's determinism digest covers findings and never
+ * proofs, so nothing downstream would catch an unstable order.
+ */
+export function resolvedHelperIdentities(
+  checkData: ScanData,
+  convention: AcceptedConvention
+): AcceptedHelperIdentity[] {
+  const requires = (convention as AcceptedConvention & { requires?: unknown }).requires;
+  if (!requires || typeof requires !== "object" || Array.isArray(requires)) {
+    return [];
+  }
+  const index = graphIndexFor(checkData);
+  // Keyed by symbol because that is the join key the engine itself uses - both
+  // `accepted_auth_helpers_for_convention` and `phase4_policy_for_convention` normalise into a
+  // BTreeMap keyed by symbol, last write winning. Mirroring that keeps this from disagreeing with
+  // the reader it is computed for.
+  const bySymbol = new Map<string, AcceptedHelperIdentity>();
+  for (const key of ACCEPTED_HELPER_REQUIRES_KEYS) {
+    const entries = (requires as Record<string, unknown>)[key];
+    if (!Array.isArray(entries)) {
+      continue;
+    }
+    for (const entry of entries) {
+      if (!entry || typeof entry !== "object" || Array.isArray(entry)) {
+        continue;
+      }
+      const record = entry as Record<string, unknown>;
+      const symbol = firstStringValue(record, HELPER_SYMBOL_KEYS);
+      const specifier = firstStringValue(record, HELPER_MODULE_KEYS);
+      if (!symbol || !specifier) {
+        continue;
+      }
+      bySymbol.set(symbol, helperIdentityFor(checkData, index, symbol, specifier));
+    }
+  }
+  return [...bySymbol.values()].sort((left, right) => (left.symbol < right.symbol ? -1 : 1));
+}
+
+function helperIdentityFor(
+  checkData: ScanData,
+  index: GraphIndex,
+  symbol: string,
+  specifier: string
+): AcceptedHelperIdentity {
+  // A barrel is a module that re-exports the helper's real module, so the chain is part of the
+  // identity: `import { requireUser } from "@/lib"` reaches `src/lib/auth.ts` and the contract
+  // naming either one is describing the same helper.
+  //
+  // `exact_specifier`, never the subpath relation the forbidden path uses: an accepted helper at
+  // `@/lib` must not absorb `@/lib/attacker-controlled` just because it sits beneath it. Widening
+  // an acceptance is laundering. The re-export chain is a different thing entirely - it follows
+  // what the repo actually re-exports, which is a fact about the code rather than about spelling.
+  const reachable = reexportClosureFor(
+    resolvedModuleNodeIdsFor(checkData, [specifier], "exact_specifier"),
+    index
+  );
+  const files = moduleFilesForNodeIds(reachable, index);
+  const bare = isBarePackageSpecifier(specifier);
+  // Classified on whether a usable FILE identity came back, not merely on whether an edge existed.
+  // An edge to a node carrying no `file_path` leaves nothing to match against, and calling that
+  // `repo_resolved` would hand Sprint 4 an empty file list to enforce - turning a silent miss into
+  // a false alarm on every compliant route, which is the one direction this refactor must not move.
+  if (files.size === 0) {
+    return { symbol, mode: bare ? "external" : "unresolved", files: [] };
+  }
+  return {
+    symbol,
+    mode: "repo_resolved",
+    files: [...files].sort(),
+    ...(bare ? { external_specifier_resolves_in_repo: true as const } : {})
+  };
+}
+
+/** Every module reachable from `startNodeIds` by `MODULE_REEXPORTS_MODULE`, the starts included. */
+function reexportClosureFor(startNodeIds: Set<string>, index: GraphIndex): Set<string> {
+  const seen = new Set<string>();
+  const queue = [...startNodeIds];
+  while (queue.length > 0) {
+    const current = queue.pop()!;
+    if (seen.has(current)) {
+      continue;
+    }
+    seen.add(current);
+    for (const next of index.reexportTargets.get(current) ?? []) {
+      queue.push(next);
+    }
+  }
+  return seen;
+}
+
+/**
+ * Whether a specifier names a package rather than something inside this repo.
+ *
+ * Node resolution semantics: `./`, `../` and `/` are paths, everything else is a package name.
+ * `@/` is excluded because it is not a valid npm scope (scopes cannot be empty) and is the near
+ * universal tsconfig alias for the repo root; `~` and `#` are the other two common repo-internal
+ * prefixes, the latter being Node's own subpath imports.
+ *
+ * A repo whose alias has no sigil at all (`src/lib/auth` via `baseUrl`) reads as a package here and
+ * is classified `external` rather than `unresolved` when it resolves to nothing. Both modes match on
+ * the exact specifier, so the practical difference is only whether the degradation is recorded - and
+ * if such a specifier DOES resolve repo-locally, `external_specifier_resolves_in_repo` fires and it
+ * is visible rather than silent.
+ */
+function isBarePackageSpecifier(specifier: string): boolean {
+  return !(
+    specifier.startsWith(".") ||
+    specifier.startsWith("/") ||
+    specifier.startsWith("@/") ||
+    specifier.startsWith("~") ||
+    specifier.startsWith("#")
+  );
+}
+
+function firstStringValue(
+  record: Record<string, unknown>,
+  keys: readonly string[]
+): string | undefined {
+  for (const key of keys) {
+    const value = record[key];
+    if (typeof value === "string" && value.length > 0) {
+      return value;
+    }
+  }
+  return undefined;
 }
 
 /** module id -> modules it re-exports, for chain walking. */

--- a/packages/cli/src/check/run-check.ts
+++ b/packages/cli/src/check/run-check.ts
@@ -3182,12 +3182,16 @@ async function runEngineOwnedDirectDataAccessCheck(input: {
     );
     const snapshots = input.checkData.snapshots.filter((snapshot) => fileSet.has(snapshot.file_path));
     const graph = graphForEngineCheck(input.checkData, fileSet, allowedGraphImportFacts);
-    // Computed from the full graph, before it is scoped to the diff.
+    // Computed from the full graph, before it is scoped to the diff. That ordering is the whole
+    // point of computing them here: `graph` above is already narrowed to the changed files, and the
+    // imports that establish what a specifier MEANS routinely live outside the diff.
     const forbiddenModuleFiles = [
       ...forbiddenModuleFiles_(input.checkData, convention.matcher.forbidden_imports ?? [])
     ];
+    const acceptedHelperModuleFiles = resolvedHelperIdentities(input.checkData, convention);
     const result = await runEngineCheck({
       forbiddenModuleFiles,
+      acceptedHelperModuleFiles,
       repoId: input.repoId,
       repoRoot: input.repoRoot,
       scanId: input.checkData.snapshots[0]?.scan_id ?? input.checkScanId,

--- a/packages/cli/src/check/run-check.ts
+++ b/packages/cli/src/check/run-check.ts
@@ -3835,6 +3835,14 @@ interface GraphIndex {
   endpointNodesByFile: Map<string, ScanData["graph_nodes"]>;
   dataOperationNodesByFile: Map<string, ScanData["graph_nodes"]>;
   reexportTargets: Map<string, string[]>;
+  /**
+   * Re-export edges WITH the name each one carries: a symbol for `export { x } from "./m"`, `"*"`
+   * for a flattening `export * from "./m"`. `reexportTargets` above drops that name, which is
+   * exactly what made the accepted-helper closure symbol-blind.
+   */
+  reexportEdgesByFrom: Map<string, Array<{ to: string; exportedName: string | undefined }>>;
+  /** module node id -> the symbol names it directly exports, from `MODULE_EXPORTS_SYMBOL`. */
+  exportedSymbolsByModule: Map<string, Set<string>>;
   /** Specifiers joined by NUL -> the files they resolve to. Shared by every specifier list. */
   resolvedModuleFilesByKey: Map<string, Set<string>>;
   /** Specifiers joined by NUL -> the module NODES they resolve to, before re-export walking. */
@@ -3907,6 +3915,8 @@ function graphIndexFor(checkData: ScanData): GraphIndex {
     endpointNodesByFile,
     dataOperationNodesByFile,
     reexportTargets: moduleReexportTargets(checkData),
+    reexportEdgesByFrom: moduleReexportEdges(checkData),
+    exportedSymbolsByModule: exportedSymbolsByModule(checkData),
     resolvedModuleFilesByKey: new Map(),
     resolvedModuleNodesByKey: new Map()
   };
@@ -4104,7 +4114,18 @@ export interface AcceptedHelperIdentity {
   /** The specifier as the contract typed it - what `external` and `unresolved` fall back to. */
   specifier: string;
   mode: AcceptedHelperResolutionMode;
-  /** Repo-relative, sorted, deduped. Empty for every mode but `repo_resolved`. */
+  /**
+   * Repo-relative, sorted, deduped. Empty for every mode but `repo_resolved`.
+   *
+   * The module the specifier names, plus the modules a re-export chain carries this helper's SYMBOL
+   * to. Not every module the barrel touches: a barrel re-exporting both `./auth` and
+   * `./attacker-controlled` contributes only the one that exports the symbol.
+   *
+   * The residual limit, stated so it is not assumed away: the closure tests symbol NAMES, not
+   * symbol identity. A barrel re-exporting the same name from two modules - ambiguous in JavaScript
+   * itself - yields both. Treat this as "the modules that plausibly supply this helper", not as
+   * proof that each one is the helper.
+   */
   files: string[];
   /**
    * The tsconfig-paths hijack shape: the contract names what looks like a package, and the repo has
@@ -4231,6 +4252,7 @@ function helperIdentityFor(
   // what the repo actually re-exports, which is a fact about the code rather than about spelling.
   const reachable = reexportClosureFor(
     resolvedModuleNodeIdsFor(checkData, [specifier], "exact_specifier"),
+    symbol,
     index
   );
   const files = moduleFilesForNodeIds(reachable, index);
@@ -4258,8 +4280,64 @@ function helperIdentityFor(
   };
 }
 
-/** Every module reachable from `startNodeIds` by `MODULE_REEXPORTS_MODULE`, the starts included. */
-function reexportClosureFor(startNodeIds: Set<string>, index: GraphIndex): Set<string> {
+/**
+ * The modules a helper's identity extends to through re-exports - and ONLY those that carry the
+ * helper's symbol.
+ *
+ * The starts are always kept: they are what the specifier literally names, which is not a claim
+ * about any symbol. Everything beyond them is a claim - "the barrel re-exports this helper from
+ * there" - and is admitted only on evidence, because that claim is what an attacker edits a barrel
+ * to forge. A barrel re-exporting both `./auth` and `./attacker-controlled` used to put both inside
+ * the accepted helper's identity.
+ *
+ * Two kinds of evidence, matching the two shapes a re-export takes:
+ *   - a NAMED edge (`export { requireUser } from "./auth"`) names the symbol itself, so the edge is
+ *     its own proof and an edge naming any other symbol cannot deliver ours;
+ *   - a STAR edge (`export * from "./auth"`) names nothing, so the target must be shown to provide
+ *     the symbol - by exporting it directly, or by re-exporting it onward from something that does.
+ *     The recursive half matters: in `barrel -> mid -> leaf` where `mid` only passes things along,
+ *     a route importing `mid` really does get the symbol, so `mid` belongs to the identity.
+ *
+ * KNOWN LIMIT, deliberately not papered over: this is a symbol-NAME test, not a symbol-identity
+ * one. A barrel that re-exports the same name from two modules is ambiguous in JavaScript itself,
+ * and both modules land here. That is a strictly smaller surface than before - the sibling has to
+ * export the helper's exact name rather than merely sit next to it - but it is not zero, and
+ * `files` should not be read as proof that every listed file is the helper.
+ */
+function reexportClosureFor(
+  startNodeIds: Set<string>,
+  symbol: string,
+  index: GraphIndex
+): Set<string> {
+  const provides = new Map<string, boolean>();
+
+  /** Does this module supply `symbol`, directly or by re-exporting it onward? */
+  const providesSymbol = (moduleId: string, onPath: Set<string>): boolean => {
+    const memo = provides.get(moduleId);
+    if (memo !== undefined) {
+      return memo;
+    }
+    // A re-export cycle is not evidence of anything; treat the revisit as "no" without memoising,
+    // so a different path to the same module can still answer honestly.
+    if (onPath.has(moduleId)) {
+      return false;
+    }
+    if (index.exportedSymbolsByModule.get(moduleId)?.has(symbol)) {
+      provides.set(moduleId, true);
+      return true;
+    }
+    onPath.add(moduleId);
+    const answer = (index.reexportEdgesByFrom.get(moduleId) ?? []).some(
+      (edge) =>
+        (edge.exportedName === symbol && edge.to !== moduleId) ||
+        (edge.exportedName === "*" && providesSymbol(edge.to, onPath))
+    );
+    onPath.delete(moduleId);
+    provides.set(moduleId, answer);
+    return answer;
+  };
+
+  const kept = new Set(startNodeIds);
   const seen = new Set<string>();
   const queue = [...startNodeIds];
   while (queue.length > 0) {
@@ -4268,11 +4346,26 @@ function reexportClosureFor(startNodeIds: Set<string>, index: GraphIndex): Set<s
       continue;
     }
     seen.add(current);
-    for (const next of index.reexportTargets.get(current) ?? []) {
-      queue.push(next);
+    for (const edge of index.reexportEdgesByFrom.get(current) ?? []) {
+      if (edge.exportedName === symbol) {
+        // The edge names our symbol: the target supplies it, by construction.
+        kept.add(edge.to);
+        queue.push(edge.to);
+        continue;
+      }
+      if (edge.exportedName !== "*") {
+        // A named re-export of some other symbol. Whatever is over there, it is not this helper.
+        continue;
+      }
+      if (providesSymbol(edge.to, new Set())) {
+        kept.add(edge.to);
+      }
+      // Still traversed even when it does not itself provide the symbol, so a longer star chain
+      // behind it is not cut off.
+      queue.push(edge.to);
     }
   }
-  return seen;
+  return kept;
 }
 
 /**
@@ -4310,6 +4403,60 @@ function firstStringValue(
     }
   }
   return undefined;
+}
+
+/**
+ * module id -> its re-export edges, each with the name it re-exports.
+ *
+ * Separate from `moduleReexportTargets` because that map feeds the forbidden-import path, which
+ * asks a different question: a barrel that re-exports a forbidden module is a dependency on it
+ * whatever name it re-exports under, so dropping the name there is correct. An ACCEPTED helper is
+ * a claim about one symbol, so dropping the name there is a hole.
+ */
+function moduleReexportEdges(
+  checkData: ScanData
+): Map<string, Array<{ to: string; exportedName: string | undefined }>> {
+  const edges = new Map<string, Array<{ to: string; exportedName: string | undefined }>>();
+  for (const edge of checkData.graph_edges) {
+    if (edge.kind !== "MODULE_REEXPORTS_MODULE") {
+      continue;
+    }
+    const entry = { to: edge.to, exportedName: stringMetadata(edge.metadata, "exported_name") };
+    const existing = edges.get(edge.from);
+    if (existing) {
+      existing.push(entry);
+    } else {
+      edges.set(edge.from, [entry]);
+    }
+  }
+  return edges;
+}
+
+/**
+ * module id -> the symbol names it directly exports.
+ *
+ * The name lives in the symbol node's LABEL, which is where the engine puts it
+ * (`insert_node(..., GraphNodeKind::Symbol, &fact.name, ...)`).
+ */
+function exportedSymbolsByModule(checkData: ScanData): Map<string, Set<string>> {
+  const nodesById = new Map(checkData.graph_nodes.map((node) => [node.id, node]));
+  const exported = new Map<string, Set<string>>();
+  for (const edge of checkData.graph_edges) {
+    if (edge.kind !== "MODULE_EXPORTS_SYMBOL") {
+      continue;
+    }
+    const symbol = nodesById.get(edge.to)?.label;
+    if (!symbol) {
+      continue;
+    }
+    const existing = exported.get(edge.from);
+    if (existing) {
+      existing.add(symbol);
+    } else {
+      exported.set(edge.from, new Set([symbol]));
+    }
+  }
+  return exported;
 }
 
 /** module id -> modules it re-exports, for chain walking. */

--- a/packages/cli/src/check/run-check.ts
+++ b/packages/cli/src/check/run-check.ts
@@ -4090,7 +4090,19 @@ function moduleFilesForNodeIds(nodeIds: Set<string>, index: GraphIndex): Set<str
 export type AcceptedHelperResolutionMode = "repo_resolved" | "external" | "unresolved";
 
 export interface AcceptedHelperIdentity {
+  /**
+   * Which `requires` list this helper came from - `auth_helpers`, `csrf_helpers`, and so on.
+   *
+   * Part of the identity, not a label. `symbol` is unique WITHIN a list and not across them, and
+   * the engine keeps the lists apart: `accepted_auth_helpers_for_convention`,
+   * `phase6_helpers_from_requires` and `security_helpers_from_requires` each build their own map.
+   * A name reused by an auth helper and a response serializer is two helpers there, so it must be
+   * two here, and a consumer needs this to join them back up.
+   */
+  requires_key: string;
   symbol: string;
+  /** The specifier as the contract typed it - what `external` and `unresolved` fall back to. */
+  specifier: string;
   mode: AcceptedHelperResolutionMode;
   /** Repo-relative, sorted, deduped. Empty for every mode but `repo_resolved`. */
   files: string[];
@@ -4162,11 +4174,16 @@ export function resolvedHelperIdentities(
     return [];
   }
   const index = graphIndexFor(checkData);
-  // Keyed by symbol because that is the join key the engine itself uses - both
-  // `accepted_auth_helpers_for_convention` and `phase4_policy_for_convention` normalise into a
-  // BTreeMap keyed by symbol, last write winning. Mirroring that keeps this from disagreeing with
-  // the reader it is computed for.
-  const bySymbol = new Map<string, AcceptedHelperIdentity>();
+  // Keyed by LIST AND SYMBOL. Keying by symbol alone collapsed a name that two requires lists both
+  // use - and collapsed it destructively, because the surviving entry carried the loser's mode: an
+  // auth helper with a resolved file identity, overwritten by an `external` serializer of the same
+  // name, leaves Sprint 4 applying specifier matching to a helper that had resolved. Which list won
+  // depended on the order of `ACCEPTED_HELPER_REQUIRES_KEYS`.
+  //
+  // The engine's own maps ARE keyed by symbol, but each is built per list, so symbol is unique
+  // within one of them and never across them. Mirroring "keyed by symbol" without mirroring
+  // "per list" was the error.
+  const byListAndSymbol = new Map<string, AcceptedHelperIdentity>();
   for (const key of ACCEPTED_HELPER_REQUIRES_KEYS) {
     const entries = (requires as Record<string, unknown>)[key];
     if (!Array.isArray(entries)) {
@@ -4182,15 +4199,25 @@ export function resolvedHelperIdentities(
       if (!symbol || !specifier) {
         continue;
       }
-      bySymbol.set(symbol, helperIdentityFor(checkData, index, symbol, specifier));
+      // Within one list a repeated symbol IS a duplicate entry, so last-wins there matches the
+      // engine's own per-list normalisation.
+      byListAndSymbol.set(
+        JSON.stringify([key, symbol]),
+        helperIdentityFor(checkData, index, key, symbol, specifier)
+      );
     }
   }
-  return [...bySymbol.values()].sort((left, right) => (left.symbol < right.symbol ? -1 : 1));
+  return [...byListAndSymbol.values()].sort((left, right) =>
+    left.requires_key === right.requires_key
+      ? (left.symbol < right.symbol ? -1 : 1)
+      : (left.requires_key < right.requires_key ? -1 : 1)
+  );
 }
 
 function helperIdentityFor(
   checkData: ScanData,
   index: GraphIndex,
+  requiresKey: string,
   symbol: string,
   specifier: string
 ): AcceptedHelperIdentity {
@@ -4213,10 +4240,18 @@ function helperIdentityFor(
   // `repo_resolved` would hand Sprint 4 an empty file list to enforce - turning a silent miss into
   // a false alarm on every compliant route, which is the one direction this refactor must not move.
   if (files.size === 0) {
-    return { symbol, mode: bare ? "external" : "unresolved", files: [] };
+    return {
+      requires_key: requiresKey,
+      symbol,
+      specifier,
+      mode: bare ? "external" : "unresolved",
+      files: []
+    };
   }
   return {
+    requires_key: requiresKey,
     symbol,
+    specifier,
     mode: "repo_resolved",
     files: [...files].sort(),
     ...(bare ? { external_specifier_resolves_in_repo: true as const } : {})

--- a/packages/cli/src/check/run-check.ts
+++ b/packages/cli/src/check/run-check.ts
@@ -3186,7 +3186,7 @@ async function runEngineOwnedDirectDataAccessCheck(input: {
     // point of computing them here: `graph` above is already narrowed to the changed files, and the
     // imports that establish what a specifier MEANS routinely live outside the diff.
     const forbiddenModuleFiles = [
-      ...forbiddenModuleFiles_(input.checkData, convention.matcher.forbidden_imports ?? [])
+      ...resolvedModuleFilesFor(input.checkData, convention.matcher.forbidden_imports ?? [])
     ];
     const acceptedHelperModuleFiles = resolvedHelperIdentities(input.checkData, convention);
     const result = await runEngineCheck({
@@ -3813,7 +3813,7 @@ function graphForEngineCheck(
  * repo size at fixed route density: openstatus (2,185 files, 37 in scope) ran 3x faster than
  * papermark (1,346 files, 283 in scope) despite a 78% larger graph.
  *
- * `forbiddenModuleFiles_` was already hoisted per convention at its other call site (:2575); this
+ * `resolvedModuleFilesFor` was already hoisted per convention at its other call site; this
  * gives the same treatment to the rest.
  *
  * Keyed on ScanData identity. The arrays indexed here are read-only for the lifetime of a check -
@@ -3933,7 +3933,7 @@ function graphImportResolvesToForbidden(
   //
   // The repository tells us what a specifier means: wherever any file imports a forbidden
   // specifier and the resolver placed that edge, the target is the file it names.
-  const forbiddenFiles = forbiddenModuleFiles_(checkData, forbiddenImports);
+  const forbiddenFiles = resolvedModuleFilesFor(checkData, forbiddenImports);
 
   return (resolvedModuleEdgesByFrom.get(importNode.id) ?? [])
     .some((edge) => {
@@ -3960,7 +3960,7 @@ function graphImportResolvesToForbidden(
  * Derived from the repo's own resolved imports rather than by re-resolving, so it needs no second
  * resolver and cannot disagree with the one that built the graph.
  *
- * This is the general form of what `forbiddenModuleFiles_` used to be on its own. The question -
+ * This began as `forbiddenModuleFiles_`, which answered only for forbidden lists. The question -
  * "what does this specifier MEAN, as opposed to how is it spelled" - is not specific to forbidden
  * imports; the accepted-security-helper side needs the identical answer about a different specifier
  * list. A second walk over `IMPORT_RESOLVES_TO_MODULE` written for that caller could drift out of
@@ -4024,8 +4024,8 @@ function specifierMatches(source: string, specifiers: string[], match: Specifier
  *
  * `resolvedModuleFilesFor` is the answer nearly every caller wants, but a re-export chain is walked
  * over node ids, and a file path cannot be walked back to a node without a second index. Splitting
- * here keeps one walk over `IMPORT_RESOLVES_TO_MODULE` behind both answers - the S3-01
- * characterization lock is what says the split did not move the file-level answer.
+ * here keeps one walk over `IMPORT_RESOLVES_TO_MODULE` behind both answers. The file-level answer is
+ * pinned literally, list by list, in `resolved-module-files.test.ts`.
  */
 function resolvedModuleNodeIdsFor(
   checkData: ScanData,
@@ -4065,16 +4065,6 @@ function moduleFilesForNodeIds(nodeIds: Set<string>, index: GraphIndex): Set<str
     }
   }
   return files;
-}
-
-/**
- * Files that the convention's forbidden specifiers actually resolve to.
- *
- * Exported for the S3-01 characterization lock, which pins that generalising the resolver did not
- * move the answer the T93 bypass closures ride on.
- */
-export function forbiddenModuleFiles_(checkData: ScanData, forbiddenImports: string[]): Set<string> {
-  return resolvedModuleFilesFor(checkData, forbiddenImports);
 }
 
 /**

--- a/packages/cli/src/engine/engine-check.ts
+++ b/packages/cli/src/engine/engine-check.ts
@@ -33,8 +33,12 @@ export interface AcceptedHelperModuleFile {
    * NAMES, so a barrel re-exporting one name from two modules still yields both.
    */
   files: string[];
-  /** The tsconfig-paths hijack shape: a package-shaped specifier that resolves repo-locally. */
-  external_specifier_resolves_in_repo?: true;
+  /**
+   * A package-shaped specifier that resolves to a repo file. States the fact and claims no intent:
+   * it is the tsconfig-paths hijack shape, and equally the shape of a workspace package or a scoped
+   * path alias. Input to a local-shadow check, not a finding.
+   */
+  package_specifier_resolves_in_repo?: true;
 }
 
 export interface EngineCheckInput {
@@ -132,8 +136,14 @@ export function engineCheckRequest(input: EngineCheckInput): EngineCheckRequest 
         // ships silently.
         matcher: {
           ...(convention.matcher as unknown as Record<string, unknown>),
+          // Sorted here, at the last point before the wire. It is built from a Set filled in
+          // graph-edge order, so the same repo could otherwise hand the engine the same files in
+          // different orders across runs. The determinism digest covers findings and never the
+          // request, so nothing downstream would catch it - the same reason
+          // `accepted_helper_module_files` is sorted, and the two should not disagree about
+          // whether order carries meaning. It does not.
           ...(input.forbiddenModuleFiles?.length
-            ? { forbidden_module_files: input.forbiddenModuleFiles }
+            ? { forbidden_module_files: [...input.forbiddenModuleFiles].sort() }
             : {}),
           ...(input.acceptedHelperModuleFiles?.length
             ? { accepted_helper_module_files: input.acceptedHelperModuleFiles }

--- a/packages/cli/src/engine/engine-check.ts
+++ b/packages/cli/src/engine/engine-check.ts
@@ -27,6 +27,11 @@ export interface AcceptedHelperModuleFile {
   /** The specifier as the contract typed it; what the non-`repo_resolved` modes fall back to. */
   specifier: string;
   mode: "repo_resolved" | "external" | "unresolved";
+  /**
+   * The module the specifier names, plus modules a re-export chain carries the helper's SYMBOL to.
+   * A barrel sibling that does not export the symbol is not in here. The closure matches symbol
+   * NAMES, so a barrel re-exporting one name from two modules still yields both.
+   */
   files: string[];
   /** The tsconfig-paths hijack shape: a package-shaped specifier that resolves repo-locally. */
   external_specifier_resolves_in_repo?: true;

--- a/packages/cli/src/engine/engine-check.ts
+++ b/packages/cli/src/engine/engine-check.ts
@@ -6,6 +6,24 @@ import { gitOutput } from "../io/git.js";
 import type { ParsedDiff } from "../check/diff.js";
 import { runRustEngineWithInput } from "./rust-engine.js";
 
+/**
+ * One accepted security helper's resolved module identity, as it travels to the engine.
+ *
+ * Structurally the CLI-side `AcceptedHelperIdentity`, restated here because this is the wire shape
+ * rather than the computation's. `mode` is not decoration: `external` means the specifier resolved
+ * to nothing BY DESIGN (the Rust resolver filters to paths inside the scan snapshot, so anything in
+ * `node_modules` never produces an edge), while `unresolved` means a repo specifier resolved to
+ * nothing, which is a degradation. A consumer that read an empty `files` without reading `mode`
+ * would treat every external auth helper as matching nothing.
+ */
+export interface AcceptedHelperModuleFile {
+  symbol: string;
+  mode: "repo_resolved" | "external" | "unresolved";
+  files: string[];
+  /** The tsconfig-paths hijack shape: a package-shaped specifier that resolves repo-locally. */
+  external_specifier_resolves_in_repo?: true;
+}
+
 export interface EngineCheckInput {
   repoId: string;
   repoRoot: string;
@@ -22,6 +40,12 @@ export interface EngineCheckInput {
   graphDiagnostics?: EngineDiagnostic[];
   /** Files the forbidden specifiers resolve to; see the matcher note below. */
   forbiddenModuleFiles?: string[];
+  /**
+   * S3-03: what each accepted security helper's import specifier actually resolves to, and the mode
+   * that answer came from. Computed CLI-side for the same reason `forbiddenModuleFiles` is - see
+   * the matcher note below. The engine accepts and ignores it; Sprint 4 consumes it.
+   */
+  acceptedHelperModuleFiles?: AcceptedHelperModuleFile[];
   conventions: AcceptedConvention[];
   baseline: BaselineViolation[];
   diff: ParsedDiff;
@@ -85,10 +109,21 @@ export function engineCheckRequest(input: EngineCheckInput): EngineCheckRequest 
         // T100: the engine receives a graph scoped to the changed files, so it cannot derive
         // what a forbidden specifier resolves to - the imports establishing that live in files
         // outside the diff. The caller computes it from the whole graph and passes it here.
+        //
+        // S3-03: `accepted_helper_module_files` is the same derivation for the other direction -
+        // what an ACCEPTED security helper's specifier resolves to - and rides the same surface for
+        // the same reason. It belongs here rather than in `requires` because `requires` is the
+        // stored contract returned verbatim below: mixing a CLI derivation into it would blur what
+        // a human accepted with what this process computed, and would bypass typing, since
+        // `requires` crosses the protocol as an untyped `Option<Value>` where a typo-shaped key
+        // ships silently.
         matcher: {
           ...(convention.matcher as unknown as Record<string, unknown>),
           ...(input.forbiddenModuleFiles?.length
             ? { forbidden_module_files: input.forbiddenModuleFiles }
+            : {}),
+          ...(input.acceptedHelperModuleFiles?.length
+            ? { accepted_helper_module_files: input.acceptedHelperModuleFiles }
             : {})
         },
         scope: convention.scope as unknown as Record<string, unknown>,

--- a/packages/cli/src/engine/engine-check.ts
+++ b/packages/cli/src/engine/engine-check.ts
@@ -17,7 +17,15 @@ import { runRustEngineWithInput } from "./rust-engine.js";
  * would treat every external auth helper as matching nothing.
  */
 export interface AcceptedHelperModuleFile {
+  /**
+   * The `requires` list this helper came from. `symbol` is unique within a list, not across them,
+   * and the engine reads each list separately - so this is what lets a consumer join an identity
+   * back to the helper it describes.
+   */
+  requires_key: string;
   symbol: string;
+  /** The specifier as the contract typed it; what the non-`repo_resolved` modes fall back to. */
+  specifier: string;
   mode: "repo_resolved" | "external" | "unresolved";
   files: string[];
   /** The tsconfig-paths hijack shape: a package-shaped specifier that resolves repo-locally. */

--- a/packages/cli/test/accepted-helper-identity-dispatch.test.ts
+++ b/packages/cli/test/accepted-helper-identity-dispatch.test.ts
@@ -1,0 +1,199 @@
+import { execFileSync } from "node:child_process";
+import { mkdir, mkdtemp, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+/**
+ * B1: the field has to arrive on a run that actually happens.
+ *
+ * `accepted_helper_module_files` was wired into `runEngineOwnedDirectDataAccessCheck`, whose loop
+ * evaluates exactly one kind - `api_route_no_direct_data_access`, which is not a security contract
+ * and carries no `requires` helper block at all. The twelve kinds that DO carry `auth_helpers`,
+ * `csrf_helpers`, `rate_limit_helpers`, `outbound_url_allowlist_helpers`, `response_serializers`
+ * and `validators` are dispatched from `runEngineOwnedAuthCheck`, which never passed the field. So
+ * on every real run the field was computed for a convention that has no helpers, and never computed
+ * for the conventions that do.
+ *
+ * The unit test in `engine-bridge.test.ts` could not see this: it hands
+ * `acceptedHelperModuleFiles` to `engineCheckRequest` directly, on kind
+ * `api_route_requires_auth_helper` - the exact kind that in production never received it. It tests
+ * the last inch of pipe while the upstream is disconnected.
+ *
+ * So this test refuses to call `engineCheckRequest`. It onboards a real repo, accepts a real auth
+ * convention, runs the real `check` command through the real dispatch loop, and reads the JSON that
+ * actually crossed the process boundary to the engine. Nothing about the assertion can be satisfied
+ * by a caller that never runs.
+ */
+
+const engineInputs: string[] = [];
+
+// Intercept only the transport, and only to record. `check-repo` payloads are captured and then
+// handed to the real engine, so this stays an end-to-end run rather than a simulation of one -
+// scan, candidate inference and the check itself all execute against the real binary.
+vi.mock("../src/engine/rust-engine.js", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("../src/engine/rust-engine.js")>();
+  return {
+    ...actual,
+    runRustEngineWithInput: async (args: string[], input: string) => {
+      if (args.includes("check-repo")) {
+        engineInputs.push(input);
+      }
+      return actual.runRustEngineWithInput(args, input);
+    }
+  };
+});
+
+const { runCli } = await import("../src/index.js");
+
+const tempDirs: string[] = [];
+afterEach(async () => {
+  await Promise.all(tempDirs.splice(0).map((dir) => rm(dir, { recursive: true, force: true })));
+  engineInputs.length = 0;
+});
+
+const TEST_TIMEOUT_MS = 120_000;
+
+function git(cwd: string, ...args: string[]): void {
+  execFileSync("git", args, { cwd, stdio: "ignore" });
+}
+
+/**
+ * A repo where the accepted helper genuinely resolves: `@/lib/auth` is a tsconfig alias onto
+ * `lib/auth.ts`, and the routes reach it by two different spellings so the resolved identity is the
+ * only thing that unifies them.
+ */
+async function onboard(): Promise<{ repoId: string; databasePath: string }> {
+  const dir = await mkdtemp(join(tmpdir(), "drift-b1-"));
+  tempDirs.push(dir);
+  const repoRoot = join(dir, "repo");
+  const stateRoot = join(dir, "state");
+
+  await mkdir(join(repoRoot, "lib"), { recursive: true });
+  await writeFile(
+    join(repoRoot, "lib/auth.ts"),
+    [
+      "export const withSession = (handler: unknown) => handler;",
+      "export const withWorkspace = (handler: unknown) => handler;",
+      ""
+    ].join("\n")
+  );
+  for (const [path, wrapper, specifier] of [
+    ["app/api/a/route.ts", "withSession", "@/lib/auth"],
+    ["app/api/b/route.ts", "withSession", "@/lib/auth"],
+    ["app/api/c/route.ts", "withWorkspace", "@/lib/auth"],
+    // The same module by a relative path. Tier 1 calls this a different helper; resolution does not.
+    ["app/api/d/route.ts", "withWorkspace", "../../../lib/auth"]
+  ] as const) {
+    await mkdir(join(repoRoot, path, ".."), { recursive: true });
+    await writeFile(
+      join(repoRoot, path),
+      [
+        `import { ${wrapper} } from "${specifier}";`,
+        `export const POST = ${wrapper}(async () => {`,
+        "  return Response.json({ ok: true });",
+        "});",
+        ""
+      ].join("\n")
+    );
+  }
+  await mkdir(join(repoRoot, "app/api/naked"), { recursive: true });
+  await writeFile(
+    join(repoRoot, "app/api/naked/route.ts"),
+    "export async function POST() { return Response.json({ ok: true }); }\n"
+  );
+  await writeFile(
+    join(repoRoot, "tsconfig.json"),
+    JSON.stringify({ compilerOptions: { baseUrl: ".", paths: { "@/*": ["./*"] } } })
+  );
+  git(repoRoot, "init", "-q");
+  git(repoRoot, "add", "-A");
+  execFileSync(
+    "git",
+    ["-c", "user.email=b1@drift.test", "-c", "user.name=b1", "commit", "-qm", "fixture"],
+    { cwd: repoRoot, stdio: "ignore" }
+  );
+
+  const started = await runCli([
+    "start",
+    "--repo-root", repoRoot,
+    "--state-root", stateRoot,
+    "--accept-defaults",
+    "--now", "2026-08-04T00:00:30.000Z",
+    "--json"
+  ]);
+  expect(started.exitCode).toBe(0);
+  const payload = JSON.parse(started.stdout);
+  return { repoId: payload.repo.id, databasePath: payload.state.database_path };
+}
+
+/** Every convention as it was actually sent to the engine, across every check-repo call. */
+function sentConventions(): Array<{ kind: string; matcher: Record<string, unknown> }> {
+  return engineInputs.flatMap((input) => JSON.parse(input).contract.conventions);
+}
+
+describe("accepted helper identity reaches the engine on a real run", () => {
+  it("arrives in the request built by the auth dispatch loop, for a convention that has helpers", async () => {
+    const { repoId, databasePath } = await onboard();
+
+    const { openDriftStorage } = await import("@drift/storage");
+    const storage = openDriftStorage({ databasePath });
+    storage.migrate();
+    const contract = storage.getRepoContract(repoId)!;
+    storage.upsertAcceptedConvention(repoId, {
+      id: "convention_auth_helper_b1",
+      contract_id: contract.id,
+      kind: "api_route_requires_auth_helper",
+      statement: "API routes must call an accepted auth helper.",
+      rationale: "accepted for test",
+      scope: { path_globs: ["app/api/**/route.ts"], file_roles: ["api_route"] },
+      matcher: {
+        kind: "api_route_requires_auth_helper",
+        required_calls: ["withSession", "withWorkspace"],
+        applies_to_file_roles: ["api_route"],
+        enforcement_semantics: "presence"
+      },
+      requires: {
+        auth_helpers: [
+          { guard_id: "auth:withSession", symbol: "withSession", import: "@/lib/auth" },
+          { guard_id: "auth:withWorkspace", symbol: "withWorkspace", import: "@/lib/auth" }
+        ]
+      },
+      severity: "warning",
+      enforcement_mode: "warn",
+      enforcement_capability: "deterministic_check",
+      exceptions: [],
+      evidence_refs: [],
+      counterexample_refs: [],
+      accepted_by: "test",
+      accepted_at: "2026-08-04T00:00:40.000Z",
+      updated_at: "2026-08-04T00:00:40.000Z"
+    } as never);
+    storage.upsertRepoContract({
+      ...contract,
+      conventions: storage.listAcceptedConventions(repoId),
+      updated_at: "2026-08-04T00:00:40.000Z"
+    });
+    storage.close();
+
+    const result = await runCli([
+      "--db", databasePath, "check", "--repo", repoId, "--scope", "full", "--json"
+    ]);
+    expect(result.exitCode).not.toBe(1);
+
+    // The auth convention really was dispatched - otherwise the assertion below would be vacuous.
+    const auth = sentConventions().filter(
+      (convention) => convention.kind === "api_route_requires_auth_helper"
+    );
+    expect(auth.length).toBeGreaterThan(0);
+
+    // Both accepted helpers resolve to the one file that defines them, computed from the whole
+    // graph rather than from the routes in scope. The routes reach that file by two different
+    // spellings (`@/lib/auth` and `../../../lib/auth`), which is what Sprint 4 will match against
+    // this file identity instead of against the specifier strings that disagree.
+    expect(auth[0]!.matcher.accepted_helper_module_files).toEqual([
+      { symbol: "withSession", mode: "repo_resolved", files: ["lib/auth.ts"] },
+      { symbol: "withWorkspace", mode: "repo_resolved", files: ["lib/auth.ts"] }
+    ]);
+  }, TEST_TIMEOUT_MS);
+});

--- a/packages/cli/test/accepted-helper-identity-dispatch.test.ts
+++ b/packages/cli/test/accepted-helper-identity-dispatch.test.ts
@@ -192,8 +192,20 @@ describe("accepted helper identity reaches the engine on a real run", () => {
     // spellings (`@/lib/auth` and `../../../lib/auth`), which is what Sprint 4 will match against
     // this file identity instead of against the specifier strings that disagree.
     expect(auth[0]!.matcher.accepted_helper_module_files).toEqual([
-      { symbol: "withSession", mode: "repo_resolved", files: ["lib/auth.ts"] },
-      { symbol: "withWorkspace", mode: "repo_resolved", files: ["lib/auth.ts"] }
+      {
+        requires_key: "auth_helpers",
+        symbol: "withSession",
+        specifier: "@/lib/auth",
+        mode: "repo_resolved",
+        files: ["lib/auth.ts"]
+      },
+      {
+        requires_key: "auth_helpers",
+        symbol: "withWorkspace",
+        specifier: "@/lib/auth",
+        mode: "repo_resolved",
+        files: ["lib/auth.ts"]
+      }
     ]);
   }, TEST_TIMEOUT_MS);
 });

--- a/packages/cli/test/accepted-helper-identity.test.ts
+++ b/packages/cli/test/accepted-helper-identity.test.ts
@@ -502,3 +502,58 @@ describe("resolvedHelperIdentities re-export closure", () => {
     expect(identityFor(identities, "requireUser")?.files).toEqual(["src/lib/index.ts"]);
   });
 });
+
+/**
+ * The classifier the whole design turns on, branch by branch.
+ *
+ * `external` and `unresolved` are both "resolved to nothing", and the ONLY thing that separates
+ * them is the shape of the specifier. Get that wrong and a repo-relative helper whose module the
+ * graph could not resolve is reported as a package that legitimately lives outside the snapshot -
+ * a real degradation, silently relabelled as normal.
+ *
+ * Four of the five exclusion branches had no test at all: dropping `~`, `#`, `/` or `.` from
+ * `isBarePackageSpecifier` killed nothing, so `./lib/auth` and `../../lib/auth` - the two commonest
+ * repo-relative forms in any codebase - could have started reporting `external` with no signal.
+ * One case per branch now.
+ */
+describe("isBarePackageSpecifier, through the mode it decides", () => {
+  /** No resolution edges at all, so mode is decided by specifier shape alone. */
+  const nothingResolves = graphScanData({ nodes: [], edges: [] });
+
+  const mode = (specifier: string): string | undefined =>
+    resolvedHelperIdentities(
+      nothingResolves,
+      conventionRequiring({
+        auth_helpers: [{ guard_id: "auth:h", symbol: "h", import: specifier }]
+      })
+    )[0]?.mode;
+
+  it.each([
+    ["./lib/auth", "a same-directory relative import"],
+    ["../../lib/auth", "a parent-directory relative import"],
+    ["/abs/lib/auth", "an absolute path"],
+    ["@/lib/auth", "the conventional tsconfig root alias"],
+    ["~/lib/auth", "a tilde alias"],
+    ["#internal/auth", "a Node subpath import"]
+  ])("classifies %s as unresolved (%s)", (specifier) => {
+    expect(mode(specifier)).toBe("unresolved");
+  });
+
+  it.each([
+    ["next-auth", "a bare package"],
+    ["@clerk/nextjs", "a scoped package"],
+    ["next-auth/react", "a package subpath"]
+  ])("classifies %s as external (%s)", (specifier) => {
+    expect(mode(specifier)).toBe("external");
+  });
+
+  /**
+   * `@/` is not a valid npm scope - scopes cannot be empty - which is what makes it separable from
+   * `@clerk/nextjs`. Pinned as a pair, because a naive `startsWith("@")` would swallow both and a
+   * naive `startsWith("@/")` removal would swallow neither.
+   */
+  it("separates the empty-scope alias from a real scoped package", () => {
+    expect(mode("@/lib/auth")).toBe("unresolved");
+    expect(mode("@clerk/nextjs")).toBe("external");
+  });
+});

--- a/packages/cli/test/accepted-helper-identity.test.ts
+++ b/packages/cli/test/accepted-helper-identity.test.ts
@@ -1,0 +1,297 @@
+import { describe, expect, it } from "vitest";
+import type { AcceptedConvention } from "@drift/core";
+import type { GraphEdge, GraphNode } from "@drift/factgraph";
+import { resolvedHelperIdentities } from "../src/check/run-check.js";
+import { graphEdge, graphScanData, importNode, moduleNode } from "./helpers/scan-data.js";
+
+/**
+ * S3-02: what an accepted security helper's import specifier actually resolves to, and how we know.
+ *
+ * The pipeline decides "does this call reach the accepted helper" at two strengths, both wrong in
+ * opposite directions. Tier 0 compares the imported NAME alone, so a helper from
+ * `@/lib/attacker-controlled` that happens to export `assertCsrf` produces a passing proof - the
+ * laundering shape. Tier 1 compares the name and the specifier AS TYPED, so `../../lib/auth` and
+ * `@/lib/auth` disagree about one file, a barrel import fails, and a renamed import fails outright -
+ * false alarms. Tier 1 is not a stronger tier 0; only resolved module identity dominates both.
+ *
+ * This computes that identity. Nothing consumes it yet.
+ *
+ * The single hardest constraint is that emptiness is NOT a failure. The Rust `resolve_import` ends
+ * by filtering to paths inside the scan snapshot, so `next-auth`, `@clerk/nextjs` and everything
+ * else in `node_modules` produce no resolution edge BY DESIGN. A resolver that met an empty table
+ * by falling back to string comparison would silently and permanently retain tier-1 semantics for
+ * every external auth helper - the most common real-world contract - and no test would ever say so.
+ * That is why the mode is computed per helper rather than per convention, and why it is recorded:
+ * the degradation has to be visible rather than assumed.
+ */
+
+const ROUTE = "app/api/thing/route.ts";
+
+/** A convention carrying only the `requires` surface the helper resolver reads. */
+function conventionRequiring(requires: Record<string, unknown>): AcceptedConvention {
+  return {
+    id: "convention_test",
+    kind: "api_route_requires_auth_helper",
+    matcher: {},
+    requires
+  } as unknown as AcceptedConvention;
+}
+
+function identityFor(
+  identities: ReturnType<typeof resolvedHelperIdentities>,
+  symbol: string
+): { symbol: string; mode: string; files: string[] } | undefined {
+  return identities.find((identity) => identity.symbol === symbol);
+}
+
+describe("resolvedHelperIdentities", () => {
+  /**
+   * One graph carrying every shape at once, because a helper resolver that only works when the
+   * graph contains nothing else is not the thing being built.
+   *
+   * `src/lib/index.ts` is a barrel re-exporting `src/lib/auth.ts`. `src/lib/attacker-controlled.ts`
+   * is an unrelated module that also exports a symbol named `assertCsrf` - it resolves, it is just
+   * not the accepted helper's module, which is the entire point of resolving instead of name
+   * matching. `next-auth` appears as an import with no resolution edge, which is what external
+   * looks like here.
+   */
+  const nodes: GraphNode[] = [
+    importNode({ id: "import:barrel", filePath: ROUTE, source: "@/lib" }),
+    importNode({ id: "import:auth", filePath: ROUTE, source: "@/lib/auth" }),
+    importNode({ id: "import:auth-relative", filePath: "app/api/other/route.ts", source: "../../lib/auth" }),
+    importNode({ id: "import:attacker", filePath: "app/api/evil/route.ts", source: "@/lib/attacker-controlled" }),
+    importNode({ id: "import:next-auth", filePath: ROUTE, source: "next-auth" }),
+    moduleNode({ id: "module:barrel", filePath: "src/lib/index.ts" }),
+    moduleNode({ id: "module:auth", filePath: "src/lib/auth.ts" }),
+    moduleNode({ id: "module:attacker", filePath: "src/lib/attacker-controlled.ts" }),
+    {
+      id: "symbol:attacker-assertCsrf",
+      kind: "symbol",
+      label: "assertCsrf",
+      stable: true,
+      evidence_ids: [],
+      metadata: { file_path: "src/lib/attacker-controlled.ts", name: "assertCsrf" }
+    },
+    {
+      id: "symbol:auth-assertCsrf",
+      kind: "symbol",
+      label: "assertCsrf",
+      stable: true,
+      evidence_ids: [],
+      metadata: { file_path: "src/lib/auth.ts", name: "assertCsrf" }
+    }
+  ];
+
+  const edges: GraphEdge[] = [
+    graphEdge({ id: "r1", kind: "IMPORT_RESOLVES_TO_MODULE", from: "import:barrel", to: "module:barrel" }),
+    graphEdge({ id: "r2", kind: "IMPORT_RESOLVES_TO_MODULE", from: "import:auth", to: "module:auth" }),
+    graphEdge({ id: "r3", kind: "IMPORT_RESOLVES_TO_MODULE", from: "import:auth-relative", to: "module:auth" }),
+    graphEdge({ id: "r4", kind: "IMPORT_RESOLVES_TO_MODULE", from: "import:attacker", to: "module:attacker" }),
+    // The barrel is what makes `@/lib` mean `src/lib/auth.ts` as well as `src/lib/index.ts`.
+    graphEdge({ id: "x1", kind: "MODULE_REEXPORTS_MODULE", from: "module:barrel", to: "module:auth" }),
+    // Symbol-level edges the laundering control needs: both modules really do export `assertCsrf`,
+    // so name matching genuinely cannot separate them and only module identity can.
+    graphEdge({ id: "s1", kind: "IMPORT_RESOLVES_TO_SYMBOL", from: "import:attacker", to: "symbol:attacker-assertCsrf" }),
+    graphEdge({ id: "s2", kind: "IMPORT_RESOLVES_TO_SYMBOL", from: "import:auth", to: "symbol:auth-assertCsrf" })
+    // `import:next-auth` deliberately has NO resolution edge. See the file header.
+  ];
+
+  const checkData = graphScanData({ nodes, edges });
+
+  it("barrel_reexport_resolves_to_the_helper_module", () => {
+    const identities = resolvedHelperIdentities(
+      checkData,
+      conventionRequiring({
+        auth_helpers: [{ guard_id: "auth:requireUser", symbol: "requireUser", import: "@/lib" }]
+      })
+    );
+
+    // Tier 1 fails this outright: the contract says `@/lib` and the helper lives in
+    // `src/lib/auth.ts`, so the strings never meet. Resolution plus the re-export chain does.
+    expect(identityFor(identities, "requireUser")).toEqual({
+      symbol: "requireUser",
+      mode: "repo_resolved",
+      files: ["src/lib/auth.ts", "src/lib/index.ts"]
+    });
+  });
+
+  it("an accepted helper does not absorb the modules sitting beneath its specifier", () => {
+    /**
+     * The forbidden-import path matches a specifier OR anything under it at a `/` boundary, which
+     * is right for a prohibition: broadening a ban only ever bans more. Reusing that relation for an
+     * accepted helper inverts it. A helper accepted at `@/lib` would absorb
+     * `@/lib/attacker-controlled`, so anyone who can add a module under that prefix owns the
+     * accepted helper's identity and gets a passing auth proof - the laundering shape, reintroduced
+     * by the very mechanism meant to close it. Acceptance matches exactly.
+     *
+     * `src/lib/auth.ts` is still here, because it arrives through the barrel's re-export chain -
+     * a fact about what the repo exports, not about how the specifier is spelled.
+     */
+    const identities = resolvedHelperIdentities(
+      checkData,
+      conventionRequiring({
+        auth_helpers: [{ guard_id: "auth:requireUser", symbol: "requireUser", import: "@/lib" }]
+      })
+    );
+
+    expect(identityFor(identities, "requireUser")?.files)
+      .not.toContain("src/lib/attacker-controlled.ts");
+  });
+
+  it("a_same_named_export_from_an_unrelated_module_resolves_elsewhere", () => {
+    const identities = resolvedHelperIdentities(
+      checkData,
+      conventionRequiring({
+        csrf_helpers: [{ helper_id: "csrf:assertCsrf", symbol: "assertCsrf", module: "@/lib/auth" }]
+      })
+    );
+
+    const identity = identityFor(identities, "assertCsrf");
+    // Both spellings of the accepted module collapse onto one file...
+    expect(identity).toEqual({
+      symbol: "assertCsrf",
+      mode: "repo_resolved",
+      files: ["src/lib/auth.ts"]
+    });
+    // ...and the attacker's identically-named export is not in it. This is the negative control:
+    // tier 0 would have accepted it on the name alone.
+    expect(identity?.files).not.toContain("src/lib/attacker-controlled.ts");
+  });
+
+  it("an_external_package_helper_is_classified_external_not_empty", () => {
+    const identities = resolvedHelperIdentities(
+      checkData,
+      conventionRequiring({
+        auth_helpers: [
+          { guard_id: "auth:getServerSession", symbol: "getServerSession", import: "next-auth" }
+        ]
+      })
+    );
+
+    // The failure this test exists to prevent is `mode: "repo_resolved", files: []`, which reads as
+    // "the accepted helper resolves to nothing" and would make every compliant route a violation
+    // once Sprint 4 matches on it. `external` says the opposite: the answer is unavailable here by
+    // design, so match the specifier and say so.
+    expect(identityFor(identities, "getServerSession")).toEqual({
+      symbol: "getServerSession",
+      mode: "external",
+      files: []
+    });
+  });
+
+  it("an_external_specifier_that_resolves_repo_locally_is_flagged", () => {
+    // The tsconfig-paths hijack shape: the contract names a package, and the repo has quietly
+    // pointed that package name at a file it controls. Accepting this silently is how a
+    // resolution-based matcher would be worse than the string one it replaces.
+    const hijacked = graphScanData({
+      nodes: [
+        importNode({ id: "import:hijack", filePath: ROUTE, source: "next-auth" }),
+        moduleNode({ id: "module:shim", filePath: "src/shim/next-auth.ts" })
+      ],
+      edges: [
+        graphEdge({ id: "h1", kind: "IMPORT_RESOLVES_TO_MODULE", from: "import:hijack", to: "module:shim" })
+      ]
+    });
+
+    const identities = resolvedHelperIdentities(
+      hijacked,
+      conventionRequiring({
+        auth_helpers: [
+          { guard_id: "auth:getServerSession", symbol: "getServerSession", import: "next-auth" }
+        ]
+      })
+    );
+
+    expect(identityFor(identities, "getServerSession")).toMatchObject({
+      symbol: "getServerSession",
+      mode: "repo_resolved",
+      files: ["src/shim/next-auth.ts"]
+    });
+    expect(identities[0]).toHaveProperty("external_specifier_resolves_in_repo", true);
+  });
+
+  it("resolved_file_lists_are_sorted_and_deduped", () => {
+    /**
+     * The repo's determinism digest covers findings, never proofs, so nothing downstream would
+     * catch an unstable order here. Insertion order is graph order: this graph reaches `zzz` first
+     * and reaches `aaa` only by following the re-export, and two imports resolve to the same file.
+     */
+    const unordered = graphScanData({
+      nodes: [
+        importNode({ id: "import:one", filePath: ROUTE, source: "@/lib" }),
+        importNode({ id: "import:two", filePath: "app/api/two/route.ts", source: "@/lib" }),
+        moduleNode({ id: "module:zzz", filePath: "src/lib/zzz.ts" }),
+        moduleNode({ id: "module:aaa", filePath: "src/lib/aaa.ts" }),
+        moduleNode({ id: "module:mmm", filePath: "src/lib/mmm.ts" })
+      ],
+      edges: [
+        graphEdge({ id: "u1", kind: "IMPORT_RESOLVES_TO_MODULE", from: "import:one", to: "module:zzz" }),
+        // Same specifier, same target file: one entry, not two.
+        graphEdge({ id: "u2", kind: "IMPORT_RESOLVES_TO_MODULE", from: "import:two", to: "module:zzz" }),
+        graphEdge({ id: "u3", kind: "MODULE_REEXPORTS_MODULE", from: "module:zzz", to: "module:mmm" }),
+        graphEdge({ id: "u4", kind: "MODULE_REEXPORTS_MODULE", from: "module:mmm", to: "module:aaa" })
+      ]
+    });
+
+    const identities = resolvedHelperIdentities(
+      unordered,
+      conventionRequiring({
+        auth_helpers: [{ guard_id: "auth:requireUser", symbol: "requireUser", import: "@/lib" }]
+      })
+    );
+
+    expect(identityFor(identities, "requireUser")?.files).toEqual([
+      "src/lib/aaa.ts",
+      "src/lib/mmm.ts",
+      "src/lib/zzz.ts"
+    ]);
+  });
+
+  it("a repo-relative specifier that resolves to nothing is unresolved, not external", () => {
+    // The third mode, and the one that must never be confused with the second: `@/lib/gone` is a
+    // repo specifier, so resolving to nothing means the graph could not answer - a degradation to
+    // record - rather than an import that lives outside the snapshot on purpose.
+    const identities = resolvedHelperIdentities(
+      checkData,
+      conventionRequiring({
+        auth_helpers: [{ guard_id: "auth:requireUser", symbol: "requireUser", import: "@/lib/gone" }]
+      })
+    );
+
+    expect(identityFor(identities, "requireUser")).toEqual({
+      symbol: "requireUser",
+      mode: "unresolved",
+      files: []
+    });
+  });
+
+  it("reads every accepted security helper list, whichever key its module hides under", () => {
+    // Three requires keys spell the module field three different ways - `import` for auth and
+    // validators, `module` for the phase 6 kinds, `import_source` for response serializers. A
+    // resolver that knew only one of them would return a confident, silently partial answer.
+    const identities = resolvedHelperIdentities(
+      checkData,
+      conventionRequiring({
+        auth_helpers: [{ guard_id: "auth:requireUser", symbol: "requireUser", import: "@/lib/auth" }],
+        csrf_helpers: [{ helper_id: "csrf:assertCsrf", symbol: "assertCsrf", module: "@/lib/auth" }],
+        rate_limit_helpers: [{ helper_id: "rl:ratelimit", symbol: "ratelimit", module: "next-auth" }],
+        outbound_url_allowlist_helpers: [
+          { helper_id: "ssrf:allowOutbound", symbol: "allowOutbound", module: "@/lib/gone" }
+        ],
+        validators: [{ validator_id: "validator:parseBody", symbol: "parseBody", import: "@/lib" }],
+        response_serializers: [
+          { serializer_id: "serializer:toDto", imported_name: "toDto", import_source: "@/lib/auth" }
+        ]
+      })
+    );
+
+    expect(identities.map((identity) => [identity.symbol, identity.mode])).toEqual([
+      ["allowOutbound", "unresolved"],
+      ["assertCsrf", "repo_resolved"],
+      ["parseBody", "repo_resolved"],
+      ["ratelimit", "external"],
+      ["requireUser", "repo_resolved"],
+      ["toDto", "repo_resolved"]
+    ]);
+  });
+});

--- a/packages/cli/test/accepted-helper-identity.test.ts
+++ b/packages/cli/test/accepted-helper-identity.test.ts
@@ -215,7 +215,51 @@ describe("resolvedHelperIdentities", () => {
       mode: "repo_resolved",
       files: ["src/shim/next-auth.ts"]
     });
-    expect(identities[0]).toHaveProperty("external_specifier_resolves_in_repo", true);
+    expect(identities[0]).toHaveProperty("package_specifier_resolves_in_repo", true);
+  });
+
+  it("states the package-shadowing fact for ordinary aliases too, without calling them attacks", () => {
+    /**
+     * The flag was named for the tsconfig-paths hijack, but it cannot tell a hijack from a
+     * perfectly ordinary config: a scoped path alias (`"@app/*": ["src/*"]`) and a pnpm workspace
+     * package both resolve a package-shaped specifier to a repo file, and both would have raised
+     * an "external specifier resolves in repo" alarm. An alarm named for an attack that fires on
+     * routine setups is an alarm that gets ignored, and ignoring it is how the real one gets
+     * through.
+     *
+     * So the field states the FACT and claims no intent. It is the input to the local-shadow check
+     * Sprint 4 applies, not a verdict.
+     */
+    const workspace = graphScanData({
+      nodes: [
+        importNode({ id: "import:ws", filePath: ROUTE, source: "@app/auth" }),
+        moduleNode({ id: "module:ws", filePath: "packages/auth/src/index.ts" }),
+        symbolNode({
+          id: "sym:ws",
+          filePath: "packages/auth/src/index.ts",
+          name: "requireUser"
+        })
+      ],
+      edges: [
+        graphEdge({ id: "w1", kind: "IMPORT_RESOLVES_TO_MODULE", from: "import:ws", to: "module:ws" }),
+        graphEdge({ id: "w2", kind: "MODULE_EXPORTS_SYMBOL", from: "module:ws", to: "sym:ws" })
+      ]
+    });
+
+    const identities = resolvedHelperIdentities(
+      workspace,
+      conventionRequiring({
+        auth_helpers: [{ guard_id: "auth:requireUser", symbol: "requireUser", import: "@app/auth" }]
+      })
+    );
+
+    // Resolving really is the better answer here - a workspace package has a genuine file identity.
+    expect(identities[0]).toMatchObject({
+      mode: "repo_resolved",
+      files: ["packages/auth/src/index.ts"],
+      package_specifier_resolves_in_repo: true
+    });
+    expect(identities[0]).not.toHaveProperty("external_specifier_resolves_in_repo");
   });
 
   it("resolved_file_lists_are_sorted_and_deduped", () => {

--- a/packages/cli/test/accepted-helper-identity.test.ts
+++ b/packages/cli/test/accepted-helper-identity.test.ts
@@ -2,7 +2,7 @@ import { describe, expect, it } from "vitest";
 import type { AcceptedConvention } from "@drift/core";
 import type { GraphEdge, GraphNode } from "@drift/factgraph";
 import { resolvedHelperIdentities } from "../src/check/run-check.js";
-import { graphEdge, graphScanData, importNode, moduleNode } from "./helpers/scan-data.js";
+import { graphEdge, graphScanData, importNode, moduleNode, symbolNode } from "./helpers/scan-data.js";
 
 /**
  * S3-02: what an accepted security helper's import specifier actually resolves to, and how we know.
@@ -64,22 +64,15 @@ describe("resolvedHelperIdentities", () => {
     moduleNode({ id: "module:barrel", filePath: "src/lib/index.ts" }),
     moduleNode({ id: "module:auth", filePath: "src/lib/auth.ts" }),
     moduleNode({ id: "module:attacker", filePath: "src/lib/attacker-controlled.ts" }),
-    {
+    symbolNode({
       id: "symbol:attacker-assertCsrf",
-      kind: "symbol",
-      label: "assertCsrf",
-      stable: true,
-      evidence_ids: [],
-      metadata: { file_path: "src/lib/attacker-controlled.ts", name: "assertCsrf" }
-    },
-    {
-      id: "symbol:auth-assertCsrf",
-      kind: "symbol",
-      label: "assertCsrf",
-      stable: true,
-      evidence_ids: [],
-      metadata: { file_path: "src/lib/auth.ts", name: "assertCsrf" }
-    }
+      filePath: "src/lib/attacker-controlled.ts",
+      name: "assertCsrf"
+    }),
+    symbolNode({ id: "symbol:auth-assertCsrf", filePath: "src/lib/auth.ts", name: "assertCsrf" }),
+    symbolNode({ id: "symbol:auth-requireUser", filePath: "src/lib/auth.ts", name: "requireUser" }),
+    symbolNode({ id: "symbol:auth-parseBody", filePath: "src/lib/auth.ts", name: "parseBody" }),
+    symbolNode({ id: "symbol:auth-toDto", filePath: "src/lib/auth.ts", name: "toDto" })
   ];
 
   const edges: GraphEdge[] = [
@@ -87,8 +80,15 @@ describe("resolvedHelperIdentities", () => {
     graphEdge({ id: "r2", kind: "IMPORT_RESOLVES_TO_MODULE", from: "import:auth", to: "module:auth" }),
     graphEdge({ id: "r3", kind: "IMPORT_RESOLVES_TO_MODULE", from: "import:auth-relative", to: "module:auth" }),
     graphEdge({ id: "r4", kind: "IMPORT_RESOLVES_TO_MODULE", from: "import:attacker", to: "module:attacker" }),
-    // The barrel is what makes `@/lib` mean `src/lib/auth.ts` as well as `src/lib/index.ts`.
-    graphEdge({ id: "x1", kind: "MODULE_REEXPORTS_MODULE", from: "module:barrel", to: "module:auth" }),
+    // The barrel is what makes `@/lib` mean `src/lib/auth.ts` as well as `src/lib/index.ts` - but
+    // only for the symbols it actually re-exports, which is why the edge carries a name and the
+    // target declares what it exports. `export * from "./auth"`.
+    graphEdge({ id: "x1", kind: "MODULE_REEXPORTS_MODULE", from: "module:barrel", to: "module:auth", exportedName: "*" }),
+    graphEdge({ id: "x2", kind: "MODULE_EXPORTS_SYMBOL", from: "module:auth", to: "symbol:auth-requireUser" }),
+    graphEdge({ id: "x3", kind: "MODULE_EXPORTS_SYMBOL", from: "module:auth", to: "symbol:auth-assertCsrf" }),
+    graphEdge({ id: "x4", kind: "MODULE_EXPORTS_SYMBOL", from: "module:auth", to: "symbol:auth-parseBody" }),
+    graphEdge({ id: "x5", kind: "MODULE_EXPORTS_SYMBOL", from: "module:auth", to: "symbol:auth-toDto" }),
+    graphEdge({ id: "x6", kind: "MODULE_EXPORTS_SYMBOL", from: "module:attacker", to: "symbol:attacker-assertCsrf" }),
     // Symbol-level edges the laundering control needs: both modules really do export `assertCsrf`,
     // so name matching genuinely cannot separate them and only module identity can.
     graphEdge({ id: "s1", kind: "IMPORT_RESOLVES_TO_SYMBOL", from: "import:attacker", to: "symbol:attacker-assertCsrf" }),
@@ -126,8 +126,10 @@ describe("resolvedHelperIdentities", () => {
      * accepted helper's identity and gets a passing auth proof - the laundering shape, reintroduced
      * by the very mechanism meant to close it. Acceptance matches exactly.
      *
-     * `src/lib/auth.ts` is still here, because it arrives through the barrel's re-export chain -
-     * a fact about what the repo exports, not about how the specifier is spelled.
+     * `src/lib/auth.ts` is still here, because it arrives through the barrel's re-export chain AND
+     * genuinely exports `requireUser` - facts about what the repo exports, not about how the
+     * specifier is spelled. The attacker module now fails both tests: it is not named exactly by
+     * the specifier, and it does not export the symbol.
      */
     const identities = resolvedHelperIdentities(
       checkData,
@@ -228,14 +230,16 @@ describe("resolvedHelperIdentities", () => {
         importNode({ id: "import:two", filePath: "app/api/two/route.ts", source: "@/lib" }),
         moduleNode({ id: "module:zzz", filePath: "src/lib/zzz.ts" }),
         moduleNode({ id: "module:aaa", filePath: "src/lib/aaa.ts" }),
-        moduleNode({ id: "module:mmm", filePath: "src/lib/mmm.ts" })
+        moduleNode({ id: "module:mmm", filePath: "src/lib/mmm.ts" }),
+        symbolNode({ id: "symbol:aaa-requireUser", filePath: "src/lib/aaa.ts", name: "requireUser" })
       ],
       edges: [
         graphEdge({ id: "u1", kind: "IMPORT_RESOLVES_TO_MODULE", from: "import:one", to: "module:zzz" }),
         // Same specifier, same target file: one entry, not two.
         graphEdge({ id: "u2", kind: "IMPORT_RESOLVES_TO_MODULE", from: "import:two", to: "module:zzz" }),
-        graphEdge({ id: "u3", kind: "MODULE_REEXPORTS_MODULE", from: "module:zzz", to: "module:mmm" }),
-        graphEdge({ id: "u4", kind: "MODULE_REEXPORTS_MODULE", from: "module:mmm", to: "module:aaa" })
+        graphEdge({ id: "u3", kind: "MODULE_REEXPORTS_MODULE", from: "module:zzz", to: "module:mmm", exportedName: "*" }),
+        graphEdge({ id: "u4", kind: "MODULE_REEXPORTS_MODULE", from: "module:mmm", to: "module:aaa", exportedName: "*" }),
+        graphEdge({ id: "u5", kind: "MODULE_EXPORTS_SYMBOL", from: "module:aaa", to: "symbol:aaa-requireUser" })
       ]
     });
 
@@ -347,5 +351,154 @@ describe("resolvedHelperIdentities", () => {
         ["response_serializers", "toDto", "repo_resolved"],
         ["validators", "parseBody", "repo_resolved"]
       ]);
+  });
+});
+
+/**
+ * B4: the barrel is the other half of the laundering surface, and the more powerful half.
+ *
+ * Bounding the SPECIFIER relation to exact match stopped an attacker dropping a module under an
+ * accepted prefix. It did nothing about the re-export closure, which followed every
+ * `MODULE_REEXPORTS_MODULE` edge out of the resolved module without regard to which SYMBOL the
+ * helper is. A barrel that re-exports both the real helper and an attacker module put the attacker
+ * module inside the accepted helper's own identity - and editing the barrel is strictly more
+ * powerful than adding a file beside it, because the barrel is what the contract points at.
+ *
+ * The graph already distinguishes them. `MODULE_REEXPORTS_MODULE` carries `exported_name` - the
+ * re-exported symbol, or `"*"` for a flattening `export *` - and `MODULE_EXPORTS_SYMBOL` says what
+ * a module actually exports. Both were present and unread.
+ */
+describe("resolvedHelperIdentities re-export closure", () => {
+  /**
+   * A barrel over two modules:
+   *   `export * from "./auth"`                -> defines `requireUser`
+   *   `export * from "./attacker-controlled"` -> defines `pwn`, and NOT `requireUser`
+   *
+   * Star re-exports both ways, which is the hard case: the edge itself names no symbol, so only
+   * what the target module exports can separate them.
+   */
+  const barrel = graphScanData({
+    nodes: [
+      importNode({ id: "import:barrel", filePath: ROUTE, source: "@/lib" }),
+      moduleNode({ id: "module:index", filePath: "src/lib/index.ts" }),
+      moduleNode({ id: "module:auth", filePath: "src/lib/auth.ts" }),
+      moduleNode({ id: "module:attacker", filePath: "src/lib/attacker-controlled.ts" }),
+      symbolNode({ id: "sym:requireUser", filePath: "src/lib/auth.ts", name: "requireUser" }),
+      symbolNode({ id: "sym:pwn", filePath: "src/lib/attacker-controlled.ts", name: "pwn" })
+    ],
+    edges: [
+      graphEdge({ id: "b1", kind: "IMPORT_RESOLVES_TO_MODULE", from: "import:barrel", to: "module:index" }),
+      graphEdge({ id: "b2", kind: "MODULE_REEXPORTS_MODULE", from: "module:index", to: "module:auth", exportedName: "*" }),
+      graphEdge({ id: "b3", kind: "MODULE_REEXPORTS_MODULE", from: "module:index", to: "module:attacker", exportedName: "*" }),
+      graphEdge({ id: "b4", kind: "MODULE_EXPORTS_SYMBOL", from: "module:auth", to: "sym:requireUser" }),
+      graphEdge({ id: "b5", kind: "MODULE_EXPORTS_SYMBOL", from: "module:attacker", to: "sym:pwn" })
+    ]
+  });
+
+  it("a_barrel_sibling_that_lacks_the_symbol_is_not_the_helper", () => {
+    const identities = resolvedHelperIdentities(
+      barrel,
+      conventionRequiring({
+        auth_helpers: [{ guard_id: "auth:requireUser", symbol: "requireUser", import: "@/lib" }]
+      })
+    );
+
+    // `src/lib/index.ts` is what the specifier literally names, so it stays. `src/lib/auth.ts` is
+    // reached because the barrel really does re-export `requireUser` from it. The attacker's
+    // module is re-exported by the same barrel and exports no such symbol, so it is not the helper.
+    expect(identityFor(identities, "requireUser")?.files)
+      .toEqual(["src/lib/auth.ts", "src/lib/index.ts"]);
+  });
+
+  it("follows a named re-export only for the symbol it actually names", () => {
+    const named = graphScanData({
+      nodes: [
+        importNode({ id: "import:barrel", filePath: ROUTE, source: "@/lib" }),
+        moduleNode({ id: "module:index", filePath: "src/lib/index.ts" }),
+        moduleNode({ id: "module:auth", filePath: "src/lib/auth.ts" }),
+        moduleNode({ id: "module:attacker", filePath: "src/lib/attacker-controlled.ts" })
+      ],
+      edges: [
+        graphEdge({ id: "n1", kind: "IMPORT_RESOLVES_TO_MODULE", from: "import:barrel", to: "module:index" }),
+        // `export { requireUser } from "./auth"` - the edge itself is the evidence.
+        graphEdge({ id: "n2", kind: "MODULE_REEXPORTS_MODULE", from: "module:index", to: "module:auth", exportedName: "requireUser" }),
+        // `export { pwn } from "./attacker-controlled"` - a different symbol entirely.
+        graphEdge({ id: "n3", kind: "MODULE_REEXPORTS_MODULE", from: "module:index", to: "module:attacker", exportedName: "pwn" })
+      ]
+    });
+
+    const identities = resolvedHelperIdentities(
+      named,
+      conventionRequiring({
+        auth_helpers: [{ guard_id: "auth:requireUser", symbol: "requireUser", import: "@/lib" }]
+      })
+    );
+
+    expect(identityFor(identities, "requireUser")?.files)
+      .toEqual(["src/lib/auth.ts", "src/lib/index.ts"]);
+  });
+
+  it("follows a star chain through a module that only passes the symbol along", () => {
+    // barrel -> mid -> leaf, both hops `export *`. `mid` exports nothing of its own, but a route
+    // importing `mid` really would get `requireUser`, so it belongs to the identity too.
+    const chain = graphScanData({
+      nodes: [
+        importNode({ id: "import:barrel", filePath: ROUTE, source: "@/lib" }),
+        moduleNode({ id: "module:index", filePath: "src/lib/index.ts" }),
+        moduleNode({ id: "module:mid", filePath: "src/lib/mid.ts" }),
+        moduleNode({ id: "module:leaf", filePath: "src/lib/leaf.ts" }),
+        moduleNode({ id: "module:other", filePath: "src/lib/other.ts" }),
+        symbolNode({ id: "sym:requireUser", filePath: "src/lib/leaf.ts", name: "requireUser" }),
+        symbolNode({ id: "sym:unrelated", filePath: "src/lib/other.ts", name: "unrelated" })
+      ],
+      edges: [
+        graphEdge({ id: "c1", kind: "IMPORT_RESOLVES_TO_MODULE", from: "import:barrel", to: "module:index" }),
+        graphEdge({ id: "c2", kind: "MODULE_REEXPORTS_MODULE", from: "module:index", to: "module:mid", exportedName: "*" }),
+        graphEdge({ id: "c3", kind: "MODULE_REEXPORTS_MODULE", from: "module:mid", to: "module:leaf", exportedName: "*" }),
+        graphEdge({ id: "c4", kind: "MODULE_REEXPORTS_MODULE", from: "module:index", to: "module:other", exportedName: "*" }),
+        graphEdge({ id: "c5", kind: "MODULE_EXPORTS_SYMBOL", from: "module:leaf", to: "sym:requireUser" }),
+        graphEdge({ id: "c6", kind: "MODULE_EXPORTS_SYMBOL", from: "module:other", to: "sym:unrelated" })
+      ]
+    });
+
+    const identities = resolvedHelperIdentities(
+      chain,
+      conventionRequiring({
+        auth_helpers: [{ guard_id: "auth:requireUser", symbol: "requireUser", import: "@/lib" }]
+      })
+    );
+
+    expect(identityFor(identities, "requireUser")?.files)
+      .toEqual(["src/lib/index.ts", "src/lib/leaf.ts", "src/lib/mid.ts"]);
+  });
+
+  it("keeps the module the specifier names even when nothing proves the symbol", () => {
+    /**
+     * The documented degradation. With no `MODULE_EXPORTS_SYMBOL` evidence anywhere - a language or
+     * file the extractor did not produce export facts for - the transitive claims cannot be
+     * checked, so they are dropped. What the specifier LITERALLY names is not a symbol claim and
+     * stays, so this narrows rather than empties: a route importing the barrel still matches, and
+     * no compliant route is turned into a violation.
+     */
+    const noSymbols = graphScanData({
+      nodes: [
+        importNode({ id: "import:barrel", filePath: ROUTE, source: "@/lib" }),
+        moduleNode({ id: "module:index", filePath: "src/lib/index.ts" }),
+        moduleNode({ id: "module:auth", filePath: "src/lib/auth.ts" })
+      ],
+      edges: [
+        graphEdge({ id: "s1", kind: "IMPORT_RESOLVES_TO_MODULE", from: "import:barrel", to: "module:index" }),
+        graphEdge({ id: "s2", kind: "MODULE_REEXPORTS_MODULE", from: "module:index", to: "module:auth", exportedName: "*" })
+      ]
+    });
+
+    const identities = resolvedHelperIdentities(
+      noSymbols,
+      conventionRequiring({
+        auth_helpers: [{ guard_id: "auth:requireUser", symbol: "requireUser", import: "@/lib" }]
+      })
+    );
+
+    expect(identityFor(identities, "requireUser")?.files).toEqual(["src/lib/index.ts"]);
   });
 });

--- a/packages/cli/test/accepted-helper-identity.test.ts
+++ b/packages/cli/test/accepted-helper-identity.test.ts
@@ -109,7 +109,9 @@ describe("resolvedHelperIdentities", () => {
     // Tier 1 fails this outright: the contract says `@/lib` and the helper lives in
     // `src/lib/auth.ts`, so the strings never meet. Resolution plus the re-export chain does.
     expect(identityFor(identities, "requireUser")).toEqual({
+      requires_key: "auth_helpers",
       symbol: "requireUser",
+      specifier: "@/lib",
       mode: "repo_resolved",
       files: ["src/lib/auth.ts", "src/lib/index.ts"]
     });
@@ -149,7 +151,9 @@ describe("resolvedHelperIdentities", () => {
     const identity = identityFor(identities, "assertCsrf");
     // Both spellings of the accepted module collapse onto one file...
     expect(identity).toEqual({
+      requires_key: "csrf_helpers",
       symbol: "assertCsrf",
+      specifier: "@/lib/auth",
       mode: "repo_resolved",
       files: ["src/lib/auth.ts"]
     });
@@ -173,7 +177,9 @@ describe("resolvedHelperIdentities", () => {
     // once Sprint 4 matches on it. `external` says the opposite: the answer is unavailable here by
     // design, so match the specifier and say so.
     expect(identityFor(identities, "getServerSession")).toEqual({
+      requires_key: "auth_helpers",
       symbol: "getServerSession",
+      specifier: "next-auth",
       mode: "external",
       files: []
     });
@@ -259,10 +265,55 @@ describe("resolvedHelperIdentities", () => {
     );
 
     expect(identityFor(identities, "requireUser")).toEqual({
+      requires_key: "auth_helpers",
       symbol: "requireUser",
+      specifier: "@/lib/gone",
       mode: "unresolved",
       files: []
     });
+  });
+
+  it("a_symbol_used_by_two_requires_lists_keeps_both_identities", () => {
+    /**
+     * B3: `symbol` is unique WITHIN a requires list, never across them. The engine keeps the lists
+     * apart - `accepted_auth_helpers_for_convention`, `phase6_helpers_from_requires` and
+     * `security_helpers_from_requires` each build their own map - so a name reused by an auth
+     * helper and a response serializer is two helpers there and must be two here.
+     *
+     * Keying by symbol alone collapsed them, last list read winning. The damage is not cosmetic:
+     * below, the auth helper resolves (`repo_resolved`, a real file identity) and the serializer
+     * does not (`external`). Collapsing yielded the single entry
+     * `{"symbol":"dup","mode":"external","files":[]}`, destroying the auth identity - so Sprint 4
+     * would apply exact-specifier matching to an auth helper that had a resolved file. That is the
+     * silent tier-1 retention this sprint exists to prevent, manufactured by the design itself,
+     * and which list won depended on the order of a literal.
+     */
+    const identities = resolvedHelperIdentities(
+      checkData,
+      conventionRequiring({
+        auth_helpers: [{ guard_id: "auth:dup", symbol: "dup", import: "@/lib/auth" }],
+        response_serializers: [
+          { serializer_id: "serializer:dup", imported_name: "dup", import_source: "next-auth" }
+        ]
+      })
+    );
+
+    expect(identities).toEqual([
+      {
+        requires_key: "auth_helpers",
+        symbol: "dup",
+        specifier: "@/lib/auth",
+        mode: "repo_resolved",
+        files: ["src/lib/auth.ts"]
+      },
+      {
+        requires_key: "response_serializers",
+        symbol: "dup",
+        specifier: "next-auth",
+        mode: "external",
+        files: []
+      }
+    ]);
   });
 
   it("reads every accepted security helper list, whichever key its module hides under", () => {
@@ -285,13 +336,16 @@ describe("resolvedHelperIdentities", () => {
       })
     );
 
-    expect(identities.map((identity) => [identity.symbol, identity.mode])).toEqual([
-      ["allowOutbound", "unresolved"],
-      ["assertCsrf", "repo_resolved"],
-      ["parseBody", "repo_resolved"],
-      ["ratelimit", "external"],
-      ["requireUser", "repo_resolved"],
-      ["toDto", "repo_resolved"]
-    ]);
+    // Ordered by requires list, then symbol - so the grouping a consumer joins on is the grouping
+    // the array already has.
+    expect(identities.map((identity) => [identity.requires_key, identity.symbol, identity.mode]))
+      .toEqual([
+        ["auth_helpers", "requireUser", "repo_resolved"],
+        ["csrf_helpers", "assertCsrf", "repo_resolved"],
+        ["outbound_url_allowlist_helpers", "allowOutbound", "unresolved"],
+        ["rate_limit_helpers", "ratelimit", "external"],
+        ["response_serializers", "toDto", "repo_resolved"],
+        ["validators", "parseBody", "repo_resolved"]
+      ]);
   });
 });

--- a/packages/cli/test/cli.test.ts
+++ b/packages/cli/test/cli.test.ts
@@ -4426,6 +4426,76 @@ storage_schema_version: MIGRATIONS.length
     }
   });
 
+  /**
+   * S3-04: a characterization lock, not a red test. It passes today, and its job is to keep passing.
+   *
+   * Accepted-helper resolution classifies a specifier `repo_resolved` on the strength of an
+   * `IMPORT_RESOLVES_TO_MODULE` edge in `checkData`, and trusts that edge came from the Rust
+   * resolver. Nothing in `resolvedHelperIdentities` verifies that, and nothing needs to - but only
+   * because of a guarantee established somewhere else entirely.
+   *
+   * There are two graphs in this codebase. The engine-streamed edges collected in
+   * `collect-scan-data.ts` are what every check sees. A separate TypeScript-derived graph in
+   * `packages/factgraph/src/index.ts` also emits `IMPORT_RESOLVES_TO_MODULE`, via a WEAKER
+   * resolver - but it is built from one call site (`scan-status.ts`), for a stored artifact, and
+   * only when the Rust engine produced no graph. In that state `run-check.ts` exits
+   * `CHECK_EXIT_REFUSED` with `blocked_reasons: ["typescript_fallback_used"]` BEFORE any check
+   * runs, at the refusal site in `runCheck` that builds the `status: "refused"` envelope and the
+   * `typescript_fallback_used` failure. So the weaker edges can never reach helper resolution.
+   *
+   * That ordering is the entire warrant for trusting `repo_resolved`. Softening the refusal - so
+   * that a degraded scan proceeds to evaluate conventions - would quietly feed a weaker resolver's
+   * edges into accepted-helper identity, and every helper it mis-resolved would still report
+   * `mode: "repo_resolved"` as though the Rust resolver had answered. This fails loudly instead.
+   *
+   * The `blocked_reasons` and exit-code assertions are shared with the enforcement test above; what
+   * is pinned HERE is that nothing was evaluated - no findings, no security boundary proofs, and no
+   * evaluation receipts, which a convention that had actually been checked would have produced.
+   */
+  it("a_typescript_fallback_scan_refuses_before_any_helper_resolution_runs", async () => {
+    const { databasePath, repoRoot } = await seedAcceptedDatabase();
+    const diffFile = join(repoRoot, "..", "diff.patch");
+    const previousBin = process.env.DRIFT_ENGINE_BIN;
+    const previousFallback = process.env.DRIFT_ALLOW_TYPESCRIPT_ENGINE_FALLBACK;
+    try {
+      process.env.DRIFT_ENGINE_BIN = join(repoRoot, "..", "missing-engine");
+      process.env.DRIFT_ALLOW_TYPESCRIPT_ENGINE_FALLBACK = "1";
+
+      const result = await runCli([
+        "--db", databasePath,
+        "check",
+        "--repo", "repo_abc",
+        "--diff-file", diffFile,
+        "--scope", "changed-hunks",
+        "--now", "2026-05-10T00:00:30.000Z",
+        "--json"
+      ]);
+
+      // CHECK_EXIT_REFUSED.
+      expect(result.exitCode).toBe(3);
+      const payload = JSON.parse(result.stdout);
+      expect(payload.summary.blocked_reasons).toContain("typescript_fallback_used");
+
+      // The refusal came first: the seeded convention was never evaluated, so no resolver of any
+      // strength was consulted about any specifier on this run.
+      expect(payload.findings).toEqual([]);
+      expect(payload.security_boundary_proofs).toEqual([]);
+      expect(payload.summary.evaluation_receipts).toBeUndefined();
+      expect(payload.check.status).toBe("refused");
+    } finally {
+      if (previousBin === undefined) {
+        delete process.env.DRIFT_ENGINE_BIN;
+      } else {
+        process.env.DRIFT_ENGINE_BIN = previousBin;
+      }
+      if (previousFallback === undefined) {
+        delete process.env.DRIFT_ALLOW_TYPESCRIPT_ENGINE_FALLBACK;
+      } else {
+        process.env.DRIFT_ALLOW_TYPESCRIPT_ENGINE_FALLBACK = previousFallback;
+      }
+    }
+  });
+
   it("expires existing findings when their accepted convention has expired", async () => {
     const { databasePath } = await seedAcceptedDatabase();
     const storage = openDriftStorage({ databasePath });

--- a/packages/cli/test/contract-liveness-bb4.test.ts
+++ b/packages/cli/test/contract-liveness-bb4.test.ts
@@ -9,7 +9,7 @@ import { runCli } from "../src/index.js";
 /**
  * BB-4: a forbidden import that resolves to nothing is a warning, not a silence.
  *
- * `forbiddenModuleFiles_` derives a forbidden module's identity from the repo's own resolved import
+ * `resolvedModuleFilesFor` derives a forbidden module's identity from the repo's own resolved import
  * edges, falling back to specifier-string matching. That design is right - it is what closed the
  * `../../../lib/prisma` and barrel-re-export bypasses (T93) - but it fails silently: rename the data
  * module and update every import, as any refactor would, and the accepted convention matches nothing

--- a/packages/cli/test/engine-bridge.test.ts
+++ b/packages/cli/test/engine-bridge.test.ts
@@ -592,6 +592,12 @@ describe("engine scan data bridge", () => {
      *
      * So this test pins both halves. The identities land under `matcher`, and `requires` comes out
      * byte-identical to what was stored.
+     *
+     * PLACEMENT ONLY. This calls `engineCheckRequest` directly and hands it the identities, so it
+     * says nothing about whether any caller ever passes them - the first wiring went to a dispatch
+     * loop whose only kind has no helpers, and this test was green throughout. That the field is
+     * emitted on a real run is `accepted-helper-identity-dispatch.test.ts`, which drives the actual
+     * dispatch loop and reads the JSON that crossed the process boundary.
      */
     const storedRequires = {
       auth_helpers: [

--- a/packages/cli/test/engine-bridge.test.ts
+++ b/packages/cli/test/engine-bridge.test.ts
@@ -628,7 +628,13 @@ describe("engine scan data bridge", () => {
     };
 
     const acceptedHelperModuleFiles = [
-      { symbol: "requireUser", mode: "repo_resolved" as const, files: ["src/lib/auth.ts"] }
+      {
+        requires_key: "auth_helpers",
+        symbol: "requireUser",
+        specifier: "@/lib/auth",
+        mode: "repo_resolved" as const,
+        files: ["src/lib/auth.ts"]
+      }
     ];
 
     const request = engineCheckRequest({

--- a/packages/cli/test/engine-bridge.test.ts
+++ b/packages/cli/test/engine-bridge.test.ts
@@ -660,6 +660,54 @@ describe("engine scan data bridge", () => {
     expect(JSON.stringify(sent.requires)).toBe(JSON.stringify(storedRequires));
   });
 
+  it("sorts forbidden_module_files, which the graph produced in edge order", () => {
+    /**
+     * The sibling field one line above `accepted_helper_module_files` in the same request object.
+     * It is built from a Set filled in graph-edge order, so the same repo could hand the engine the
+     * same files in different orders across runs - twelve edge permutations produced four distinct
+     * orderings.
+     *
+     * The determinism digest covers findings and never the request, so nothing downstream would
+     * notice. That was the stated reason for sorting the new field; it applies here verbatim, and
+     * the two fields should not disagree about whether order is meaningful.
+     */
+    const request = engineCheckRequest({
+      repoId: "repo_abc",
+      repoRoot: "/repo",
+      scanId: "scan_check_abc",
+      snapshots: [],
+      facts: [],
+      forbiddenModuleFiles: ["src/z.ts", "src/a.ts", "src/m.ts"],
+      conventions: [{
+        id: "convention_no_direct_db",
+        repo_id: "repo_abc",
+        contract_id: "contract_abc",
+        kind: "api_route_no_direct_data_access",
+        statement: "API routes should not import data-access clients directly.",
+        scope: { path_globs: ["app/api/**/route.ts"] },
+        matcher: {
+          kind: "api_route_no_direct_data_access",
+          forbidden_imports: ["@/lib/prisma"]
+        },
+        severity: "error",
+        enforcement_mode: "block",
+        enforcement_capability: "deterministic_check",
+        exceptions: [],
+        evidence_refs: [],
+        counterexample_refs: [],
+        accepted_by: "human",
+        accepted_at: "2026-05-10T00:00:00.000Z",
+        updated_at: "2026-05-10T00:00:00.000Z"
+      } as unknown as Parameters<typeof engineCheckRequest>[0]["conventions"][number]],
+      baseline: [],
+      diff: { files: [], deletedFiles: [] },
+      scope: "changed-hunks"
+    });
+
+    expect(request.contract.conventions[0]!.matcher.forbidden_module_files)
+      .toEqual(["src/a.ts", "src/m.ts", "src/z.ts"]);
+  });
+
   it("builds a stable fact graph artifact from snapshots and facts", () => {
     const artifact = buildFactGraphArtifact({
       repoId: "repo_abc",

--- a/packages/cli/test/engine-bridge.test.ts
+++ b/packages/cli/test/engine-bridge.test.ts
@@ -576,6 +576,78 @@ describe("engine scan data bridge", () => {
     });
   });
 
+  it("accepted_helper_module_files_is_a_typed_matcher_field_not_inside_requires", () => {
+    /**
+     * S3-03: where a CLI-computed field lands is a correctness question, not a style one.
+     *
+     * `requires` is the stored convention's contract, returned verbatim by `securityRequires` -
+     * what a human accepted. Injecting a CLI derivation into it mixes contract with derivation, and
+     * bypasses typing on the way: the protocol field is an untyped `Option<Value>` on the Rust
+     * side, so a typo-shaped key would ship silently and be read by nothing forever.
+     *
+     * `matcher` is the surface that already carries exactly this kind of derivation, typed:
+     * `forbidden_module_files` sits in `CheckMatcher`, computed CLI-side for the same structural
+     * reason - the engine sees a graph scoped to the changed files and cannot resolve a specifier
+     * whose meaning is established outside the diff.
+     *
+     * So this test pins both halves. The identities land under `matcher`, and `requires` comes out
+     * byte-identical to what was stored.
+     */
+    const storedRequires = {
+      auth_helpers: [
+        { guard_id: "auth:requireUser", symbol: "requireUser", import: "@/lib/auth" }
+      ]
+    };
+    const convention = {
+      id: "convention_auth_helper",
+      repo_id: "repo_abc",
+      contract_id: "contract_abc",
+      kind: "api_route_requires_auth_helper",
+      statement: "API routes must call an accepted auth helper.",
+      scope: { path_globs: ["app/api/**/route.ts"] },
+      matcher: {
+        kind: "api_route_requires_auth_helper",
+        required_calls: ["requireUser"]
+      },
+      requires: storedRequires,
+      severity: "error",
+      enforcement_mode: "block",
+      enforcement_capability: "deterministic_check",
+      exceptions: [],
+      evidence_refs: [],
+      counterexample_refs: [],
+      accepted_by: "human",
+      accepted_at: "2026-05-10T00:00:00.000Z",
+      updated_at: "2026-05-10T00:00:00.000Z"
+    };
+
+    const acceptedHelperModuleFiles = [
+      { symbol: "requireUser", mode: "repo_resolved" as const, files: ["src/lib/auth.ts"] }
+    ];
+
+    const request = engineCheckRequest({
+      repoId: "repo_abc",
+      repoRoot: "/repo",
+      scanId: "scan_check_abc",
+      snapshots: [],
+      facts: [],
+      acceptedHelperModuleFiles,
+      conventions: [convention as unknown as Parameters<typeof engineCheckRequest>[0]["conventions"][number]],
+      baseline: [],
+      diff: { files: [], deletedFiles: [] },
+      scope: "changed-hunks"
+    });
+
+    const sent = request.contract.conventions[0];
+    expect(sent.matcher).toMatchObject({
+      accepted_helper_module_files: acceptedHelperModuleFiles
+    });
+    // Not smuggled into the contract surface.
+    expect(sent.requires).not.toHaveProperty("accepted_helper_module_files");
+    // And the contract surface is untouched, byte for byte.
+    expect(JSON.stringify(sent.requires)).toBe(JSON.stringify(storedRequires));
+  });
+
   it("builds a stable fact graph artifact from snapshots and facts", () => {
     const artifact = buildFactGraphArtifact({
       repoId: "repo_abc",

--- a/packages/cli/test/helpers/scan-data.ts
+++ b/packages/cli/test/helpers/scan-data.ts
@@ -1,0 +1,92 @@
+import type { GraphEdge, GraphNode } from "@drift/factgraph";
+import type { ScanData } from "../../src/engine/collect-scan-data.js";
+
+/**
+ * A minimal engine-produced `ScanData` carrying only a graph.
+ *
+ * The resolver under test reads `graph_nodes` and `graph_edges` and nothing else, so everything
+ * else is filled with the empty shape rather than a fixture. `engineSource: "rust"` is not
+ * decoration: every consumer of `IMPORT_RESOLVES_TO_MODULE` in the check path is reachable only
+ * on the engine path, because the TypeScript fallback refuses before any check runs
+ * (`run-check.ts`, the `typescript_fallback_used` refusal). A synthetic ScanData that claimed
+ * `"typescript"` would describe a state the check path cannot observe.
+ */
+export function graphScanData(input: {
+  nodes: GraphNode[];
+  edges: GraphEdge[];
+}): ScanData {
+  return {
+    files: [],
+    facts: [],
+    snapshots: [],
+    engineSource: "rust",
+    fallbackStatus: {
+      engine_source: "rust",
+      fallback_used: false,
+      fallback_reason: null,
+      engine_error_message: null,
+      degraded_capabilities: [],
+      enforcement_degraded: false,
+      engine_resolution: "workspace_release_binary",
+      engine_build_profile: "release"
+    },
+    diagnostics: [],
+    graph_nodes: input.nodes,
+    graph_edges: input.edges,
+    graph_evidence: [],
+    graph_diagnostics: [],
+    framework_adapters: [],
+    normalized_entrypoints: [],
+    framework_parser_gaps: [],
+    framework_capabilities: []
+  };
+}
+
+/** An `import_decl` node as the engine emits it: the specifier lives in `metadata.source`. */
+export function importNode(input: {
+  id: string;
+  filePath: string;
+  source: string;
+  localName?: string;
+}): GraphNode {
+  return {
+    id: input.id,
+    kind: "import_decl",
+    label: input.source,
+    stable: true,
+    evidence_ids: [],
+    metadata: {
+      file_path: input.filePath,
+      source: input.source,
+      local_name: input.localName ?? "helper"
+    }
+  };
+}
+
+/** A `module` node: the file it is defined by lives in `metadata.file_path`. */
+export function moduleNode(input: { id: string; filePath: string }): GraphNode {
+  return {
+    id: input.id,
+    kind: "module",
+    label: input.filePath,
+    stable: true,
+    evidence_ids: [],
+    metadata: { file_path: input.filePath }
+  };
+}
+
+export function graphEdge(input: {
+  id: string;
+  kind: GraphEdge["kind"];
+  from: string;
+  to: string;
+}): GraphEdge {
+  return {
+    id: input.id,
+    kind: input.kind,
+    from: input.from,
+    to: input.to,
+    evidence_ids: [],
+    metadata: {}
+  };
+}

--- a/packages/cli/test/helpers/scan-data.ts
+++ b/packages/cli/test/helpers/scan-data.ts
@@ -75,11 +75,31 @@ export function moduleNode(input: { id: string; filePath: string }): GraphNode {
   };
 }
 
+/**
+ * A `symbol` node. The engine puts the symbol's name in the node LABEL (`insert_node(..., Symbol,
+ * &fact.name, ...)`), not in metadata, so that is where the name lives here too.
+ */
+export function symbolNode(input: { id: string; filePath: string; name: string }): GraphNode {
+  return {
+    id: input.id,
+    kind: "symbol",
+    label: input.name,
+    stable: true,
+    evidence_ids: [],
+    metadata: { file_path: input.filePath, symbol_kind: "function", exported: true }
+  };
+}
+
 export function graphEdge(input: {
   id: string;
   kind: GraphEdge["kind"];
   from: string;
   to: string;
+  /**
+   * `MODULE_REEXPORTS_MODULE` carries the re-exported name here - a symbol name for
+   * `export { x } from "./m"`, or `"*"` for a flattening `export * from "./m"`.
+   */
+  exportedName?: string;
 }): GraphEdge {
   return {
     id: input.id,
@@ -87,6 +107,6 @@ export function graphEdge(input: {
     from: input.from,
     to: input.to,
     evidence_ids: [],
-    metadata: {}
+    metadata: input.exportedName === undefined ? {} : { exported_name: input.exportedName }
   };
 }

--- a/packages/cli/test/resolved-module-files.test.ts
+++ b/packages/cli/test/resolved-module-files.test.ts
@@ -1,20 +1,23 @@
 import { describe, expect, it } from "vitest";
-import { forbiddenModuleFiles_, resolvedModuleFilesFor } from "../src/check/run-check.js";
+import { resolvedModuleFilesFor } from "../src/check/run-check.js";
 import { graphEdge, graphScanData, importNode, moduleNode } from "./helpers/scan-data.js";
 
 /**
  * S3-01: the specifier resolver stops being about forbidden imports specifically.
  *
- * `forbiddenModuleFiles_` answers one question - "what files do these specifiers actually resolve
- * to, according to the repo's own resolved-import edges" - and answers it for the one caller that
- * happened to need it first. The accepted-security-helper side of the pipeline needs the identical
- * answer about a different specifier list, and the wrong way to get it is a second walk over
- * `IMPORT_RESOLVES_TO_MODULE` that can drift out of agreement with this one.
+ * `forbiddenModuleFiles_` answered a question that has nothing to do with the word "forbidden" in
+ * its name: given some import specifiers, what files does this repo actually resolve them to. It
+ * answers it from the repo's own `IMPORT_RESOLVES_TO_MODULE` edges rather than by re-resolving,
+ * which is why it cannot disagree with the resolver that built the graph - and that property is
+ * what closed the T93 bypasses, where `../../lib/prisma` and a barrel re-export of the same module
+ * both slipped past specifier-string comparison.
  *
- * So this is a characterization lock rather than a behaviour test. It asserts nothing about what
- * the right answer IS; it asserts that generalising the function did not change the answer the
- * forbidden-import path already relies on. If a later change to `resolvedModuleFilesFor` shifts
- * that answer, the T93 bypass closures ride on it and this fails first.
+ * This is the characterization lock over that extraction, and it pins the ANSWER rather than an
+ * identity. The first version of this file compared `resolvedModuleFilesFor` against
+ * `forbiddenModuleFiles_` - which by then was a one-line caller of it, so the test compared a
+ * function to itself and could not fail. Replacing the entire body of the resolver with
+ * `return new Set(["MUTANT/does-not-exist.ts"])` left it green. Every row below now names the files
+ * that specifier list must produce, so a resolver that stops resolving fails here first.
  */
 describe("resolvedModuleFilesFor", () => {
   /**
@@ -46,51 +49,65 @@ describe("resolvedModuleFilesFor", () => {
   });
 
   /**
-   * Every specifier list the forbidden-import path can hand this function, including the two
-   * degenerate ones. The empty list matters: `graphImportResolvesToForbidden` returns early on it
-   * today, but `run-check.ts` still calls the resolver directly with
-   * `convention.matcher.forbidden_imports ?? []` when building the engine request, so an empty
-   * list reaching it is a live shape, not a hypothetical.
+   * Every specifier list the forbidden-import path can hand this function, each with the answer it
+   * must produce. The empty list matters: `run-check.ts` calls the resolver with
+   * `convention.matcher.forbidden_imports ?? []` when building the engine request, so an empty list
+   * reaching it is a live shape rather than a hypothetical.
+   *
+   * `@/lib` resolving to all three modules beneath it is the subpath relation this default
+   * behaviour is built on, and is exactly what an ACCEPTED helper list must NOT do - see
+   * `SpecifierMatch` and the accepted-helper identity tests.
+   *
+   * `@/lib/prisma` does NOT pick up `@/lib/prisma-legacy`: the relation is bounded at `/`, and that
+   * boundary is what keeps the T03 negative control green.
    */
-  const specifierLists: string[][] = [
-    [],
-    ["@/lib/prisma"],
-    ["../../lib/prisma"],
-    ["@/lib/prisma", "../../lib/prisma"],
-    ["@/lib/prisma-legacy"],
-    ["@/lib/barrel"],
-    ["next-auth"],
-    ["@/lib"],
-    ["@/lib/prisma", "next-auth", "@/lib/barrel"]
+  const cases: Array<{ specifiers: string[]; files: string[] }> = [
+    { specifiers: [], files: [] },
+    { specifiers: ["@/lib/prisma"], files: ["src/lib/prisma.ts"] },
+    { specifiers: ["../../lib/prisma"], files: ["src/lib/prisma.ts"] },
+    { specifiers: ["@/lib/prisma", "../../lib/prisma"], files: ["src/lib/prisma.ts"] },
+    { specifiers: ["@/lib/prisma-legacy"], files: ["src/lib/prisma-legacy.ts"] },
+    { specifiers: ["@/lib/barrel"], files: ["src/lib/barrel.ts"] },
+    { specifiers: ["next-auth"], files: [] },
+    {
+      specifiers: ["@/lib"],
+      files: ["src/lib/barrel.ts", "src/lib/prisma-legacy.ts", "src/lib/prisma.ts"]
+    },
+    {
+      specifiers: ["@/lib/prisma", "next-auth", "@/lib/barrel"],
+      files: ["src/lib/barrel.ts", "src/lib/prisma.ts"]
+    }
   ];
 
-  it("resolvedModuleFilesFor_matches_forbiddenModuleFiles_", () => {
-    for (const specifiers of specifierLists) {
+  it("resolves each specifier list to the files the repo says it means", () => {
+    for (const { specifiers, files } of cases) {
       expect(
         [...resolvedModuleFilesFor(checkData, specifiers)].sort(),
         `specifiers: ${JSON.stringify(specifiers)}`
-      ).toEqual([...forbiddenModuleFiles_(checkData, specifiers)].sort());
+      ).toEqual(files);
     }
   });
 
   /**
-   * The lock above would pass if both functions returned the empty set for everything, so pin the
-   * one answer that makes it worth locking: two differently-typed specifiers naming one file agree,
-   * and the lookalike does not join them.
+   * The subpath relation is the DEFAULT, and an accepted-helper list must never get it. Pinned here
+   * so that flipping the default - which would silently widen every accepted helper - fails in the
+   * file that documents the relation rather than only in the security tests downstream.
    */
-  it("resolves two spellings of one module to the same file, and a lookalike to its own", () => {
-    expect([...resolvedModuleFilesFor(checkData, ["@/lib/prisma", "../../lib/prisma"])])
+  it("matches a specifier or its subpaths by default, and only the exact specifier on request", () => {
+    expect([...resolvedModuleFilesFor(checkData, ["@/lib"], "specifier_or_subpath")].sort())
+      .toEqual(["src/lib/barrel.ts", "src/lib/prisma-legacy.ts", "src/lib/prisma.ts"]);
+    expect([...resolvedModuleFilesFor(checkData, ["@/lib"], "exact_specifier")]).toEqual([]);
+    expect([...resolvedModuleFilesFor(checkData, ["@/lib/prisma"], "exact_specifier")])
       .toEqual(["src/lib/prisma.ts"]);
-    expect([...resolvedModuleFilesFor(checkData, ["@/lib/prisma-legacy"])])
-      .toEqual(["src/lib/prisma-legacy.ts"]);
   });
 
   /**
-   * A bare package name resolves to nothing, because the Rust resolver filters to paths inside the
-   * scan snapshot and `node_modules` is outside it. This is the emptiness that S3-02 must classify
-   * rather than treat as "no such helper".
+   * A bare package resolves to nothing, because the Rust resolver filters to paths inside the scan
+   * snapshot and `node_modules` is outside it. This is the emptiness that helper identity must
+   * classify as `external` rather than treat as "no such helper".
    */
   it("returns nothing for an external package, which has no resolution edge by design", () => {
     expect([...resolvedModuleFilesFor(checkData, ["next-auth"])]).toEqual([]);
   });
+
 });

--- a/packages/cli/test/resolved-module-files.test.ts
+++ b/packages/cli/test/resolved-module-files.test.ts
@@ -1,0 +1,96 @@
+import { describe, expect, it } from "vitest";
+import { forbiddenModuleFiles_, resolvedModuleFilesFor } from "../src/check/run-check.js";
+import { graphEdge, graphScanData, importNode, moduleNode } from "./helpers/scan-data.js";
+
+/**
+ * S3-01: the specifier resolver stops being about forbidden imports specifically.
+ *
+ * `forbiddenModuleFiles_` answers one question - "what files do these specifiers actually resolve
+ * to, according to the repo's own resolved-import edges" - and answers it for the one caller that
+ * happened to need it first. The accepted-security-helper side of the pipeline needs the identical
+ * answer about a different specifier list, and the wrong way to get it is a second walk over
+ * `IMPORT_RESOLVES_TO_MODULE` that can drift out of agreement with this one.
+ *
+ * So this is a characterization lock rather than a behaviour test. It asserts nothing about what
+ * the right answer IS; it asserts that generalising the function did not change the answer the
+ * forbidden-import path already relies on. If a later change to `resolvedModuleFilesFor` shifts
+ * that answer, the T93 bypass closures ride on it and this fails first.
+ */
+describe("resolvedModuleFilesFor", () => {
+  /**
+   * Three shapes the forbidden-import path already depends on, in one graph:
+   *   - two distinct specifiers for the same file (`@/lib/prisma` and `../../lib/prisma`), which is
+   *     the whole reason resolution beats string comparison;
+   *   - a lookalike (`@/lib/prisma-legacy`) that must resolve to its own file and stay out;
+   *   - a bare package (`next-auth`) with no resolution edge at all, which is what an external
+   *     import looks like in this graph - the Rust resolver filters to paths inside the snapshot.
+   */
+  const checkData = graphScanData({
+    nodes: [
+      importNode({ id: "import:a", filePath: "app/api/a/route.ts", source: "@/lib/prisma" }),
+      importNode({ id: "import:b", filePath: "app/api/b/route.ts", source: "../../lib/prisma" }),
+      importNode({ id: "import:c", filePath: "app/api/c/route.ts", source: "@/lib/prisma-legacy" }),
+      importNode({ id: "import:d", filePath: "app/api/d/route.ts", source: "@/lib/barrel" }),
+      importNode({ id: "import:e", filePath: "app/api/e/route.ts", source: "next-auth" }),
+      moduleNode({ id: "module:prisma", filePath: "src/lib/prisma.ts" }),
+      moduleNode({ id: "module:legacy", filePath: "src/lib/prisma-legacy.ts" }),
+      moduleNode({ id: "module:barrel", filePath: "src/lib/barrel.ts" })
+    ],
+    edges: [
+      graphEdge({ id: "e1", kind: "IMPORT_RESOLVES_TO_MODULE", from: "import:a", to: "module:prisma" }),
+      graphEdge({ id: "e2", kind: "IMPORT_RESOLVES_TO_MODULE", from: "import:b", to: "module:prisma" }),
+      graphEdge({ id: "e3", kind: "IMPORT_RESOLVES_TO_MODULE", from: "import:c", to: "module:legacy" }),
+      graphEdge({ id: "e4", kind: "IMPORT_RESOLVES_TO_MODULE", from: "import:d", to: "module:barrel" }),
+      graphEdge({ id: "e5", kind: "MODULE_REEXPORTS_MODULE", from: "module:barrel", to: "module:prisma" })
+    ]
+  });
+
+  /**
+   * Every specifier list the forbidden-import path can hand this function, including the two
+   * degenerate ones. The empty list matters: `graphImportResolvesToForbidden` returns early on it
+   * today, but `run-check.ts` still calls the resolver directly with
+   * `convention.matcher.forbidden_imports ?? []` when building the engine request, so an empty
+   * list reaching it is a live shape, not a hypothetical.
+   */
+  const specifierLists: string[][] = [
+    [],
+    ["@/lib/prisma"],
+    ["../../lib/prisma"],
+    ["@/lib/prisma", "../../lib/prisma"],
+    ["@/lib/prisma-legacy"],
+    ["@/lib/barrel"],
+    ["next-auth"],
+    ["@/lib"],
+    ["@/lib/prisma", "next-auth", "@/lib/barrel"]
+  ];
+
+  it("resolvedModuleFilesFor_matches_forbiddenModuleFiles_", () => {
+    for (const specifiers of specifierLists) {
+      expect(
+        [...resolvedModuleFilesFor(checkData, specifiers)].sort(),
+        `specifiers: ${JSON.stringify(specifiers)}`
+      ).toEqual([...forbiddenModuleFiles_(checkData, specifiers)].sort());
+    }
+  });
+
+  /**
+   * The lock above would pass if both functions returned the empty set for everything, so pin the
+   * one answer that makes it worth locking: two differently-typed specifiers naming one file agree,
+   * and the lookalike does not join them.
+   */
+  it("resolves two spellings of one module to the same file, and a lookalike to its own", () => {
+    expect([...resolvedModuleFilesFor(checkData, ["@/lib/prisma", "../../lib/prisma"])])
+      .toEqual(["src/lib/prisma.ts"]);
+    expect([...resolvedModuleFilesFor(checkData, ["@/lib/prisma-legacy"])])
+      .toEqual(["src/lib/prisma-legacy.ts"]);
+  });
+
+  /**
+   * A bare package name resolves to nothing, because the Rust resolver filters to paths inside the
+   * scan snapshot and `node_modules` is outside it. This is the emptiness that S3-02 must classify
+   * rather than treat as "no such helper".
+   */
+  it("returns nothing for an external package, which has no resolution edge by design", () => {
+    expect([...resolvedModuleFilesFor(checkData, ["next-auth"])]).toEqual([]);
+  });
+});

--- a/packages/cli/test/resolved-module-files.test.ts
+++ b/packages/cli/test/resolved-module-files.test.ts
@@ -110,4 +110,32 @@ describe("resolvedModuleFilesFor", () => {
     expect([...resolvedModuleFilesFor(checkData, ["next-auth"])]).toEqual([]);
   });
 
+  /**
+   * The memo key joined the specifiers with NUL, which is an ambiguous encoding: a two-specifier
+   * list and a one-specifier list whose single entry contains the separator produce the same key,
+   * so the second call to arrive silently receives the first one's answer.
+   *
+   * Defensive rather than observed - no real specifier contains a NUL byte. But the key is derived
+   * from caller-supplied contract data, the cache is memoised for the lifetime of a ScanData, and
+   * a wrong answer here is a wrong verdict about a forbidden import. A structural encoding costs
+   * one function call and removes the question.
+   */
+  it("does not let two different specifier lists share one cache entry", () => {
+    const collide = graphScanData({
+      nodes: [
+        importNode({ id: "import:x", filePath: "app/api/x/route.ts", source: "@/a" }),
+        moduleNode({ id: "module:x", filePath: "src/a.ts" })
+      ],
+      edges: [
+        graphEdge({ id: "j1", kind: "IMPORT_RESOLVES_TO_MODULE", from: "import:x", to: "module:x" })
+      ]
+    });
+
+    // Populates the cache under a key the next call must not reuse.
+    expect([...resolvedModuleFilesFor(collide, ["@/a", "@/b"])]).toEqual(["src/a.ts"]);
+    // One specifier, spelled with the old separator inside it. It matches no import, so the honest
+    // answer is empty; the ambiguous key handed back the previous list's answer instead.
+    expect([...resolvedModuleFilesFor(collide, ["@/a\u0000@/b"])]).toEqual([]);
+  });
+
 });


### PR DESCRIPTION
Sprint 3 of the security-convention pipeline refactor. Computes, per accepted security helper, what its import specifier **actually resolves to** — and what mode that answer came from — and ships it to the engine as a typed matcher field.

**The engine accepts and ignores it. No engine behavior changes.** Sprint 4 consumes it.

Revised after adversarial review — four blockers, all fixed. See **Review round**.

## Why

The pipeline decides "does this call resolve to the accepted security helper" at two strengths, both wrong in opposite directions:

- **Tier 0, name only** — accepts any module exporting the right symbol, so a helper from `@/lib/attacker-controlled` produces a passing auth proof. Laundering.
- **Tier 1, name + specifier string** — compares the specifier *as typed*, so `../../lib/auth` and `@/lib/auth` (the same file) disagree, a barrel import fails, and a renamed import fails outright. False alarms.

Only resolved module identity dominates both. This computes it.

## Modes, per helper — not per convention

| mode | when | what Sprint 4 will do |
|---|---|---|
| `repo_resolved` | the specifier produced an `IMPORT_RESOLVES_TO_MODULE` edge resolving to a usable file | resolved-file identity, including re-export chains |
| `external` | a bare package specifier that resolved to nothing | exact specifier match + local-shadow check |
| `unresolved` | a repo-relative specifier that resolved to nothing | exact specifier match, degradation recorded |

External imports produce no resolution edge **by design** — the Rust resolver only resolves into the scan snapshot. A per-convention "empty table → fall back to strings" would silently retain tier-1 semantics for every external auth helper, the most common real-world contract. Hence a per-helper mode, recorded rather than assumed.

## Review round — four blockers

### B1 — the feature never ran

The only call sat in the direct-data-access evaluator, whose loop `continue`s for every kind except `api_route_no_direct_data_access` — a kind marked `security_contract: false`, carrying no helper block at all. The twelve kinds that *do* have `auth_helpers` dispatch elsewhere and never received it. `accepted_helper_module_files` was never emitted on any real run, which voided the stated rationale for landing the wire shape first.

The existing test concealed it by hand-feeding the field into `engineCheckRequest` on the exact kind that in production never receives it — testing the last inch while the pipe upstream was disconnected.

Fixed by **moving** the call (not adding a second one — leaving a dead computation behind reads as coverage). The new test onboards a real repo, runs a real `check` through the real dispatch loop, and reads the JSON that actually crossed the process boundary.

### B2 — the characterization lock could not fail

`forbiddenModuleFiles_` had been reduced to a one-line passthrough, so the "lock" compared a function against itself — and via the shared memo cache, against the same Set object. Verified: replacing the resolver body with `new Set(["MUTANT/does-not-exist.ts"])` left the named lock green while its neighbors died.

The lock now pins literal expected files for all nine specifier lists. Under the same mutation **all four tests fail**. `forbiddenModuleFiles_` is deleted rather than re-commented — once nothing compares against it, it is a rename with no callers. Both false comments corrected.

### B3 — symbol collision silently downgraded a helper

Identities were keyed by symbol alone across all six requires-lists, last write wins, justified by a symmetry with the engine that does not exist — the engine's maps are **per-list**. Verified: a symbol present as an auth helper at `@/lib/auth` and as a serializer at `next-auth` collapsed to one `external` entry, destroying the `repo_resolved` auth identity. Sprint 4 would then apply exact-specifier matching to it — the silent tier-1 retention this sprint exists to prevent, produced by the design itself.

Now keyed `(requires_key, symbol)`, and both `requires_key` and `specifier` ship on the wire — without them Sprint 4 cannot join an identity back to its helper, since the six lists spell their symbol and module fields differently.

### B4 — the laundering guard was one-sided

The re-export closure followed every `MODULE_REEXPORTS_MODULE` edge **unfiltered by the helper's symbol**, so a barrel re-exporting `attacker-controlled.ts` pulled it into the accepted helper's identity. The headline test passed only because its fixture's barrel happened to re-export just `auth`. The cheaper attack (drop a file under the prefix) was closed; the stronger one (edit the barrel) was open.

The graph already carried the distinction unread: `MODULE_REEXPORTS_MODULE` records `exported_name`, `MODULE_EXPORTS_SYMBOL` records what a module exports. The rule now:

- modules the specifier **names** are kept unconditionally — not a symbol claim, so nothing to evidence
- everything **beyond** is a claim needing evidence — a named edge is self-proving; a star edge requires the target to supply the symbol directly or re-export it onward, recursively (in `barrel → mid → leaf`, a route importing `mid` really does get the symbol)

Keeping direct targets unconditional is what makes this safe rather than a new false-alarm source: with no symbol facts at all it narrows to what the specifier literally names — never empty, so it cannot turn a compliant route into a violation. Tested as its own case.

**Also documented as a limit**, because the filter compares symbol *names*, not identity: a barrel re-exporting one name from two modules still yields both, which is ambiguous in JavaScript itself. `files` is described at all three places Sprint 4 reads it as "modules that plausibly supply this helper" — never "proven to be it".

Two existing tests had to **gain evidence** rather than be adjusted: their fixtures asserted barrel behavior while carrying no `exported_name` and no export edges, so they were passing on the unfiltered closure and describing a graph the engine does not emit.

## Also fixed

- **The crux classifier was nearly untested** — four of five `isBarePackageSpecifier` branches survived mutation, including `./` and `../`, the commonest repo-relative forms. One case per branch; dropping `.` now kills 2 tests, `/` 1, `@/` 7, `~` 1, `#` 1.
- **Cache key** → `JSON.stringify`; `["a","b"]` and `["a\0b"]` shared an entry.
- **`forbidden_module_files` sorted at emission** — the sibling field one line above shipped in 4 distinct orderings across 12 edge permutations.
- **The hijack alarm is renamed** `package_specifier_resolves_in_repo`. It cannot distinguish a hijack from a pnpm workspace package or `"@app/*": ["src/*"]`, so it now states the fact and claims no intent.
- **`mode` is a Rust enum**, verified to reject: emitting `repo_resolvd` exits 1.

## Contract decisions for Sprint 4

1. `repo_resolved` requires a usable **file**, not merely an edge.
2. Helpers with no module specifier are **absent** from the array rather than `unresolved`.
3. `files` means "plausibly supplies this helper", not "proven to be it" (see B4).

## Verification

- **No engine behavior changed:** one Rust file, **91 insertions, 0 deletions**, **zero Rust test files changed**.
- 24 CLI identity tests (up from 8); `pnpm verify:ci` exits 0; `cargo test -p drift-engine` green.
- Independently mutation-verified: neutering `providesSymbol` kills 3 tests including the barrel-sibling case; neutering the resolver kills all 4 lock tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)