### PR TITLE
fix(vocabulary,engine,core,engine-contract): eight proof vocabularies, typed once instead of copied twice

### DIFF
--- a/crates/drift-engine/src/check_command.rs
+++ b/crates/drift-engine/src/check_command.rs
@@ -16,11 +16,11 @@ use drift_engine::{
     Phase6RawSqlContract, Phase6SecurityContract, Phase6SecurityProof, Phase6SsrfContract,
     RequestValidatorBehavior, RequestValidatorKind, RouteSecurityBoundaryProof, RuleFinding,
     ScanCapability, SecurityBoundaryProof, SecurityProofStatus, SessionTrustReason, Severity,
-    accepted_phase5_contract_from_requires, build_auth_boundary_proofs_for_file,
-    build_phase4_security_proof_with_policy, build_phase6_security_proofs_for_file,
-    classify_findings_against_diff, materialize_direct_data_access_findings,
-    materialize_direct_data_access_findings_with_sources, phase6_proof_to_json,
-    sensitive_field_source_is_trusted, sensitive_response_field_rejections,
+    TenantMissingReason, accepted_phase5_contract_from_requires,
+    build_auth_boundary_proofs_for_file, build_phase4_security_proof_with_policy,
+    build_phase6_security_proofs_for_file, classify_findings_against_diff,
+    materialize_direct_data_access_findings, materialize_direct_data_access_findings_with_sources,
+    phase6_proof_to_json, sensitive_field_source_is_trusted, sensitive_response_field_rejections,
 };
 use serde_json::json;
 
@@ -3624,12 +3624,20 @@ fn request_validation_proof_json(
 
 fn phase4_missing_code(proof: &SecurityBoundaryProof, convention_kind: &str) -> String {
     match convention_kind {
+        // Passed through unmapped, as it always was: every reason this builder emits is
+        // also a member of the finding-level SecurityMissingProofCodeSchema, so the two
+        // vocabularies agree here and need no bridge. The four members with no producer
+        // are recorded in the parity baseline.
         "api_route_requires_tenant_scope" => proof
             .tenant
             .missing
             .first()
-            .map(|missing| missing.reason.clone())
-            .unwrap_or_else(|| "tenant_predicate_missing".to_string()),
+            .map(|missing| missing.reason.as_wire().to_string())
+            .unwrap_or_else(|| {
+                TenantMissingReason::TenantPredicateMissing
+                    .as_wire()
+                    .to_string()
+            }),
         // Passed through unmapped, as it always was: every reason this builder emits
         // (authorization_guard_missing, session_not_trusted,
         // authorization_guard_not_dominating_sink) is also a member of the finding-level
@@ -3903,7 +3911,7 @@ fn phase4_proof_json(
             })).collect::<Vec<_>>(),
             "missing": proof.tenant.missing.iter().map(|missing| json!({
                 "data_operation_fact_id": missing.data_operation_fact_id,
-                "reason": missing.reason
+                "reason": missing.reason.as_wire()
             })).collect::<Vec<_>>()
         },
         "missing_proof": missing_proof,

--- a/crates/drift-engine/src/check_command.rs
+++ b/crates/drift-engine/src/check_command.rs
@@ -19,8 +19,8 @@ use drift_engine::{
     TenantMissingReason, accepted_phase5_contract_from_requires,
     build_auth_boundary_proofs_for_file, build_phase4_security_proof_with_policy,
     build_phase6_security_proofs_for_file, classify_findings_against_diff,
-    materialize_direct_data_access_findings, materialize_direct_data_access_findings_with_sources,
-    phase6_proof_to_json, sensitive_field_source_is_trusted, sensitive_response_field_rejections,
+    materialize_direct_data_access_findings_with_sources, phase6_proof_to_json,
+    sensitive_field_source_is_trusted, sensitive_response_field_rejections,
 };
 use serde_json::json;
 

--- a/crates/drift-engine/src/check_command.rs
+++ b/crates/drift-engine/src/check_command.rs
@@ -1575,7 +1575,7 @@ fn phase6_missing_code(proof: &Phase6SecurityProof, kind: &str) -> String {
     proof
         .parser_gaps
         .first()
-        .map(|gap| gap.code.clone())
+        .map(|gap| gap.code.as_wire().to_string())
         .or_else(|| missing.first().map(|missing| missing.code.clone()))
         .unwrap_or_else(|| "missing_phase6_proof".to_string())
 }
@@ -3006,7 +3006,7 @@ fn request_validation_missing_code(proof: &SecurityBoundaryProof) -> String {
     proof
         .parser_gaps
         .first()
-        .map(|gap| gap.code.clone())
+        .map(|gap| gap.code.as_wire().to_string())
         .or_else(|| {
             proof
                 .request_validation
@@ -3203,7 +3203,7 @@ fn phase5_proof_json(
                 } else {
                     "secret_exposure"
                 },
-                "code": gap.code,
+                "code": gap.code.as_wire(),
                 "file_path": gap.file_path,
                 "reason": gap.reason,
                 "affected_contract_kinds": [convention.kind.clone()],
@@ -3308,7 +3308,7 @@ fn route_security_proof_json(
             json!({
                 "parser_gap_id": gap.parser_gap_id,
                 "capability": "control_flow_guard_dominance",
-                "code": gap.code,
+                "code": gap.code.as_wire(),
                 "file_path": gap.file_path,
                 "reason": gap.reason,
                 "affected_contract_kinds": ["api_route_requires_auth_helper"],
@@ -3482,7 +3482,7 @@ fn request_validation_proof_json(
             json!({
                 "parser_gap_id": gap.parser_gap_id,
                 "capability": "request_validation_facts",
-                "code": gap.code,
+                "code": gap.code.as_wire(),
                 "file_path": gap.file_path,
                 "reason": gap.reason,
                 "affected_contract_kinds": ["api_route_requires_request_validation"],
@@ -3765,7 +3765,7 @@ fn phase4_proof_json(
             json!({
                 "parser_gap_id": gap.parser_gap_id,
                 "capability": phase4_expected_layer(&convention.kind),
-                "code": gap.code,
+                "code": gap.code.as_wire(),
                 "file_path": gap.file_path,
                 "reason": gap.reason,
                 "affected_contract_kinds": [convention.kind.clone()],

--- a/crates/drift-engine/src/check_command.rs
+++ b/crates/drift-engine/src/check_command.rs
@@ -15,7 +15,7 @@ use drift_engine::{
     Phase6AcceptedHelper, Phase6CorsContract, Phase6RawSqlContract, Phase6SecurityContract,
     Phase6SecurityProof, Phase6SsrfContract, RequestValidatorBehavior, RequestValidatorKind,
     RouteSecurityBoundaryProof, RuleFinding, ScanCapability, SecurityBoundaryProof,
-    SecurityProofStatus, Severity, accepted_phase5_contract_from_requires,
+    SecurityProofStatus, SessionTrustReason, Severity, accepted_phase5_contract_from_requires,
     build_auth_boundary_proofs_for_file, build_phase4_security_proof_with_policy,
     build_phase6_security_proofs_for_file, classify_findings_against_diff,
     materialize_direct_data_access_findings_with_sources, phase6_proof_to_json,
@@ -3639,20 +3639,37 @@ fn phase4_missing_code(proof: &SecurityBoundaryProof, convention_kind: &str) -> 
             .session_trust
             .missing_trust
             .first()
-            // Proof-level reasons and finding-level codes are separate vocabularies.
-            // This mapping must be TOTAL over the proof-level enum. A reason that falls
-            // through lands in SecurityMissingProofCodeSchema, and the consequence is NOT
-            // a soft one: engine-contract normalizes an unknown code to
-            // `unknown_reason_code` via a z.preprocess, but packages/core's copy is a
-            // plain hard z.enum, so it THROWS on the CLI's own read path and on all four
-            // storage parses. An unmapped reason is a second F1-class crash, not a
-            // degraded string.
+            // Proof-level reasons and finding-level codes are separate vocabularies, and
+            // this is the only bridge between them. The mapping must be TOTAL over the
+            // proof-level enum, and the consequence of a gap is NOT a soft one:
+            // engine-contract normalizes an unknown code to `unknown_reason_code` via a
+            // z.preprocess, but packages/core's copy is a plain hard z.enum, so it THROWS
+            // on the CLI's own read path and on all four storage parses. An unmapped
+            // reason is a second F1-class crash, not a degraded string.
             //
-            // NOTE the `.unwrap_or_else` below is a separate, live defect -- see
-            // `an_empty_missing_list_can_state_the_opposite_of_the_proof` in the tests.
-            .map(|missing| match missing.reason.as_str() {
-                "derived_from_request" | "unknown_helper" => "session_not_trusted".to_string(),
-                _ => missing.reason.clone(),
+            // S2-02 made `reason` a typed enum, so this match has NO catch-all arm and
+            // totality is now the compiler's problem rather than a reviewer's: adding a
+            // member to session_trust_reason fails to build until someone decides where it
+            // lands. That is the whole point of typing the field.
+            //
+            // The last arm is a characterization, not an endorsement. `missing_auth_guard`
+            // is a member of both vocabularies, so passing it through is correct.
+            // `parser_gap` is NOT a finding-level member - unreachable today, because the
+            // builder emits neither, and left unfixed on purpose: choosing a finding-level
+            // code for a parser-gapped session-trust proof is a product decision, not a
+            // mechanical one. A parser gap travels on the separate `parser_gaps` surface
+            // and drives `proof_status == ParserGap`, so answering `session_not_trusted`
+            // here would assert a trust failure that was never established.
+            //
+            // NOTE the `.unwrap_or_else` below is a separate, LIVE defect (issue #129) --
+            // see `an_empty_missing_list_can_state_the_opposite_of_the_proof` in the tests.
+            .map(|missing| match missing.reason {
+                SessionTrustReason::DerivedFromRequest | SessionTrustReason::UnknownHelper => {
+                    "session_not_trusted".to_string()
+                }
+                SessionTrustReason::MissingAuthGuard | SessionTrustReason::ParserGap => {
+                    missing.reason.as_wire().to_string()
+                }
             })
             .unwrap_or_else(|| "session_not_trusted".to_string()),
         _ => "missing_proof".to_string(),
@@ -3831,7 +3848,7 @@ fn phase4_proof_json(
             "missing_trust": proof.session_trust.missing_trust.iter().map(|missing| json!({
                 "fact_id": missing.fact_id,
                 "variable": missing.variable,
-                "reason": missing.reason
+                "reason": missing.reason.as_wire()
             })).collect::<Vec<_>>()
         },
         "authorization": {
@@ -4517,22 +4534,27 @@ mod finding_fingerprint_dc3_tests {
 mod phase4_missing_code_tests {
     use super::phase4_missing_code;
     use drift_engine::{
-        AcceptedAuthHelper, AuthGuardBehavior, SecurityBoundaryProof, build_phase4_security_proof,
+        AcceptedAuthHelper, AuthGuardBehavior, SecurityBoundaryProof, SessionTrustReason,
+        build_phase4_security_proof,
     };
 
     const SESSION_TRUST: &str = "session_object_must_come_from_trusted_helper";
 
     /// The PROOF-level session-trust reasons `build_session_trust_proof_from_facts` can
-    /// actually emit. The wire enum in packages/core/src/security.ts also declares
+    /// actually emit. The `session_trust_reason` vocabulary also declares
     /// `missing_auth_guard` and `parser_gap`, but neither has a producer -- see the
-    /// unreachable-member pin below.
-    const REACHABLE_REASONS: [&str; 2] = ["derived_from_request", "unknown_helper"];
+    /// unreachable-member pin below, and their reserved entries in
+    /// scripts/vocabulary-parity-baseline.json.
+    const REACHABLE_REASONS: [SessionTrustReason; 2] = [
+        SessionTrustReason::DerivedFromRequest,
+        SessionTrustReason::UnknownHelper,
+    ];
 
     /// The FINDING-level codes (SecurityMissingProofCodeSchema) this mapper may produce
     /// for a session-trust convention.
     const FINDING_LEVEL_CODES: [&str; 2] = ["session_not_trusted", "missing_auth_guard"];
 
-    fn proof_with_session_reason(reason: &str) -> SecurityBoundaryProof {
+    fn proof_with_session_reason(reason: SessionTrustReason) -> SecurityBoundaryProof {
         let source = concat!(
             "export async function GET(request: Request) {\n",
             "  const session = await getSession(request);\n",
@@ -4546,7 +4568,7 @@ mod phase4_missing_code_tests {
             .missing_trust
             .first_mut()
             .expect("fixture must produce a missing_trust entry")
-            .reason = reason.to_string();
+            .reason = reason;
         proof
     }
 
@@ -4561,7 +4583,7 @@ mod phase4_missing_code_tests {
             let code = phase4_missing_code(&proof_with_session_reason(reason), SESSION_TRUST);
             assert!(
                 FINDING_LEVEL_CODES.contains(&code.as_str()),
-                "proof-level reason {reason:?} mapped to {code:?}, which is not a \
+                "proof-level reason {reason} mapped to {code:?}, which is not a \
                  member of the finding-level vocabulary {FINDING_LEVEL_CODES:?}"
             );
         }
@@ -4577,7 +4599,7 @@ mod phase4_missing_code_tests {
             assert_eq!(
                 phase4_missing_code(&proof_with_session_reason(reason), SESSION_TRUST),
                 "session_not_trusted",
-                "proof-level reason {reason:?}"
+                "proof-level reason {reason}"
             );
         }
     }
@@ -4661,14 +4683,17 @@ mod phase4_missing_code_tests {
     fn the_unproduced_reasons_are_pinned_where_they_currently_land() {
         assert_eq!(
             phase4_missing_code(
-                &proof_with_session_reason("missing_auth_guard"),
+                &proof_with_session_reason(SessionTrustReason::MissingAuthGuard),
                 SESSION_TRUST
             ),
             "missing_auth_guard",
             "a member of both vocabularies survives the fall-through"
         );
         assert_eq!(
-            phase4_missing_code(&proof_with_session_reason("parser_gap"), SESSION_TRUST),
+            phase4_missing_code(
+                &proof_with_session_reason(SessionTrustReason::ParserGap),
+                SESSION_TRUST
+            ),
             "parser_gap",
             "not a finding-level member; would normalize to unknown_reason_code downstream"
         );

--- a/crates/drift-engine/src/check_command.rs
+++ b/crates/drift-engine/src/check_command.rs
@@ -3395,7 +3395,7 @@ fn route_security_proof_json(
             "undominated_sinks": proof.undominated_sinks.iter().map(|sink| json!({
                 "sink_id": sink.sink_id,
                 "sink_kind": sink.sink_kind,
-                "reason": sink.reason,
+                "reason": sink.reason.as_wire(),
                 "fact_ids": sink.fact_ids
             })).collect::<Vec<_>>()
         },

--- a/crates/drift-engine/src/check_command.rs
+++ b/crates/drift-engine/src/check_command.rs
@@ -9,15 +9,16 @@ use drift_engine::next_routes::next_api_route_identity;
 use drift_engine::{
     AcceptedAuthHelper, AcceptedAuthorizationHelper, AcceptedHelperImport,
     AcceptedRequestValidator, AcceptedSecurityHelper, AcceptedTenantHelper, AuthGuardBehavior,
-    AuthorizationHelperBehavior, AuthorizationHelperKind, BaselineStatus, BaselineViolation,
-    ConventionDispatch, ConventionKind, DiffFile, DiffScope, DirectDataAccessRule, EnforcementMode,
-    Fact, FactKind, FindingStatus, GraphEdgeKind, GraphNodeKind, ParsedDiff, Phase4SecurityPolicy,
-    Phase6AcceptedHelper, Phase6CorsContract, Phase6RawSqlContract, Phase6SecurityContract,
-    Phase6SecurityProof, Phase6SsrfContract, RequestValidatorBehavior, RequestValidatorKind,
-    RouteSecurityBoundaryProof, RuleFinding, ScanCapability, SecurityBoundaryProof,
-    SecurityProofStatus, SessionTrustReason, Severity, accepted_phase5_contract_from_requires,
-    build_auth_boundary_proofs_for_file, build_phase4_security_proof_with_policy,
-    build_phase6_security_proofs_for_file, classify_findings_against_diff,
+    AuthorizationHelperBehavior, AuthorizationHelperKind, AuthorizationMissingReason,
+    BaselineStatus, BaselineViolation, ConventionDispatch, ConventionKind, DiffFile, DiffScope,
+    DirectDataAccessRule, EnforcementMode, Fact, FactKind, FindingStatus, GraphEdgeKind,
+    GraphNodeKind, ParsedDiff, Phase4SecurityPolicy, Phase6AcceptedHelper, Phase6CorsContract,
+    Phase6RawSqlContract, Phase6SecurityContract, Phase6SecurityProof, Phase6SsrfContract,
+    RequestValidatorBehavior, RequestValidatorKind, RouteSecurityBoundaryProof, RuleFinding,
+    ScanCapability, SecurityBoundaryProof, SecurityProofStatus, SessionTrustReason, Severity,
+    accepted_phase5_contract_from_requires, build_auth_boundary_proofs_for_file,
+    build_phase4_security_proof_with_policy, build_phase6_security_proofs_for_file,
+    classify_findings_against_diff, materialize_direct_data_access_findings,
     materialize_direct_data_access_findings_with_sources, phase6_proof_to_json,
     sensitive_field_source_is_trusted, sensitive_response_field_rejections,
 };
@@ -3629,12 +3630,22 @@ fn phase4_missing_code(proof: &SecurityBoundaryProof, convention_kind: &str) -> 
             .first()
             .map(|missing| missing.reason.clone())
             .unwrap_or_else(|| "tenant_predicate_missing".to_string()),
+        // Passed through unmapped, as it always was: every reason this builder emits
+        // (authorization_guard_missing, session_not_trusted,
+        // authorization_guard_not_dominating_sink) is also a member of the finding-level
+        // SecurityMissingProofCodeSchema, so the two vocabularies agree here rather than
+        // needing a bridge. The three older spellings that are NOT finding-level members
+        // have no producer - see their reserved entries in the parity baseline.
         "api_route_requires_authorization" => proof
             .authorization
             .missing
             .first()
-            .map(|missing| missing.reason.clone())
-            .unwrap_or_else(|| "authorization_guard_missing".to_string()),
+            .map(|missing| missing.reason.as_wire().to_string())
+            .unwrap_or_else(|| {
+                AuthorizationMissingReason::AuthorizationGuardMissing
+                    .as_wire()
+                    .to_string()
+            }),
         "session_object_must_come_from_trusted_helper" => proof
             .session_trust
             .missing_trust
@@ -3871,7 +3882,7 @@ fn phase4_proof_json(
                 serde_json::Value::Object(object)
             }).collect::<Vec<_>>(),
             "missing": proof.authorization.missing.iter().map(|missing| json!({
-                "reason": missing.reason,
+                "reason": missing.reason.as_wire(),
                 "sink_fact_id": missing.sink_fact_id
             })).collect::<Vec<_>>()
         },

--- a/crates/drift-engine/src/check_command.rs
+++ b/crates/drift-engine/src/check_command.rs
@@ -3012,7 +3012,7 @@ fn request_validation_missing_code(proof: &SecurityBoundaryProof) -> String {
                 .request_validation
                 .unvalidated_uses
                 .first()
-                .map(|use_proof| use_proof.reason.clone())
+                .map(|use_proof| use_proof.reason.as_wire().to_string())
         })
         .unwrap_or_else(|| "request_input_not_validated".to_string())
 }
@@ -3434,7 +3434,7 @@ fn request_validation_proof_json(
             .request_validation
             .unvalidated_uses
             .iter()
-            .map(|use_proof| use_proof.reason.clone())
+            .map(|use_proof| use_proof.reason.as_wire().to_string())
             .collect::<Vec<_>>()
     } else {
         vec![request_validation_missing_code(proof)]

--- a/crates/drift-engine/src/lib.rs
+++ b/crates/drift-engine/src/lib.rs
@@ -106,6 +106,7 @@ pub use security_rules::{
 pub use vocabulary::{
     AuthorizationMissingReason, ConventionDispatch, ConventionKind, FactKind, FileRole,
     GraphEdgeKind, GraphNodeKind, RouteFlavor, ScanCapability, SessionTrustReason,
+    TenantMissingReason,
 };
 
 #[derive(Debug, Clone, PartialEq, Eq)]

--- a/crates/drift-engine/src/lib.rs
+++ b/crates/drift-engine/src/lib.rs
@@ -106,7 +106,7 @@ pub use security_rules::{
 pub use vocabulary::{
     AuthorizationMissingReason, ConventionDispatch, ConventionKind, FactKind, FileRole,
     GraphEdgeKind, GraphNodeKind, RouteFlavor, ScanCapability, SessionTrustReason,
-    TenantMissingReason,
+    TenantMissingReason, UndominatedSinkReason,
 };
 
 #[derive(Debug, Clone, PartialEq, Eq)]

--- a/crates/drift-engine/src/lib.rs
+++ b/crates/drift-engine/src/lib.rs
@@ -104,8 +104,8 @@ pub use security_rules::{
     evaluate_api_route_requires_tenant_scope, evaluate_middleware_must_cover_routes,
 };
 pub use vocabulary::{
-    ConventionDispatch, ConventionKind, FactKind, FileRole, GraphEdgeKind, GraphNodeKind,
-    RouteFlavor, ScanCapability, SessionTrustReason,
+    AuthorizationMissingReason, ConventionDispatch, ConventionKind, FactKind, FileRole,
+    GraphEdgeKind, GraphNodeKind, RouteFlavor, ScanCapability, SessionTrustReason,
 };
 
 #[derive(Debug, Clone, PartialEq, Eq)]

--- a/crates/drift-engine/src/lib.rs
+++ b/crates/drift-engine/src/lib.rs
@@ -105,7 +105,7 @@ pub use security_rules::{
 };
 pub use vocabulary::{
     ConventionDispatch, ConventionKind, FactKind, FileRole, GraphEdgeKind, GraphNodeKind,
-    RouteFlavor, ScanCapability,
+    RouteFlavor, ScanCapability, SessionTrustReason,
 };
 
 #[derive(Debug, Clone, PartialEq, Eq)]

--- a/crates/drift-engine/src/lib.rs
+++ b/crates/drift-engine/src/lib.rs
@@ -105,8 +105,8 @@ pub use security_rules::{
 };
 pub use vocabulary::{
     AuthorizationMissingReason, ConventionDispatch, ConventionKind, FactKind, FileRole,
-    GraphEdgeKind, GraphNodeKind, RouteFlavor, ScanCapability, SessionTrustReason,
-    TenantMissingReason, UndominatedSinkReason,
+    GraphEdgeKind, GraphNodeKind, MiddlewareMismatchReason, RequestUnvalidatedReason, RouteFlavor,
+    ScanCapability, SessionTrustReason, TenantMissingReason, UndominatedSinkReason,
 };
 
 #[derive(Debug, Clone, PartialEq, Eq)]

--- a/crates/drift-engine/src/lib.rs
+++ b/crates/drift-engine/src/lib.rs
@@ -106,7 +106,8 @@ pub use security_rules::{
 pub use vocabulary::{
     AuthorizationMissingReason, ConventionDispatch, ConventionKind, FactKind, FileRole,
     GraphEdgeKind, GraphNodeKind, MiddlewareMismatchReason, RequestUnvalidatedReason, RouteFlavor,
-    ScanCapability, SessionTrustReason, TenantMissingReason, UndominatedSinkReason,
+    ScanCapability, SecurityParserGapCode, SessionTrustReason, TenantMissingReason,
+    UndominatedSinkReason,
 };
 
 #[derive(Debug, Clone, PartialEq, Eq)]

--- a/crates/drift-engine/src/security_control_flow.rs
+++ b/crates/drift-engine/src/security_control_flow.rs
@@ -1,7 +1,7 @@
 use crate::{
     Fact, FactKind,
     next_routes::next_api_route_identity,
-    vocabulary::{MiddlewareMismatchReason, UndominatedSinkReason},
+    vocabulary::{MiddlewareMismatchReason, SecurityParserGapCode, UndominatedSinkReason},
 };
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -41,7 +41,8 @@ pub struct ValidatedInputUse {
 pub struct SecretFlowParserGap {
     pub source_line: usize,
     pub sink_line: usize,
-    pub code: String,
+    /// From the one `security_parser_gap_code` vocabulary.
+    pub code: SecurityParserGapCode,
 }
 
 pub fn guard_dominates_straight_line_sinks(facts: &[Fact]) -> Vec<DominatedSink> {
@@ -273,7 +274,7 @@ pub fn indirect_secret_flow_parser_gaps(
                     gaps.push(SecretFlowParserGap {
                         source_line,
                         sink_line: sink_index + 1,
-                        code: "unsupported_dynamic_control_flow".to_string(),
+                        code: SecurityParserGapCode::UnsupportedDynamicControlFlow,
                     });
                 }
             }

--- a/crates/drift-engine/src/security_control_flow.rs
+++ b/crates/drift-engine/src/security_control_flow.rs
@@ -1,4 +1,6 @@
-use crate::{Fact, FactKind, next_routes::next_api_route_identity};
+use crate::{
+    Fact, FactKind, next_routes::next_api_route_identity, vocabulary::UndominatedSinkReason,
+};
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct DominatedSink {
@@ -60,7 +62,7 @@ pub fn guard_dominates_straight_line_sinks(facts: &[Fact]) -> Vec<DominatedSink>
         .collect()
 }
 
-pub fn undominated_straight_line_reasons(facts: &[Fact]) -> Vec<String> {
+pub fn undominated_straight_line_reasons(facts: &[Fact]) -> Vec<UndominatedSinkReason> {
     let first_guard_line = facts
         .iter()
         .filter(|fact| fact.kind == FactKind::AuthGuardCalled)
@@ -70,14 +72,14 @@ pub fn undominated_straight_line_reasons(facts: &[Fact]) -> Vec<String> {
     protected_sinks(facts)
         .into_iter()
         .filter_map(|sink| match first_guard_line {
-            Some(line) if line > sink.start_line => Some("guard_after_sink".to_string()),
+            Some(line) if line > sink.start_line => Some(UndominatedSinkReason::GuardAfterSink),
             Some(_) => None,
-            None => Some("no_guard_call".to_string()),
+            None => Some(UndominatedSinkReason::NoGuardCall),
         })
         .collect()
 }
 
-pub fn branch_bypass_reasons(source: &str, facts: &[Fact]) -> Vec<String> {
+pub fn branch_bypass_reasons(source: &str, facts: &[Fact]) -> Vec<UndominatedSinkReason> {
     let lines: Vec<&str> = source.lines().collect();
     for (index, line) in lines.iter().enumerate() {
         if !line.contains("if") || !line.contains('{') {
@@ -104,13 +106,16 @@ pub fn branch_bypass_reasons(source: &str, facts: &[Fact]) -> Vec<String> {
         if (then_has_guard && else_has_sink && !else_has_guard)
             || (else_has_guard && then_has_sink && !then_has_guard)
         {
-            return vec!["guard_only_in_one_branch".to_string()];
+            return vec![UndominatedSinkReason::GuardOnlyInOneBranch];
         }
     }
     Vec::new()
 }
 
-pub fn conditional_guard_without_else_reasons(source: &str, facts: &[Fact]) -> Vec<String> {
+pub fn conditional_guard_without_else_reasons(
+    source: &str,
+    facts: &[Fact],
+) -> Vec<UndominatedSinkReason> {
     let lines: Vec<&str> = source.lines().collect();
     for (index, line) in lines.iter().enumerate() {
         if !line.contains("if") || !line.contains('{') {
@@ -139,13 +144,13 @@ pub fn conditional_guard_without_else_reasons(source: &str, facts: &[Fact]) -> V
             .iter()
             .any(|fact| fact.start_line > block_end);
         if guard_inside_if && sink_after_if {
-            return vec!["guard_only_in_one_branch".to_string()];
+            return vec![UndominatedSinkReason::GuardOnlyInOneBranch];
         }
     }
     Vec::new()
 }
 
-pub fn callback_boundary_reasons(source: &str, facts: &[Fact]) -> Vec<String> {
+pub fn callback_boundary_reasons(source: &str, facts: &[Fact]) -> Vec<UndominatedSinkReason> {
     let lines: Vec<&str> = source.lines().collect();
     let guard_in_callback = facts
         .iter()
@@ -153,7 +158,7 @@ pub fn callback_boundary_reasons(source: &str, facts: &[Fact]) -> Vec<String> {
         .any(|fact| line_is_inside_callback(&lines, fact.start_line));
 
     if guard_in_callback {
-        vec!["callback_boundary".to_string()]
+        vec![UndominatedSinkReason::CallbackBoundary]
     } else {
         Vec::new()
     }

--- a/crates/drift-engine/src/security_control_flow.rs
+++ b/crates/drift-engine/src/security_control_flow.rs
@@ -1,5 +1,7 @@
 use crate::{
-    Fact, FactKind, next_routes::next_api_route_identity, vocabulary::UndominatedSinkReason,
+    Fact, FactKind,
+    next_routes::next_api_route_identity,
+    vocabulary::{MiddlewareMismatchReason, UndominatedSinkReason},
 };
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -20,7 +22,8 @@ pub struct MatchedMiddleware {
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct MiddlewareMismatch {
     pub middleware_id: Option<String>,
-    pub reason: String,
+    /// The PROOF-level reason, from the one `middleware_mismatch_reason` vocabulary.
+    pub reason: MiddlewareMismatchReason,
     pub parser_gap_id: Option<String>,
 }
 
@@ -613,7 +616,7 @@ pub fn static_middleware_coverage(
             Vec::new(),
             vec![MiddlewareMismatch {
                 middleware_id: None,
-                reason: "unknown_framework".to_string(),
+                reason: MiddlewareMismatchReason::UnknownFramework,
                 parser_gap_id: None,
             }],
         );
@@ -657,7 +660,7 @@ pub fn static_middleware_coverage(
                 Vec::new(),
                 vec![MiddlewareMismatch {
                     middleware_id: middleware_id.clone(),
-                    reason: "path_not_matched".to_string(),
+                    reason: MiddlewareMismatchReason::PathNotMatched,
                     parser_gap_id: None,
                 }],
             );
@@ -680,13 +683,13 @@ pub fn static_middleware_coverage(
         } else if !static_matcher_covers_path(&pattern, &route_path) {
             mismatches.push(MiddlewareMismatch {
                 middleware_id: middleware_id.clone(),
-                reason: "path_not_matched".to_string(),
+                reason: MiddlewareMismatchReason::PathNotMatched,
                 parser_gap_id: None,
             });
         } else {
             mismatches.push(MiddlewareMismatch {
                 middleware_id: middleware_id.clone(),
-                reason: "method_not_matched".to_string(),
+                reason: MiddlewareMismatchReason::MethodNotMatched,
                 parser_gap_id: None,
             });
         }

--- a/crates/drift-engine/src/security_phase6.rs
+++ b/crates/drift-engine/src/security_phase6.rs
@@ -4,7 +4,7 @@ use serde_json::json;
 
 use crate::{
     AcceptedSecurityHelper, Fact, FactExtractError, FactKind, SecurityParserGap,
-    SecurityProofResult, SecurityProofStatus, extract_typescript_facts,
+    SecurityParserGapCode, SecurityProofResult, SecurityProofStatus, extract_typescript_facts,
     next_routes::next_api_route_identity,
 };
 
@@ -366,7 +366,7 @@ fn build_ssrf_proof(
                         parser_gap_id: format!(
                             "parser_gap:{file_path}:{line_number}:unsupported_dynamic_outbound_url"
                         ),
-                        code: "unsupported_dynamic_outbound_url".to_string(),
+                        code: SecurityParserGapCode::UnsupportedDynamicOutboundUrl,
                         file_path: file_path.to_string(),
                         reason: "Unsupported dynamic outbound URL prevents deterministic allowlist proof"
                             .to_string(),
@@ -382,7 +382,7 @@ fn build_ssrf_proof(
         && missing_codes.is_empty()
         && !parser_gaps
             .iter()
-            .any(|gap| gap.code == "unsupported_dynamic_outbound_url");
+            .any(|gap| gap.code == SecurityParserGapCode::UnsupportedDynamicOutboundUrl);
     Phase6SsrfProof {
         required: true,
         proven,
@@ -505,7 +505,7 @@ fn build_cors_proof(
                 parser_gap_id: format!(
                     "parser_gap:{file_path}:{line_number}:unsupported_dynamic_cors_origin"
                 ),
-                code: "unsupported_dynamic_cors_origin".to_string(),
+                code: SecurityParserGapCode::UnsupportedDynamicCorsOrigin,
                 file_path: file_path.to_string(),
                 reason: "Dynamic CORS origin prevents deterministic policy proof".to_string(),
                 blocks_enforcement: true,

--- a/crates/drift-engine/src/security_proof.rs
+++ b/crates/drift-engine/src/security_proof.rs
@@ -11,6 +11,7 @@ use crate::{
         unsupported_dynamic_control_flow,
     },
     security_patterns::dynamic_middleware_matcher_line,
+    vocabulary::SessionTrustReason,
 };
 use serde_json::Value;
 
@@ -104,7 +105,16 @@ pub struct SessionTrustBoundaryProof {
 pub struct SessionMissingTrustProof {
     pub fact_id: String,
     pub variable: String,
-    pub reason: String,
+    /// The PROOF-level reason, from the one vocabulary that declares them.
+    ///
+    /// This was a `String`, and S1-01 is what that cost: the builder wrote
+    /// `session_not_trusted` here - a FINDING-level code, a non-member of the proof-level
+    /// enum the CLI parses this field with - and the engine's own output failed
+    /// `SecurityBoundaryProofSchema`. Nothing in Rust could have caught it, because every
+    /// string is a valid `String`.
+    ///
+    /// Typed, the same mistake does not compile.
+    pub reason: SessionTrustReason,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -1461,16 +1471,14 @@ fn build_session_trust_proof_from_facts(facts: &[Fact]) -> SessionTrustProof {
                 missing_trust.push(SessionMissingTrustProof {
                     fact_id: fact_id(fact),
                     variable,
-                    // PROOF-level vocabulary (core/src/security.ts SecurityBoundaryProof
-                    // session_trust enum), NOT the finding-level code a user sees. The
+                    // PROOF-level vocabulary, NOT the finding-level code a user sees. The
                     // finding-level `session_not_trusted` is derived from this by the
                     // phase4 finding-reason mapper in check_command.rs.
                     reason: if source == Some("unknown_helper") {
-                        "unknown_helper"
+                        SessionTrustReason::UnknownHelper
                     } else {
-                        "derived_from_request"
-                    }
-                    .to_string(),
+                        SessionTrustReason::DerivedFromRequest
+                    },
                 });
             }
             _ => {}
@@ -2098,8 +2106,11 @@ mod tests {
     /// `missing_trust[].reason` is PROOF-level vocabulary, and an unrecognized helper
     /// is `unknown_helper` -- never the finding-level `session_not_trusted`.
     ///
-    /// Verified non-vacuous: reverting the emission site to "session_not_trusted"
-    /// fails this test with left: "session_not_trusted", right: "unknown_helper".
+    /// Verified non-vacuous: reverting the emission site to
+    /// `SessionTrustReason::DerivedFromRequest` fails this test with
+    /// left: DerivedFromRequest, right: UnknownHelper. Since S2-02 the ORIGINAL
+    /// regression - writing the finding-level `session_not_trusted` here - can no longer
+    /// be expressed: it is not a member of the enum, so it does not compile.
     #[test]
     fn unknown_helper_source_maps_to_unknown_helper_reason() {
         let source = concat!(
@@ -2116,6 +2127,6 @@ mod tests {
             .missing_trust
             .first()
             .expect("an unrecognized session helper must produce a missing_trust entry");
-        assert_eq!(missing.reason, "unknown_helper");
+        assert_eq!(missing.reason, SessionTrustReason::UnknownHelper);
     }
 }

--- a/crates/drift-engine/src/security_proof.rs
+++ b/crates/drift-engine/src/security_proof.rs
@@ -11,7 +11,7 @@ use crate::{
         unsupported_dynamic_control_flow,
     },
     security_patterns::dynamic_middleware_matcher_line,
-    vocabulary::SessionTrustReason,
+    vocabulary::{AuthorizationMissingReason, SessionTrustReason},
 };
 use serde_json::Value;
 
@@ -138,7 +138,8 @@ pub struct AuthorizationGuardProof {
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct AuthorizationMissingProof {
-    pub reason: String,
+    /// The PROOF-level reason, from the one `authorization_missing_reason` vocabulary.
+    pub reason: AuthorizationMissingReason,
     pub sink_fact_id: Option<String>,
 }
 
@@ -1119,7 +1120,7 @@ fn build_authorization_proof_from_facts(
     let mut missing = Vec::new();
     if !data_operations.is_empty() && guards.is_empty() {
         missing.push(AuthorizationMissingProof {
-            reason: "authorization_guard_missing".to_string(),
+            reason: AuthorizationMissingReason::AuthorizationGuardMissing,
             sink_fact_id: data_operations.first().map(|fact| sink_id(fact)),
         });
     }
@@ -1130,13 +1131,13 @@ fn build_authorization_proof_from_facts(
             .is_some_and(|subject| !subject_uses_trusted_session(subject, session_trust))
         {
             missing.push(AuthorizationMissingProof {
-                reason: "session_not_trusted".to_string(),
+                reason: AuthorizationMissingReason::SessionNotTrusted,
                 sink_fact_id: data_operations.first().map(|fact| sink_id(fact)),
             });
         }
         if !guard.dominates_sinks {
             missing.push(AuthorizationMissingProof {
-                reason: "authorization_guard_not_dominating_sink".to_string(),
+                reason: AuthorizationMissingReason::AuthorizationGuardNotDominatingSink,
                 sink_fact_id: data_operations.first().map(|fact| sink_id(fact)),
             });
         }

--- a/crates/drift-engine/src/security_proof.rs
+++ b/crates/drift-engine/src/security_proof.rs
@@ -12,8 +12,8 @@ use crate::{
     },
     security_patterns::dynamic_middleware_matcher_line,
     vocabulary::{
-        AuthorizationMissingReason, RequestUnvalidatedReason, SessionTrustReason,
-        TenantMissingReason, UndominatedSinkReason,
+        AuthorizationMissingReason, RequestUnvalidatedReason, SecurityParserGapCode,
+        SessionTrustReason, TenantMissingReason, UndominatedSinkReason,
     },
 };
 use serde_json::Value;
@@ -254,7 +254,8 @@ pub struct SecurityProofResult {
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct SecurityParserGap {
     pub parser_gap_id: String,
-    pub code: String,
+    /// From the one `security_parser_gap_code` vocabulary.
+    pub code: SecurityParserGapCode,
     pub file_path: String,
     pub reason: String,
     pub blocks_enforcement: bool,
@@ -294,7 +295,7 @@ pub fn build_auth_boundary_proof(
                     .map(|fact| fact.file_path.as_str())
                     .unwrap_or("unknown")
             ),
-            code: "unsupported_dynamic_control_flow".to_string(),
+            code: SecurityParserGapCode::UnsupportedDynamicControlFlow,
             file_path: facts
                 .first()
                 .map(|fact| fact.file_path.clone())
@@ -471,7 +472,7 @@ fn build_route_auth_boundary_proof(
     let parser_gaps = if dynamic_control_flow {
         vec![SecurityParserGap {
             parser_gap_id: format!("{route_id}:parser_gap:unsupported_dynamic_control_flow"),
-            code: "unsupported_dynamic_control_flow".to_string(),
+            code: SecurityParserGapCode::UnsupportedDynamicControlFlow,
             file_path: file_path.clone(),
             reason: "Dynamic control flow could not be analysed, so auth coverage for this route is unknown".to_string(),
             blocks_enforcement: true,
@@ -611,7 +612,7 @@ pub fn build_middleware_coverage_proof(
                     "parser_gap:{}:{}:unsupported_dynamic_middleware_matcher",
                     middleware_file_path_string, line
                 ),
-                code: "unsupported_dynamic_middleware_matcher".to_string(),
+                code: SecurityParserGapCode::UnsupportedDynamicMiddlewareMatcher,
                 file_path: middleware_file_path_string.clone(),
                 reason: "Dynamic middleware matcher prevents deterministic route coverage proof"
                     .to_string(),
@@ -936,7 +937,9 @@ pub fn build_secret_exposure_proof(
             .map(|gap| SecurityParserGap {
                 parser_gap_id: format!(
                     "parser_gap:{}:{}:{}",
-                    file_path_string, gap.source_line, gap.code
+                    file_path_string,
+                    gap.source_line,
+                    gap.code.as_wire()
                 ),
                 code: gap.code,
                 file_path: file_path_string.clone(),
@@ -1055,7 +1058,7 @@ fn phase4_parser_gaps(file_path: &str, source: &str) -> Vec<SecurityParserGap> {
             gaps.push(phase4_parser_gap(
                 file_path,
                 line_number,
-                "unsupported_tenant_dynamic_property",
+                SecurityParserGapCode::UnsupportedTenantDynamicProperty,
                 "Computed tenant predicate key prevents deterministic tenant proof",
             ));
         }
@@ -1074,7 +1077,7 @@ fn phase4_parser_gaps(file_path: &str, source: &str) -> Vec<SecurityParserGap> {
                 gaps.push(phase4_parser_gap(
                     file_path,
                     line_number,
-                    "unsupported_tenant_query_object_alias",
+                    SecurityParserGapCode::UnsupportedTenantQueryObjectAlias,
                     "Tenant query object alias prevents deterministic tenant proof",
                 ));
             }
@@ -1083,7 +1086,7 @@ fn phase4_parser_gaps(file_path: &str, source: &str) -> Vec<SecurityParserGap> {
             gaps.push(phase4_parser_gap(
                 file_path,
                 line_number,
-                "unsupported_session_nested_destructure",
+                SecurityParserGapCode::UnsupportedSessionNestedDestructure,
                 "Nested session destructuring prevents deterministic session trust proof",
             ));
         }
@@ -1100,12 +1103,12 @@ fn phase4_parser_gaps(file_path: &str, source: &str) -> Vec<SecurityParserGap> {
 fn phase4_parser_gap(
     file_path: &str,
     line_number: usize,
-    code: &str,
+    code: SecurityParserGapCode,
     reason: &str,
 ) -> SecurityParserGap {
     SecurityParserGap {
-        parser_gap_id: format!("parser_gap:{file_path}:{line_number}:{code}"),
-        code: code.to_string(),
+        parser_gap_id: format!("parser_gap:{file_path}:{line_number}:{}", code.as_wire()),
+        code,
         file_path: file_path.to_string(),
         reason: reason.to_string(),
         blocks_enforcement: true,
@@ -1639,7 +1642,7 @@ fn response_shape_parser_gaps(file_path: &str, source: &str) -> Vec<SecurityPars
                 file_path,
                 index + 1
             ),
-            code: "unsupported_destructuring_or_spread".to_string(),
+            code: SecurityParserGapCode::UnsupportedDestructuringOrSpread,
             file_path: file_path.to_string(),
             reason: "Dynamic response spread prevents deterministic response-shape proof"
                 .to_string(),
@@ -1779,7 +1782,7 @@ fn request_input_parser_gaps(
                         file_path,
                         index + 1
                     ),
-                    code: "unsupported_request_input_spread".to_string(),
+                    code: SecurityParserGapCode::UnsupportedRequestInputSpread,
                     file_path: file_path.to_string(),
                     reason:
                         "Object spread from request input prevents deterministic validation proof"
@@ -1795,7 +1798,7 @@ fn request_input_parser_gaps(
                         file_path,
                         index + 1
                     ),
-                    code: "unsupported_request_input_destructure".to_string(),
+                    code: SecurityParserGapCode::UnsupportedRequestInputDestructure,
                     file_path: file_path.to_string(),
                     reason:
                         "Destructuring from request input prevents deterministic validation proof"

--- a/crates/drift-engine/src/security_proof.rs
+++ b/crates/drift-engine/src/security_proof.rs
@@ -11,7 +11,9 @@ use crate::{
         unsupported_dynamic_control_flow,
     },
     security_patterns::dynamic_middleware_matcher_line,
-    vocabulary::{AuthorizationMissingReason, SessionTrustReason, TenantMissingReason},
+    vocabulary::{
+        AuthorizationMissingReason, SessionTrustReason, TenantMissingReason, UndominatedSinkReason,
+    },
 };
 use serde_json::Value;
 
@@ -55,7 +57,8 @@ pub struct TrustedGuardCallProof {
 pub struct UndominatedSinkProof {
     pub sink_id: String,
     pub sink_kind: String,
-    pub reason: String,
+    /// The PROOF-level reason, from the one `undominated_sink_reason` vocabulary.
+    pub reason: UndominatedSinkReason,
     pub fact_ids: Vec<String>,
 }
 
@@ -64,7 +67,8 @@ pub struct AuthBoundaryProof {
     pub required: bool,
     pub proven: bool,
     pub dominated_sinks: Vec<DominatedSink>,
-    pub undominated_sinks: Vec<String>,
+    /// The PROOF-level reasons, from the one `undominated_sink_reason` vocabulary.
+    pub undominated_sinks: Vec<UndominatedSinkReason>,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -277,7 +281,7 @@ pub fn build_auth_boundary_proof(
     undominated_sinks.extend(callback_boundary_reasons(source, &facts));
     let dynamic_control_flow = unsupported_dynamic_control_flow(source);
     if dynamic_control_flow {
-        undominated_sinks.push("unsupported_dynamic_control_flow".to_string());
+        undominated_sinks.push(UndominatedSinkReason::UnsupportedDynamicControlFlow);
     }
     let parser_gaps = if dynamic_control_flow {
         vec![SecurityParserGap {
@@ -416,19 +420,19 @@ fn build_route_auth_boundary_proof(
         let sink_kind = sink_kind(sink).to_string();
         let fact_ids = vec![fact_id(sink)];
         if dynamic_control_flow {
-            undominated_sinks.push("unsupported_dynamic_control_flow".to_string());
+            undominated_sinks.push(UndominatedSinkReason::UnsupportedDynamicControlFlow);
             undominated_sink_proofs.push(UndominatedSinkProof {
                 sink_id,
                 sink_kind,
-                reason: "unsupported_dynamic_control_flow".to_string(),
+                reason: UndominatedSinkReason::UnsupportedDynamicControlFlow,
                 fact_ids,
             });
         } else if let Some(reason) = path_sensitive_reasons.first() {
-            undominated_sinks.push(reason.clone());
+            undominated_sinks.push(*reason);
             undominated_sink_proofs.push(UndominatedSinkProof {
                 sink_id,
                 sink_kind,
-                reason: reason.clone(),
+                reason: *reason,
                 fact_ids,
             });
         } else if first_guard_line.is_some_and(|line| line < sink.start_line) {
@@ -438,19 +442,19 @@ fn build_route_auth_boundary_proof(
                 edge_id: format!("edge:auth-dominates:{}:{}", sink.file_path, sink.start_line),
             });
         } else if first_guard_line.is_some_and(|line| line > sink.start_line) {
-            undominated_sinks.push("guard_after_sink".to_string());
+            undominated_sinks.push(UndominatedSinkReason::GuardAfterSink);
             undominated_sink_proofs.push(UndominatedSinkProof {
                 sink_id,
                 sink_kind,
-                reason: "guard_after_sink".to_string(),
+                reason: UndominatedSinkReason::GuardAfterSink,
                 fact_ids,
             });
         } else {
-            undominated_sinks.push("no_guard_call".to_string());
+            undominated_sinks.push(UndominatedSinkReason::NoGuardCall);
             undominated_sink_proofs.push(UndominatedSinkProof {
                 sink_id,
                 sink_kind,
-                reason: "no_guard_call".to_string(),
+                reason: UndominatedSinkReason::NoGuardCall,
                 fact_ids,
             });
         }
@@ -483,7 +487,7 @@ fn build_route_auth_boundary_proof(
     } else {
         undominated_sinks
             .iter()
-            .map(|reason| missing_proof_code(reason).to_string())
+            .map(|reason| missing_proof_code(*reason).to_string())
             .collect()
     };
 
@@ -513,11 +517,20 @@ fn build_route_auth_boundary_proof(
     }
 }
 
-fn missing_proof_code(reason: &str) -> &'static str {
+/// The PROOF-level undominated-sink reason, as the FINDING-level code a user reads.
+///
+/// Exhaustive over the enum since S2-03, with no catch-all: a member added to
+/// `undominated_sink_reason` does not compile until somebody decides what the finding says.
+/// The three that collapse to `auth_guard_not_dominating_sink` do so because that is what
+/// they mean - a guard exists and does not cover the sink - which is a different statement
+/// from `missing_auth_guard`, where there is no guard at all.
+fn missing_proof_code(reason: UndominatedSinkReason) -> &'static str {
     match reason {
-        "no_guard_call" => "missing_auth_guard",
-        "unsupported_dynamic_control_flow" => "unsupported_dynamic_control_flow",
-        _ => "auth_guard_not_dominating_sink",
+        UndominatedSinkReason::NoGuardCall => "missing_auth_guard",
+        UndominatedSinkReason::UnsupportedDynamicControlFlow => "unsupported_dynamic_control_flow",
+        UndominatedSinkReason::GuardAfterSink
+        | UndominatedSinkReason::GuardOnlyInOneBranch
+        | UndominatedSinkReason::CallbackBoundary => "auth_guard_not_dominating_sink",
     }
 }
 

--- a/crates/drift-engine/src/security_proof.rs
+++ b/crates/drift-engine/src/security_proof.rs
@@ -12,7 +12,8 @@ use crate::{
     },
     security_patterns::dynamic_middleware_matcher_line,
     vocabulary::{
-        AuthorizationMissingReason, SessionTrustReason, TenantMissingReason, UndominatedSinkReason,
+        AuthorizationMissingReason, RequestUnvalidatedReason, SessionTrustReason,
+        TenantMissingReason, UndominatedSinkReason,
     },
 };
 use serde_json::Value;
@@ -211,7 +212,8 @@ pub struct RequestUnvalidatedUseProof {
     pub input_fact_id: String,
     pub sink_fact_id: String,
     pub sink_kind: String,
-    pub reason: String,
+    /// The PROOF-level reason, from the one `request_unvalidated_reason` vocabulary.
+    pub reason: RequestUnvalidatedReason,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -1921,7 +1923,7 @@ fn request_unvalidated_uses(
                     input_fact_id: input.fact_id.clone(),
                     sink_fact_id,
                     sink_kind: sink_kind(sink).to_string(),
-                    reason: "validation_result_not_used".to_string(),
+                    reason: RequestUnvalidatedReason::ValidationResultNotUsed,
                 });
                 continue;
             }
@@ -1933,7 +1935,7 @@ fn request_unvalidated_uses(
                     input_fact_id: input.fact_id.clone(),
                     sink_fact_id,
                     sink_kind: sink_kind(sink).to_string(),
-                    reason: "request_input_not_validated".to_string(),
+                    reason: RequestUnvalidatedReason::RequestInputNotValidated,
                 });
             }
         }
@@ -2009,7 +2011,7 @@ fn unknown_validator_uses(
                     input_fact_id: input.fact_id.clone(),
                     sink_fact_id: sink_id(sink),
                     sink_kind: sink_kind(sink).to_string(),
-                    reason: "unknown_validator".to_string(),
+                    reason: RequestUnvalidatedReason::UnknownValidator,
                 });
             }
         }

--- a/crates/drift-engine/src/security_proof.rs
+++ b/crates/drift-engine/src/security_proof.rs
@@ -464,8 +464,9 @@ fn build_route_auth_boundary_proof(
     }
     undominated_sinks.sort();
     undominated_sinks.dedup();
-    undominated_sink_proofs
-        .sort_by(|left, right| (&left.reason, &left.sink_id).cmp(&(&right.reason, &right.sink_id)));
+    undominated_sink_proofs.sort_by(|left, right| {
+        (left.reason.as_wire(), &left.sink_id).cmp(&(right.reason.as_wire(), &right.sink_id))
+    });
     undominated_sink_proofs
         .dedup_by(|left, right| left.reason == right.reason && left.sink_id == right.sink_id);
 
@@ -1092,7 +1093,8 @@ fn phase4_parser_gaps(file_path: &str, source: &str) -> Vec<SecurityParserGap> {
         }
     }
     gaps.sort_by(|left, right| {
-        (&left.code, &left.parser_gap_id).cmp(&(&right.code, &right.parser_gap_id))
+        (left.code.as_wire(), &left.parser_gap_id)
+            .cmp(&(right.code.as_wire(), &right.parser_gap_id))
     });
     gaps.dedup_by(|left, right| {
         left.code == right.code && left.parser_gap_id == right.parser_gap_id
@@ -1161,8 +1163,16 @@ fn build_authorization_proof_from_facts(
             });
         }
     }
+    // Sort on the WIRE STRING, not the enum. Deriving Ord orders variants by their
+    // position in vocabulary/vocabulary.json, which is not the lexicographic order these
+    // lists were sorted in while `reason` was a String. That difference is not cosmetic:
+    // consumers read `.first()` -- `phase4_missing_code` for the finding's missing_code,
+    // and security_rules.rs for `actual_layer` -- so a reordering silently changes which
+    // reason a user is shown. Proven here: `session_not_trusted` is declared before
+    // `authorization_guard_not_dominating_sink` but sorts after it as a string.
     missing.sort_by(|left, right| {
-        (&left.reason, &left.sink_fact_id).cmp(&(&right.reason, &right.sink_fact_id))
+        (left.reason.as_wire(), &left.sink_fact_id)
+            .cmp(&(right.reason.as_wire(), &right.sink_fact_id))
     });
     missing.dedup();
     let required = !data_operations.is_empty();
@@ -1264,8 +1274,8 @@ fn build_tenant_proof_from_facts(
         });
     }
     missing.sort_by(|left, right| {
-        (&left.reason, &left.data_operation_fact_id)
-            .cmp(&(&right.reason, &right.data_operation_fact_id))
+        (left.reason.as_wire(), &left.data_operation_fact_id)
+            .cmp(&(right.reason.as_wire(), &right.data_operation_fact_id))
     });
     missing.dedup();
     let required = protected_operation_count > 0;
@@ -2148,5 +2158,60 @@ mod tests {
             .first()
             .expect("an unrecognized session helper must produce a missing_trust entry");
         assert_eq!(missing.reason, SessionTrustReason::UnknownHelper);
+    }
+}
+
+#[cfg(test)]
+mod reason_ordering_tests {
+    use super::*;
+
+    /// Typing these fields changed how they SORT, which changed what a user is told.
+    ///
+    /// While `reason` was a `String` these lists sorted lexicographically by wire value.
+    /// Deriving `Ord` on the generated enum orders by position in
+    /// vocabulary/vocabulary.json instead. Consumers read `.first()` --
+    /// `phase4_missing_code` for a finding's missing_code, `security_rules.rs` for its
+    /// `actual_layer` -- so the two orders disagreeing silently changes which of several
+    /// true reasons gets shown.
+    ///
+    /// `session_not_trusted` is declared BEFORE `authorization_guard_not_dominating_sink`
+    /// and sorts AFTER it as a string, so a route carrying both flips on the enum order.
+    /// Nothing else pins this: every affected sort is textually unchanged by the typing,
+    /// and the whole engine suite stayed green while the output moved.
+    #[test]
+    fn authorization_reasons_sort_by_wire_string_not_declaration_order() {
+        let mut missing = [
+            AuthorizationMissingProof {
+                reason: AuthorizationMissingReason::SessionNotTrusted,
+                sink_fact_id: Some("sink:1".to_string()),
+            },
+            AuthorizationMissingProof {
+                reason: AuthorizationMissingReason::AuthorizationGuardNotDominatingSink,
+                sink_fact_id: Some("sink:1".to_string()),
+            },
+        ];
+        missing.sort_by(|left, right| {
+            (left.reason.as_wire(), &left.sink_fact_id)
+                .cmp(&(right.reason.as_wire(), &right.sink_fact_id))
+        });
+
+        assert_eq!(
+            missing
+                .iter()
+                .map(|entry| entry.reason.as_wire())
+                .collect::<Vec<_>>(),
+            [
+                "authorization_guard_not_dominating_sink",
+                "session_not_trusted"
+            ],
+            "sorted on the enum's derived Ord instead of the wire string"
+        );
+
+        // The two orders genuinely disagree -- if they ever agree this test is vacuous.
+        assert!(
+            AuthorizationMissingReason::SessionNotTrusted
+                < AuthorizationMissingReason::AuthorizationGuardNotDominatingSink,
+            "declaration order no longer differs; this test has stopped proving anything"
+        );
     }
 }

--- a/crates/drift-engine/src/security_proof.rs
+++ b/crates/drift-engine/src/security_proof.rs
@@ -11,7 +11,7 @@ use crate::{
         unsupported_dynamic_control_flow,
     },
     security_patterns::dynamic_middleware_matcher_line,
-    vocabulary::{AuthorizationMissingReason, SessionTrustReason},
+    vocabulary::{AuthorizationMissingReason, SessionTrustReason, TenantMissingReason},
 };
 use serde_json::Value;
 
@@ -172,7 +172,8 @@ pub struct TenantPredicateProof {
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct TenantMissingProof {
     pub data_operation_fact_id: String,
-    pub reason: String,
+    /// The PROOF-level reason, from the one `tenant_missing_reason` vocabulary.
+    pub reason: TenantMissingReason,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -1201,7 +1202,7 @@ fn build_tenant_proof_from_facts(
                 .first()
                 .map(|fact| fact_id(fact))
                 .unwrap_or_default(),
-            reason: "tenant_predicate_missing".to_string(),
+            reason: TenantMissingReason::TenantPredicateMissing,
         });
     }
     // A tenant predicate only has a *source* to distrust when the route itself supplies the tenant
@@ -1232,7 +1233,7 @@ fn build_tenant_proof_from_facts(
                 .first()
                 .map(|fact| fact_id(fact))
                 .unwrap_or_default(),
-            reason: "tenant_source_untrusted".to_string(),
+            reason: TenantMissingReason::TenantSourceUntrusted,
         });
     }
     if protected_operation_count > 0 && predicates.is_empty() && !tenant_sources.is_empty() {
@@ -1241,7 +1242,7 @@ fn build_tenant_proof_from_facts(
                 .first()
                 .map(|fact| fact_id(fact))
                 .unwrap_or_default(),
-            reason: "tenant_predicate_not_bound_to_query".to_string(),
+            reason: TenantMissingReason::TenantPredicateNotBoundToQuery,
         });
     }
     missing.sort_by(|left, right| {

--- a/crates/drift-engine/src/security_rules.rs
+++ b/crates/drift-engine/src/security_rules.rs
@@ -2,7 +2,7 @@ use crate::{
     AcceptedAuthHelper, AcceptedAuthorizationHelper, AcceptedPhase5Contract,
     AcceptedRequestValidator, AcceptedTenantHelper, AuthorizationHelperBehavior,
     AuthorizationHelperKind, AuthorizationMissingReason, Fact, FactExtractError, FactKind,
-    Phase4SecurityPolicy, RequestValidationProofScope, SecurityProofStatus,
+    Phase4SecurityPolicy, RequestValidationProofScope, SecurityProofStatus, TenantMissingReason,
     build_auth_boundary_proof, build_middleware_coverage_proof,
     build_phase4_security_proof_with_policy, build_request_validation_proof_with_scope,
     build_response_shape_proof, build_secret_exposure_proof,
@@ -536,8 +536,12 @@ pub fn evaluate_api_route_requires_tenant_scope(
             .tenant
             .missing
             .first()
-            .map(|missing| missing.reason.clone())
-            .unwrap_or_else(|| "tenant_predicate_missing".to_string()),
+            .map(|missing| missing.reason.as_wire().to_string())
+            .unwrap_or_else(|| {
+                TenantMissingReason::TenantPredicateMissing
+                    .as_wire()
+                    .to_string()
+            }),
         enforcement_result: match contract.enforcement_mode {
             SecurityEnforcementMode::Brief => SecurityFindingResult::Brief,
             SecurityEnforcementMode::Warn => SecurityFindingResult::Warn,

--- a/crates/drift-engine/src/security_rules.rs
+++ b/crates/drift-engine/src/security_rules.rs
@@ -1,11 +1,12 @@
 use crate::{
     AcceptedAuthHelper, AcceptedAuthorizationHelper, AcceptedPhase5Contract,
     AcceptedRequestValidator, AcceptedTenantHelper, AuthorizationHelperBehavior,
-    AuthorizationHelperKind, Fact, FactExtractError, FactKind, Phase4SecurityPolicy,
-    RequestValidationProofScope, SecurityProofStatus, build_auth_boundary_proof,
-    build_middleware_coverage_proof, build_phase4_security_proof_with_policy,
-    build_request_validation_proof_with_scope, build_response_shape_proof,
-    build_secret_exposure_proof, extract_security_facts_with_validation, extract_typescript_facts,
+    AuthorizationHelperKind, AuthorizationMissingReason, Fact, FactExtractError, FactKind,
+    Phase4SecurityPolicy, RequestValidationProofScope, SecurityProofStatus,
+    build_auth_boundary_proof, build_middleware_coverage_proof,
+    build_phase4_security_proof_with_policy, build_request_validation_proof_with_scope,
+    build_response_shape_proof, build_secret_exposure_proof,
+    extract_security_facts_with_validation, extract_typescript_facts,
     next_routes::next_api_route_identity,
 };
 
@@ -576,8 +577,12 @@ pub fn evaluate_api_route_requires_authorization(
             .authorization
             .missing
             .first()
-            .map(|missing| missing.reason.clone())
-            .unwrap_or_else(|| "authorization_guard_missing".to_string()),
+            .map(|missing| missing.reason.as_wire().to_string())
+            .unwrap_or_else(|| {
+                AuthorizationMissingReason::AuthorizationGuardMissing
+                    .as_wire()
+                    .to_string()
+            }),
         enforcement_result: match contract.enforcement_mode {
             SecurityEnforcementMode::Brief => SecurityFindingResult::Brief,
             SecurityEnforcementMode::Warn => SecurityFindingResult::Warn,

--- a/crates/drift-engine/src/security_rules.rs
+++ b/crates/drift-engine/src/security_rules.rs
@@ -3,7 +3,7 @@ use crate::{
     AcceptedRequestValidator, AcceptedTenantHelper, AuthorizationHelperBehavior,
     AuthorizationHelperKind, AuthorizationMissingReason, Fact, FactExtractError, FactKind,
     Phase4SecurityPolicy, RequestValidationProofScope, SecurityProofStatus, TenantMissingReason,
-    build_auth_boundary_proof, build_middleware_coverage_proof,
+    UndominatedSinkReason, build_auth_boundary_proof, build_middleware_coverage_proof,
     build_phase4_security_proof_with_policy, build_request_validation_proof_with_scope,
     build_response_shape_proof, build_secret_exposure_proof,
     extract_security_facts_with_validation, extract_typescript_facts,
@@ -178,14 +178,12 @@ pub fn evaluate_api_route_requires_auth_helper(
         contract_id: contract.contract_id.clone(),
         title: "API route missing required auth proof".to_string(),
         expected_layer: "auth_guard".to_string(),
-        actual_layer: normalize_auth_actual_layer(
-            &proof
-                .auth
-                .undominated_sinks
-                .first()
-                .cloned()
-                .unwrap_or_else(|| "missing_auth_guard".to_string()),
-        ),
+        actual_layer: proof
+            .auth
+            .undominated_sinks
+            .first()
+            .map(|reason| normalize_auth_actual_layer(*reason))
+            .unwrap_or_else(|| "missing_auth_guard".to_string()),
         enforcement_result: match contract.enforcement_mode {
             SecurityEnforcementMode::Brief => SecurityFindingResult::Brief,
             SecurityEnforcementMode::Warn => SecurityFindingResult::Warn,
@@ -224,11 +222,18 @@ pub fn evaluate_api_route_requires_auth_helper_with_middleware(
     evaluate_api_route_requires_auth_helper(route_file_path, route_source, contract)
 }
 
-fn normalize_auth_actual_layer(reason: &str) -> String {
-    if reason == "no_guard_call" {
-        "missing_auth_guard".to_string()
-    } else {
-        reason.to_string()
+/// The proof-level reason, as the layer name a finding reports.
+///
+/// Only `no_guard_call` is renamed - "there is no guard" reads as `missing_auth_guard` to a
+/// user. Every other reason already says what it means. Exhaustive over the enum with no
+/// catch-all, so a new member forces the choice rather than inheriting this one.
+fn normalize_auth_actual_layer(reason: UndominatedSinkReason) -> String {
+    match reason {
+        UndominatedSinkReason::NoGuardCall => "missing_auth_guard".to_string(),
+        UndominatedSinkReason::GuardAfterSink
+        | UndominatedSinkReason::GuardOnlyInOneBranch
+        | UndominatedSinkReason::CallbackBoundary
+        | UndominatedSinkReason::UnsupportedDynamicControlFlow => reason.as_wire().to_string(),
     }
 }
 

--- a/crates/drift-engine/src/security_rules.rs
+++ b/crates/drift-engine/src/security_rules.rs
@@ -280,7 +280,7 @@ pub fn evaluate_middleware_must_cover_routes(
             .middleware
             .mismatches
             .first()
-            .map(|mismatch| mismatch.reason.clone())
+            .map(|mismatch| mismatch.reason.as_wire().to_string())
             .unwrap_or_else(|| "middleware_not_covering_route".to_string()),
         enforcement_result: match contract.enforcement_mode {
             SecurityEnforcementMode::Brief => SecurityFindingResult::Brief,
@@ -334,7 +334,7 @@ pub fn evaluate_api_route_requires_request_validation(
             .request_validation
             .unvalidated_uses
             .first()
-            .map(|use_proof| use_proof.reason.clone())
+            .map(|use_proof| use_proof.reason.as_wire().to_string())
             .unwrap_or_else(|| "request_input_not_validated".to_string()),
         enforcement_result: match contract.enforcement_mode {
             SecurityEnforcementMode::Brief => SecurityFindingResult::Brief,

--- a/crates/drift-engine/src/vocabulary.rs
+++ b/crates/drift-engine/src/vocabulary.rs
@@ -1319,3 +1319,90 @@ impl<'de> serde::Deserialize<'de> for SessionTrustReason {
         })
     }
 }
+
+/// Why an authorization proof could not be completed. PROOF-LEVEL vocabulary, on `authorization.missing[].reason`. The list carries two spellings of the same three concepts - an older `no_authorization_guard`/`guard_not_dominating_sink` pair and the newer `authorization_guard_missing`/`authorization_guard_not_dominating_sink` - because the enum was WIDENED rather than migrated when the engine's wording changed. Only the newer spelling has a producer today; the older one is reserved, because the schema is applied on read and stored rows may still hold it.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
+pub enum AuthorizationMissingReason {
+    NoAuthorizationGuard,
+    GuardNotDominatingSink,
+    UnknownPolicyHelper,
+    SessionNotTrusted,
+    AuthorizationGuardMissing,
+    AuthorizationGuardNotDominatingSink,
+}
+
+impl AuthorizationMissingReason {
+    /// Every member, in manifest order.
+    pub const ALL: &'static [AuthorizationMissingReason] = &[
+        AuthorizationMissingReason::NoAuthorizationGuard,
+        AuthorizationMissingReason::GuardNotDominatingSink,
+        AuthorizationMissingReason::UnknownPolicyHelper,
+        AuthorizationMissingReason::SessionNotTrusted,
+        AuthorizationMissingReason::AuthorizationGuardMissing,
+        AuthorizationMissingReason::AuthorizationGuardNotDominatingSink,
+    ];
+
+    /// The string this member takes on the wire.
+    pub fn as_wire(self) -> &'static str {
+        match self {
+            AuthorizationMissingReason::NoAuthorizationGuard => "no_authorization_guard",
+            AuthorizationMissingReason::GuardNotDominatingSink => "guard_not_dominating_sink",
+            AuthorizationMissingReason::UnknownPolicyHelper => "unknown_policy_helper",
+            AuthorizationMissingReason::SessionNotTrusted => "session_not_trusted",
+            AuthorizationMissingReason::AuthorizationGuardMissing => "authorization_guard_missing",
+            AuthorizationMissingReason::AuthorizationGuardNotDominatingSink => {
+                "authorization_guard_not_dominating_sink"
+            }
+        }
+    }
+
+    /// Parse a wire string. `None` is an unknown member, never a silently dropped one.
+    pub fn from_wire(value: &str) -> Option<Self> {
+        match value {
+            "no_authorization_guard" => Some(AuthorizationMissingReason::NoAuthorizationGuard),
+            "guard_not_dominating_sink" => Some(AuthorizationMissingReason::GuardNotDominatingSink),
+            "unknown_policy_helper" => Some(AuthorizationMissingReason::UnknownPolicyHelper),
+            "session_not_trusted" => Some(AuthorizationMissingReason::SessionNotTrusted),
+            "authorization_guard_missing" => {
+                Some(AuthorizationMissingReason::AuthorizationGuardMissing)
+            }
+            "authorization_guard_not_dominating_sink" => {
+                Some(AuthorizationMissingReason::AuthorizationGuardNotDominatingSink)
+            }
+            _ => None,
+        }
+    }
+
+    /// Every member's wire string, sorted, for the engine/CLI vocabulary handshake.
+    pub fn all_wire_names() -> Vec<String> {
+        let mut names: Vec<String> = Self::ALL
+            .iter()
+            .map(|member| member.as_wire().to_string())
+            .collect();
+        names.sort();
+        names
+    }
+}
+
+impl std::fmt::Display for AuthorizationMissingReason {
+    fn fmt(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        formatter.write_str(self.as_wire())
+    }
+}
+
+impl serde::Serialize for AuthorizationMissingReason {
+    fn serialize<S: serde::Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
+        serializer.serialize_str(self.as_wire())
+    }
+}
+
+impl<'de> serde::Deserialize<'de> for AuthorizationMissingReason {
+    fn deserialize<D: serde::Deserializer<'de>>(deserializer: D) -> Result<Self, D::Error> {
+        let raw = <String as serde::Deserialize>::deserialize(deserializer)?;
+        AuthorizationMissingReason::from_wire(&raw).ok_or_else(|| {
+            serde::de::Error::custom(format!(
+                "unknown authorization_missing_reason \"{raw}\": this engine and its caller disagree about the authorization_missing_reason vocabulary"
+            ))
+        })
+    }
+}

--- a/crates/drift-engine/src/vocabulary.rs
+++ b/crates/drift-engine/src/vocabulary.rs
@@ -1495,3 +1495,84 @@ impl<'de> serde::Deserialize<'de> for TenantMissingReason {
         })
     }
 }
+
+/// Why an auth guard does not dominate a sink. PROOF-LEVEL vocabulary, on `auth.undominated_sinks[].reason`. Unlike the other proof reason vocabularies this one has TWO producers: the straight-line and dynamic-control-flow cases are decided in security_proof.rs, and the path-sensitive ones - a guard in only one branch, a guard behind a callback boundary - in security_control_flow.rs. Every member is produced.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
+pub enum UndominatedSinkReason {
+    GuardAfterSink,
+    GuardOnlyInOneBranch,
+    CallbackBoundary,
+    UnsupportedDynamicControlFlow,
+    NoGuardCall,
+}
+
+impl UndominatedSinkReason {
+    /// Every member, in manifest order.
+    pub const ALL: &'static [UndominatedSinkReason] = &[
+        UndominatedSinkReason::GuardAfterSink,
+        UndominatedSinkReason::GuardOnlyInOneBranch,
+        UndominatedSinkReason::CallbackBoundary,
+        UndominatedSinkReason::UnsupportedDynamicControlFlow,
+        UndominatedSinkReason::NoGuardCall,
+    ];
+
+    /// The string this member takes on the wire.
+    pub fn as_wire(self) -> &'static str {
+        match self {
+            UndominatedSinkReason::GuardAfterSink => "guard_after_sink",
+            UndominatedSinkReason::GuardOnlyInOneBranch => "guard_only_in_one_branch",
+            UndominatedSinkReason::CallbackBoundary => "callback_boundary",
+            UndominatedSinkReason::UnsupportedDynamicControlFlow => {
+                "unsupported_dynamic_control_flow"
+            }
+            UndominatedSinkReason::NoGuardCall => "no_guard_call",
+        }
+    }
+
+    /// Parse a wire string. `None` is an unknown member, never a silently dropped one.
+    pub fn from_wire(value: &str) -> Option<Self> {
+        match value {
+            "guard_after_sink" => Some(UndominatedSinkReason::GuardAfterSink),
+            "guard_only_in_one_branch" => Some(UndominatedSinkReason::GuardOnlyInOneBranch),
+            "callback_boundary" => Some(UndominatedSinkReason::CallbackBoundary),
+            "unsupported_dynamic_control_flow" => {
+                Some(UndominatedSinkReason::UnsupportedDynamicControlFlow)
+            }
+            "no_guard_call" => Some(UndominatedSinkReason::NoGuardCall),
+            _ => None,
+        }
+    }
+
+    /// Every member's wire string, sorted, for the engine/CLI vocabulary handshake.
+    pub fn all_wire_names() -> Vec<String> {
+        let mut names: Vec<String> = Self::ALL
+            .iter()
+            .map(|member| member.as_wire().to_string())
+            .collect();
+        names.sort();
+        names
+    }
+}
+
+impl std::fmt::Display for UndominatedSinkReason {
+    fn fmt(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        formatter.write_str(self.as_wire())
+    }
+}
+
+impl serde::Serialize for UndominatedSinkReason {
+    fn serialize<S: serde::Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
+        serializer.serialize_str(self.as_wire())
+    }
+}
+
+impl<'de> serde::Deserialize<'de> for UndominatedSinkReason {
+    fn deserialize<D: serde::Deserializer<'de>>(deserializer: D) -> Result<Self, D::Error> {
+        let raw = <String as serde::Deserialize>::deserialize(deserializer)?;
+        UndominatedSinkReason::from_wire(&raw).ok_or_else(|| {
+            serde::de::Error::custom(format!(
+                "unknown undominated_sink_reason \"{raw}\": this engine and its caller disagree about the undominated_sink_reason vocabulary"
+            ))
+        })
+    }
+}

--- a/crates/drift-engine/src/vocabulary.rs
+++ b/crates/drift-engine/src/vocabulary.rs
@@ -1246,3 +1246,76 @@ impl ScanCapability {
         ScanCapability::TenantScope,
     ];
 }
+
+/// Why a session object could not be proven trusted. PROOF-LEVEL vocabulary: it says why the proof failed. The FINDING-level code a user sees (SecurityMissingProofCodeSchema) is separate and is derived from this by the phase4 finding-reason mapping in check_command.rs. The two are deliberately different vocabularies; mapping between them must be total.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
+pub enum SessionTrustReason {
+    DerivedFromRequest,
+    UnknownHelper,
+    MissingAuthGuard,
+    ParserGap,
+}
+
+impl SessionTrustReason {
+    /// Every member, in manifest order.
+    pub const ALL: &'static [SessionTrustReason] = &[
+        SessionTrustReason::DerivedFromRequest,
+        SessionTrustReason::UnknownHelper,
+        SessionTrustReason::MissingAuthGuard,
+        SessionTrustReason::ParserGap,
+    ];
+
+    /// The string this member takes on the wire.
+    pub fn as_wire(self) -> &'static str {
+        match self {
+            SessionTrustReason::DerivedFromRequest => "derived_from_request",
+            SessionTrustReason::UnknownHelper => "unknown_helper",
+            SessionTrustReason::MissingAuthGuard => "missing_auth_guard",
+            SessionTrustReason::ParserGap => "parser_gap",
+        }
+    }
+
+    /// Parse a wire string. `None` is an unknown member, never a silently dropped one.
+    pub fn from_wire(value: &str) -> Option<Self> {
+        match value {
+            "derived_from_request" => Some(SessionTrustReason::DerivedFromRequest),
+            "unknown_helper" => Some(SessionTrustReason::UnknownHelper),
+            "missing_auth_guard" => Some(SessionTrustReason::MissingAuthGuard),
+            "parser_gap" => Some(SessionTrustReason::ParserGap),
+            _ => None,
+        }
+    }
+
+    /// Every member's wire string, sorted, for the engine/CLI vocabulary handshake.
+    pub fn all_wire_names() -> Vec<String> {
+        let mut names: Vec<String> = Self::ALL
+            .iter()
+            .map(|member| member.as_wire().to_string())
+            .collect();
+        names.sort();
+        names
+    }
+}
+
+impl std::fmt::Display for SessionTrustReason {
+    fn fmt(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        formatter.write_str(self.as_wire())
+    }
+}
+
+impl serde::Serialize for SessionTrustReason {
+    fn serialize<S: serde::Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
+        serializer.serialize_str(self.as_wire())
+    }
+}
+
+impl<'de> serde::Deserialize<'de> for SessionTrustReason {
+    fn deserialize<D: serde::Deserializer<'de>>(deserializer: D) -> Result<Self, D::Error> {
+        let raw = <String as serde::Deserialize>::deserialize(deserializer)?;
+        SessionTrustReason::from_wire(&raw).ok_or_else(|| {
+            serde::de::Error::custom(format!(
+                "unknown session_trust_reason \"{raw}\": this engine and its caller disagree about the session_trust_reason vocabulary"
+            ))
+        })
+    }
+}

--- a/crates/drift-engine/src/vocabulary.rs
+++ b/crates/drift-engine/src/vocabulary.rs
@@ -1406,3 +1406,92 @@ impl<'de> serde::Deserialize<'de> for AuthorizationMissingReason {
         })
     }
 }
+
+/// Why a tenant-scope proof could not be completed. PROOF-LEVEL vocabulary, on `tenant.missing[].reason`. Widened the same way authorization_missing_reason was: the first three members are the spelling the original design named, the last three are the spelling the engine emits, and `parser_gap` is a fourth concept with no producer at all. Only the newer three are constructed; the rest are reserved rather than deleted, because the schema is applied on read.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
+pub enum TenantMissingReason {
+    NoTenantPredicate,
+    UntrustedTenantSource,
+    PredicateNotBoundToQuery,
+    ParserGap,
+    TenantPredicateMissing,
+    TenantSourceUntrusted,
+    TenantPredicateNotBoundToQuery,
+}
+
+impl TenantMissingReason {
+    /// Every member, in manifest order.
+    pub const ALL: &'static [TenantMissingReason] = &[
+        TenantMissingReason::NoTenantPredicate,
+        TenantMissingReason::UntrustedTenantSource,
+        TenantMissingReason::PredicateNotBoundToQuery,
+        TenantMissingReason::ParserGap,
+        TenantMissingReason::TenantPredicateMissing,
+        TenantMissingReason::TenantSourceUntrusted,
+        TenantMissingReason::TenantPredicateNotBoundToQuery,
+    ];
+
+    /// The string this member takes on the wire.
+    pub fn as_wire(self) -> &'static str {
+        match self {
+            TenantMissingReason::NoTenantPredicate => "no_tenant_predicate",
+            TenantMissingReason::UntrustedTenantSource => "untrusted_tenant_source",
+            TenantMissingReason::PredicateNotBoundToQuery => "predicate_not_bound_to_query",
+            TenantMissingReason::ParserGap => "parser_gap",
+            TenantMissingReason::TenantPredicateMissing => "tenant_predicate_missing",
+            TenantMissingReason::TenantSourceUntrusted => "tenant_source_untrusted",
+            TenantMissingReason::TenantPredicateNotBoundToQuery => {
+                "tenant_predicate_not_bound_to_query"
+            }
+        }
+    }
+
+    /// Parse a wire string. `None` is an unknown member, never a silently dropped one.
+    pub fn from_wire(value: &str) -> Option<Self> {
+        match value {
+            "no_tenant_predicate" => Some(TenantMissingReason::NoTenantPredicate),
+            "untrusted_tenant_source" => Some(TenantMissingReason::UntrustedTenantSource),
+            "predicate_not_bound_to_query" => Some(TenantMissingReason::PredicateNotBoundToQuery),
+            "parser_gap" => Some(TenantMissingReason::ParserGap),
+            "tenant_predicate_missing" => Some(TenantMissingReason::TenantPredicateMissing),
+            "tenant_source_untrusted" => Some(TenantMissingReason::TenantSourceUntrusted),
+            "tenant_predicate_not_bound_to_query" => {
+                Some(TenantMissingReason::TenantPredicateNotBoundToQuery)
+            }
+            _ => None,
+        }
+    }
+
+    /// Every member's wire string, sorted, for the engine/CLI vocabulary handshake.
+    pub fn all_wire_names() -> Vec<String> {
+        let mut names: Vec<String> = Self::ALL
+            .iter()
+            .map(|member| member.as_wire().to_string())
+            .collect();
+        names.sort();
+        names
+    }
+}
+
+impl std::fmt::Display for TenantMissingReason {
+    fn fmt(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        formatter.write_str(self.as_wire())
+    }
+}
+
+impl serde::Serialize for TenantMissingReason {
+    fn serialize<S: serde::Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
+        serializer.serialize_str(self.as_wire())
+    }
+}
+
+impl<'de> serde::Deserialize<'de> for TenantMissingReason {
+    fn deserialize<D: serde::Deserializer<'de>>(deserializer: D) -> Result<Self, D::Error> {
+        let raw = <String as serde::Deserialize>::deserialize(deserializer)?;
+        TenantMissingReason::from_wire(&raw).ok_or_else(|| {
+            serde::de::Error::custom(format!(
+                "unknown tenant_missing_reason \"{raw}\": this engine and its caller disagree about the tenant_missing_reason vocabulary"
+            ))
+        })
+    }
+}

--- a/crates/drift-engine/src/vocabulary.rs
+++ b/crates/drift-engine/src/vocabulary.rs
@@ -1576,3 +1576,147 @@ impl<'de> serde::Deserialize<'de> for UndominatedSinkReason {
         })
     }
 }
+
+/// Why a middleware does not cover a route. PROOF-LEVEL vocabulary, on `middleware.mismatches[].reason`, produced by static_middleware_coverage in security_control_flow.rs. `dynamic_matcher` has no producer: a dynamic matcher is reported as a parser gap and drives proof_status == ParserGap rather than as a coverage mismatch, so the mismatch spelling of it was declared and never built.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
+pub enum MiddlewareMismatchReason {
+    PathNotMatched,
+    MethodNotMatched,
+    DynamicMatcher,
+    UnknownFramework,
+}
+
+impl MiddlewareMismatchReason {
+    /// Every member, in manifest order.
+    pub const ALL: &'static [MiddlewareMismatchReason] = &[
+        MiddlewareMismatchReason::PathNotMatched,
+        MiddlewareMismatchReason::MethodNotMatched,
+        MiddlewareMismatchReason::DynamicMatcher,
+        MiddlewareMismatchReason::UnknownFramework,
+    ];
+
+    /// The string this member takes on the wire.
+    pub fn as_wire(self) -> &'static str {
+        match self {
+            MiddlewareMismatchReason::PathNotMatched => "path_not_matched",
+            MiddlewareMismatchReason::MethodNotMatched => "method_not_matched",
+            MiddlewareMismatchReason::DynamicMatcher => "dynamic_matcher",
+            MiddlewareMismatchReason::UnknownFramework => "unknown_framework",
+        }
+    }
+
+    /// Parse a wire string. `None` is an unknown member, never a silently dropped one.
+    pub fn from_wire(value: &str) -> Option<Self> {
+        match value {
+            "path_not_matched" => Some(MiddlewareMismatchReason::PathNotMatched),
+            "method_not_matched" => Some(MiddlewareMismatchReason::MethodNotMatched),
+            "dynamic_matcher" => Some(MiddlewareMismatchReason::DynamicMatcher),
+            "unknown_framework" => Some(MiddlewareMismatchReason::UnknownFramework),
+            _ => None,
+        }
+    }
+
+    /// Every member's wire string, sorted, for the engine/CLI vocabulary handshake.
+    pub fn all_wire_names() -> Vec<String> {
+        let mut names: Vec<String> = Self::ALL
+            .iter()
+            .map(|member| member.as_wire().to_string())
+            .collect();
+        names.sort();
+        names
+    }
+}
+
+impl std::fmt::Display for MiddlewareMismatchReason {
+    fn fmt(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        formatter.write_str(self.as_wire())
+    }
+}
+
+impl serde::Serialize for MiddlewareMismatchReason {
+    fn serialize<S: serde::Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
+        serializer.serialize_str(self.as_wire())
+    }
+}
+
+impl<'de> serde::Deserialize<'de> for MiddlewareMismatchReason {
+    fn deserialize<D: serde::Deserializer<'de>>(deserializer: D) -> Result<Self, D::Error> {
+        let raw = <String as serde::Deserialize>::deserialize(deserializer)?;
+        MiddlewareMismatchReason::from_wire(&raw).ok_or_else(|| {
+            serde::de::Error::custom(format!(
+                "unknown middleware_mismatch_reason \"{raw}\": this engine and its caller disagree about the middleware_mismatch_reason vocabulary"
+            ))
+        })
+    }
+}
+
+/// Why a request input reaching a sink is not covered by a validation proof. PROOF-LEVEL vocabulary, on `request_validation.unvalidated_uses[].reason`. Every member is produced by request_unvalidated_uses in security_proof.rs, and all three are also members of the finding-level SecurityMissingProofCodeSchema, so the two vocabularies agree here and need no bridge.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
+pub enum RequestUnvalidatedReason {
+    RequestInputNotValidated,
+    ValidationResultNotUsed,
+    UnknownValidator,
+}
+
+impl RequestUnvalidatedReason {
+    /// Every member, in manifest order.
+    pub const ALL: &'static [RequestUnvalidatedReason] = &[
+        RequestUnvalidatedReason::RequestInputNotValidated,
+        RequestUnvalidatedReason::ValidationResultNotUsed,
+        RequestUnvalidatedReason::UnknownValidator,
+    ];
+
+    /// The string this member takes on the wire.
+    pub fn as_wire(self) -> &'static str {
+        match self {
+            RequestUnvalidatedReason::RequestInputNotValidated => "request_input_not_validated",
+            RequestUnvalidatedReason::ValidationResultNotUsed => "validation_result_not_used",
+            RequestUnvalidatedReason::UnknownValidator => "unknown_validator",
+        }
+    }
+
+    /// Parse a wire string. `None` is an unknown member, never a silently dropped one.
+    pub fn from_wire(value: &str) -> Option<Self> {
+        match value {
+            "request_input_not_validated" => {
+                Some(RequestUnvalidatedReason::RequestInputNotValidated)
+            }
+            "validation_result_not_used" => Some(RequestUnvalidatedReason::ValidationResultNotUsed),
+            "unknown_validator" => Some(RequestUnvalidatedReason::UnknownValidator),
+            _ => None,
+        }
+    }
+
+    /// Every member's wire string, sorted, for the engine/CLI vocabulary handshake.
+    pub fn all_wire_names() -> Vec<String> {
+        let mut names: Vec<String> = Self::ALL
+            .iter()
+            .map(|member| member.as_wire().to_string())
+            .collect();
+        names.sort();
+        names
+    }
+}
+
+impl std::fmt::Display for RequestUnvalidatedReason {
+    fn fmt(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        formatter.write_str(self.as_wire())
+    }
+}
+
+impl serde::Serialize for RequestUnvalidatedReason {
+    fn serialize<S: serde::Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
+        serializer.serialize_str(self.as_wire())
+    }
+}
+
+impl<'de> serde::Deserialize<'de> for RequestUnvalidatedReason {
+    fn deserialize<D: serde::Deserializer<'de>>(deserializer: D) -> Result<Self, D::Error> {
+        let raw = <String as serde::Deserialize>::deserialize(deserializer)?;
+        RequestUnvalidatedReason::from_wire(&raw).ok_or_else(|| {
+            serde::de::Error::custom(format!(
+                "unknown request_unvalidated_reason \"{raw}\": this engine and its caller disagree about the request_unvalidated_reason vocabulary"
+            ))
+        })
+    }
+}

--- a/crates/drift-engine/src/vocabulary.rs
+++ b/crates/drift-engine/src/vocabulary.rs
@@ -1720,3 +1720,160 @@ impl<'de> serde::Deserialize<'de> for RequestUnvalidatedReason {
         })
     }
 }
+
+/// Why a SECURITY proof could not be completed because a construct could not be analysed. Carried on `parser_gaps[].code` inside a security boundary proof, and produced by build_phase4_security_proof, the phase5/phase6 builders and phase4_parser_gap.
+///
+/// NOT the same vocabulary as `parser_gap_kind`, despite the name. That one is the repo-wide taxonomy of why a REGION of the repo could not be understood - unresolved_import, parser_error, partial_parse - derived CLI-side from engine diagnostic codes and named by the semantic capability contracts. This one is the set of specific TypeScript constructs a security proof gives up on. The two lists are disjoint and the collision is in the English word `parser gap`, not in the concept; merging them would put `unresolved_import` where a security proof expects `unsupported_request_input_spread`.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
+pub enum SecurityParserGapCode {
+    RouteBindingUnresolved,
+    HandlerUnresolved,
+    UnsupportedDynamicControlFlow,
+    UnsupportedDynamicMiddlewareMatcher,
+    UnsupportedRequestInputSpread,
+    UnsupportedRequestInputDestructure,
+    UnsupportedDynamicOutboundUrl,
+    UnsupportedDynamicCorsOrigin,
+    DynamicResponseShape,
+    UnsupportedDestructuringOrSpread,
+    UnsupportedTenantDynamicProperty,
+    UnsupportedTenantQueryObjectAlias,
+    UnsupportedSessionNestedDestructure,
+    UnsupportedCallbackBoundary,
+}
+
+impl SecurityParserGapCode {
+    /// Every member, in manifest order.
+    pub const ALL: &'static [SecurityParserGapCode] = &[
+        SecurityParserGapCode::RouteBindingUnresolved,
+        SecurityParserGapCode::HandlerUnresolved,
+        SecurityParserGapCode::UnsupportedDynamicControlFlow,
+        SecurityParserGapCode::UnsupportedDynamicMiddlewareMatcher,
+        SecurityParserGapCode::UnsupportedRequestInputSpread,
+        SecurityParserGapCode::UnsupportedRequestInputDestructure,
+        SecurityParserGapCode::UnsupportedDynamicOutboundUrl,
+        SecurityParserGapCode::UnsupportedDynamicCorsOrigin,
+        SecurityParserGapCode::DynamicResponseShape,
+        SecurityParserGapCode::UnsupportedDestructuringOrSpread,
+        SecurityParserGapCode::UnsupportedTenantDynamicProperty,
+        SecurityParserGapCode::UnsupportedTenantQueryObjectAlias,
+        SecurityParserGapCode::UnsupportedSessionNestedDestructure,
+        SecurityParserGapCode::UnsupportedCallbackBoundary,
+    ];
+
+    /// The string this member takes on the wire.
+    pub fn as_wire(self) -> &'static str {
+        match self {
+            SecurityParserGapCode::RouteBindingUnresolved => "route_binding_unresolved",
+            SecurityParserGapCode::HandlerUnresolved => "handler_unresolved",
+            SecurityParserGapCode::UnsupportedDynamicControlFlow => {
+                "unsupported_dynamic_control_flow"
+            }
+            SecurityParserGapCode::UnsupportedDynamicMiddlewareMatcher => {
+                "unsupported_dynamic_middleware_matcher"
+            }
+            SecurityParserGapCode::UnsupportedRequestInputSpread => {
+                "unsupported_request_input_spread"
+            }
+            SecurityParserGapCode::UnsupportedRequestInputDestructure => {
+                "unsupported_request_input_destructure"
+            }
+            SecurityParserGapCode::UnsupportedDynamicOutboundUrl => {
+                "unsupported_dynamic_outbound_url"
+            }
+            SecurityParserGapCode::UnsupportedDynamicCorsOrigin => {
+                "unsupported_dynamic_cors_origin"
+            }
+            SecurityParserGapCode::DynamicResponseShape => "dynamic_response_shape",
+            SecurityParserGapCode::UnsupportedDestructuringOrSpread => {
+                "unsupported_destructuring_or_spread"
+            }
+            SecurityParserGapCode::UnsupportedTenantDynamicProperty => {
+                "unsupported_tenant_dynamic_property"
+            }
+            SecurityParserGapCode::UnsupportedTenantQueryObjectAlias => {
+                "unsupported_tenant_query_object_alias"
+            }
+            SecurityParserGapCode::UnsupportedSessionNestedDestructure => {
+                "unsupported_session_nested_destructure"
+            }
+            SecurityParserGapCode::UnsupportedCallbackBoundary => "unsupported_callback_boundary",
+        }
+    }
+
+    /// Parse a wire string. `None` is an unknown member, never a silently dropped one.
+    pub fn from_wire(value: &str) -> Option<Self> {
+        match value {
+            "route_binding_unresolved" => Some(SecurityParserGapCode::RouteBindingUnresolved),
+            "handler_unresolved" => Some(SecurityParserGapCode::HandlerUnresolved),
+            "unsupported_dynamic_control_flow" => {
+                Some(SecurityParserGapCode::UnsupportedDynamicControlFlow)
+            }
+            "unsupported_dynamic_middleware_matcher" => {
+                Some(SecurityParserGapCode::UnsupportedDynamicMiddlewareMatcher)
+            }
+            "unsupported_request_input_spread" => {
+                Some(SecurityParserGapCode::UnsupportedRequestInputSpread)
+            }
+            "unsupported_request_input_destructure" => {
+                Some(SecurityParserGapCode::UnsupportedRequestInputDestructure)
+            }
+            "unsupported_dynamic_outbound_url" => {
+                Some(SecurityParserGapCode::UnsupportedDynamicOutboundUrl)
+            }
+            "unsupported_dynamic_cors_origin" => {
+                Some(SecurityParserGapCode::UnsupportedDynamicCorsOrigin)
+            }
+            "dynamic_response_shape" => Some(SecurityParserGapCode::DynamicResponseShape),
+            "unsupported_destructuring_or_spread" => {
+                Some(SecurityParserGapCode::UnsupportedDestructuringOrSpread)
+            }
+            "unsupported_tenant_dynamic_property" => {
+                Some(SecurityParserGapCode::UnsupportedTenantDynamicProperty)
+            }
+            "unsupported_tenant_query_object_alias" => {
+                Some(SecurityParserGapCode::UnsupportedTenantQueryObjectAlias)
+            }
+            "unsupported_session_nested_destructure" => {
+                Some(SecurityParserGapCode::UnsupportedSessionNestedDestructure)
+            }
+            "unsupported_callback_boundary" => {
+                Some(SecurityParserGapCode::UnsupportedCallbackBoundary)
+            }
+            _ => None,
+        }
+    }
+
+    /// Every member's wire string, sorted, for the engine/CLI vocabulary handshake.
+    pub fn all_wire_names() -> Vec<String> {
+        let mut names: Vec<String> = Self::ALL
+            .iter()
+            .map(|member| member.as_wire().to_string())
+            .collect();
+        names.sort();
+        names
+    }
+}
+
+impl std::fmt::Display for SecurityParserGapCode {
+    fn fmt(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        formatter.write_str(self.as_wire())
+    }
+}
+
+impl serde::Serialize for SecurityParserGapCode {
+    fn serialize<S: serde::Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
+        serializer.serialize_str(self.as_wire())
+    }
+}
+
+impl<'de> serde::Deserialize<'de> for SecurityParserGapCode {
+    fn deserialize<D: serde::Deserializer<'de>>(deserializer: D) -> Result<Self, D::Error> {
+        let raw = <String as serde::Deserialize>::deserialize(deserializer)?;
+        SecurityParserGapCode::from_wire(&raw).ok_or_else(|| {
+            serde::de::Error::custom(format!(
+                "unknown security_parser_gap_code \"{raw}\": this engine and its caller disagree about the security_parser_gap_code vocabulary"
+            ))
+        })
+    }
+}

--- a/crates/drift-engine/tests/security_control_flow.rs
+++ b/crates/drift-engine/tests/security_control_flow.rs
@@ -1,8 +1,8 @@
 use drift_engine::{
     AcceptedAuthHelper, AcceptedAuthorizationHelper, AcceptedRequestValidator, AuthGuardBehavior,
     AuthorizationHelperBehavior, AuthorizationHelperKind, AuthorizationMissingReason, FactKind,
-    Phase4SecurityPolicy, RequestValidatorBehavior, RequestValidatorKind, SecurityProofStatus,
-    SessionTrustReason, UndominatedSinkReason, build_auth_boundary_proof,
+    Phase4SecurityPolicy, RequestUnvalidatedReason, RequestValidatorBehavior, RequestValidatorKind,
+    SecurityProofStatus, SessionTrustReason, UndominatedSinkReason, build_auth_boundary_proof,
     build_middleware_coverage_proof, build_phase4_security_proof,
     build_phase4_security_proof_with_policy, build_request_validation_proof,
     extract_security_facts,
@@ -616,8 +616,10 @@ export async function POST(request: Request) {
             .request_validation
             .unvalidated_uses
             .iter()
-            .any(|use_proof| use_proof.reason == "validation_result_not_used"
-                || use_proof.reason == "request_input_not_validated")
+            .any(
+                |use_proof| use_proof.reason == RequestUnvalidatedReason::ValidationResultNotUsed
+                    || use_proof.reason == RequestUnvalidatedReason::RequestInputNotValidated
+            )
     );
 }
 
@@ -712,7 +714,7 @@ export async function POST(request: Request) {
             .request_validation
             .unvalidated_uses
             .iter()
-            .any(|use_proof| use_proof.reason == "request_input_not_validated")
+            .any(|use_proof| use_proof.reason == RequestUnvalidatedReason::RequestInputNotValidated)
     );
 }
 

--- a/crates/drift-engine/tests/security_control_flow.rs
+++ b/crates/drift-engine/tests/security_control_flow.rs
@@ -1,8 +1,8 @@
 use drift_engine::{
     AcceptedAuthHelper, AcceptedAuthorizationHelper, AcceptedRequestValidator, AuthGuardBehavior,
     AuthorizationHelperBehavior, AuthorizationHelperKind, FactKind, Phase4SecurityPolicy,
-    RequestValidatorBehavior, RequestValidatorKind, SecurityProofStatus, build_auth_boundary_proof,
-    build_middleware_coverage_proof, build_phase4_security_proof,
+    RequestValidatorBehavior, RequestValidatorKind, SecurityProofStatus, SessionTrustReason,
+    build_auth_boundary_proof, build_middleware_coverage_proof, build_phase4_security_proof,
     build_phase4_security_proof_with_policy, build_request_validation_proof,
     extract_security_facts,
 };
@@ -110,9 +110,8 @@ export async function GET(request: Request) {
             .session_trust
             .missing_trust
             .iter()
-            .any(
-                |missing| missing.variable == "session" && missing.reason == "derived_from_request"
-            ),
+            .any(|missing| missing.variable == "session"
+                && missing.reason == SessionTrustReason::DerivedFromRequest),
         "missing derived_from_request trust failure: {untrusted_proof:#?}"
     );
 }

--- a/crates/drift-engine/tests/security_control_flow.rs
+++ b/crates/drift-engine/tests/security_control_flow.rs
@@ -1,10 +1,10 @@
 use drift_engine::{
     AcceptedAuthHelper, AcceptedAuthorizationHelper, AcceptedRequestValidator, AuthGuardBehavior,
-    AuthorizationHelperBehavior, AuthorizationHelperKind, FactKind, Phase4SecurityPolicy,
-    RequestValidatorBehavior, RequestValidatorKind, SecurityProofStatus, SessionTrustReason,
-    build_auth_boundary_proof, build_middleware_coverage_proof, build_phase4_security_proof,
-    build_phase4_security_proof_with_policy, build_request_validation_proof,
-    extract_security_facts,
+    AuthorizationHelperBehavior, AuthorizationHelperKind, AuthorizationMissingReason, FactKind,
+    Phase4SecurityPolicy, RequestValidatorBehavior, RequestValidatorKind, SecurityProofStatus,
+    SessionTrustReason, build_auth_boundary_proof, build_middleware_coverage_proof,
+    build_phase4_security_proof, build_phase4_security_proof_with_policy,
+    build_request_validation_proof, extract_security_facts,
 };
 
 #[test]
@@ -178,7 +178,8 @@ export async function DELETE(request: Request) {
                 .authorization
                 .missing
                 .iter()
-                .any(|missing| missing.reason == "authorization_guard_not_dominating_sink"),
+                .any(|missing| missing.reason
+                    == AuthorizationMissingReason::AuthorizationGuardNotDominatingSink),
             "missing dominance failure proof: {proof:#?}"
         );
     }

--- a/crates/drift-engine/tests/security_control_flow.rs
+++ b/crates/drift-engine/tests/security_control_flow.rs
@@ -2,9 +2,10 @@ use drift_engine::{
     AcceptedAuthHelper, AcceptedAuthorizationHelper, AcceptedRequestValidator, AuthGuardBehavior,
     AuthorizationHelperBehavior, AuthorizationHelperKind, AuthorizationMissingReason, FactKind,
     Phase4SecurityPolicy, RequestValidatorBehavior, RequestValidatorKind, SecurityProofStatus,
-    SessionTrustReason, build_auth_boundary_proof, build_middleware_coverage_proof,
-    build_phase4_security_proof, build_phase4_security_proof_with_policy,
-    build_request_validation_proof, extract_security_facts,
+    SessionTrustReason, UndominatedSinkReason, build_auth_boundary_proof,
+    build_middleware_coverage_proof, build_phase4_security_proof,
+    build_phase4_security_proof_with_policy, build_request_validation_proof,
+    extract_security_facts,
 };
 
 #[test]
@@ -33,7 +34,10 @@ export async function GET() {
 
     assert!(proof.auth.required);
     assert!(proof.auth.proven, "proof should prove auth: {proof:#?}");
-    assert_eq!(proof.auth.undominated_sinks, Vec::<String>::new());
+    assert_eq!(
+        proof.auth.undominated_sinks,
+        Vec::<UndominatedSinkReason>::new()
+    );
     assert!(
         proof
             .auth
@@ -274,7 +278,7 @@ export async function GET() {
         proof
             .auth
             .undominated_sinks
-            .contains(&"guard_after_sink".to_string()),
+            .contains(&UndominatedSinkReason::GuardAfterSink),
         "missing guard_after_sink reason: {proof:#?}"
     );
     assert_eq!(proof.result.proof_status, SecurityProofStatus::MissingProof);
@@ -313,7 +317,7 @@ export async function GET(request: Request) {
         proof
             .auth
             .undominated_sinks
-            .contains(&"guard_only_in_one_branch".to_string()),
+            .contains(&UndominatedSinkReason::GuardOnlyInOneBranch),
         "missing guard_only_in_one_branch reason: {proof:#?}"
     );
 }
@@ -349,7 +353,7 @@ export async function GET() {
         proof
             .auth
             .undominated_sinks
-            .contains(&"callback_boundary".to_string()),
+            .contains(&UndominatedSinkReason::CallbackBoundary),
         "missing callback_boundary reason: {proof:#?}"
     );
 
@@ -406,7 +410,7 @@ export async function GET(request: Request) {
         proof
             .auth
             .undominated_sinks
-            .contains(&"unsupported_dynamic_control_flow".to_string()),
+            .contains(&UndominatedSinkReason::UnsupportedDynamicControlFlow),
         "missing unsupported_dynamic_control_flow reason: {proof:#?}"
     );
     assert!(

--- a/crates/drift-engine/tests/security_control_flow.rs
+++ b/crates/drift-engine/tests/security_control_flow.rs
@@ -2,8 +2,8 @@ use drift_engine::{
     AcceptedAuthHelper, AcceptedAuthorizationHelper, AcceptedRequestValidator, AuthGuardBehavior,
     AuthorizationHelperBehavior, AuthorizationHelperKind, AuthorizationMissingReason, FactKind,
     Phase4SecurityPolicy, RequestUnvalidatedReason, RequestValidatorBehavior, RequestValidatorKind,
-    SecurityProofStatus, SessionTrustReason, UndominatedSinkReason, build_auth_boundary_proof,
-    build_middleware_coverage_proof, build_phase4_security_proof,
+    SecurityParserGapCode, SecurityProofStatus, SessionTrustReason, UndominatedSinkReason,
+    build_auth_boundary_proof, build_middleware_coverage_proof, build_phase4_security_proof,
     build_phase4_security_proof_with_policy, build_request_validation_proof,
     extract_security_facts,
 };
@@ -231,9 +231,18 @@ export async function GET(request: Request) {
     }];
 
     let cases = [
-        (dynamic_property, "unsupported_tenant_dynamic_property"),
-        (query_object_alias, "unsupported_tenant_query_object_alias"),
-        (nested_destructure, "unsupported_session_nested_destructure"),
+        (
+            dynamic_property,
+            SecurityParserGapCode::UnsupportedTenantDynamicProperty,
+        ),
+        (
+            query_object_alias,
+            SecurityParserGapCode::UnsupportedTenantQueryObjectAlias,
+        ),
+        (
+            nested_destructure,
+            SecurityParserGapCode::UnsupportedSessionNestedDestructure,
+        ),
     ];
     for (source, expected_code) in cases {
         let proof = build_phase4_security_proof("app/api/projects/route.ts", source, &helpers)
@@ -414,10 +423,9 @@ export async function GET(request: Request) {
         "missing unsupported_dynamic_control_flow reason: {proof:#?}"
     );
     assert!(
-        proof
-            .parser_gaps
-            .iter()
-            .any(|gap| gap.code == "unsupported_dynamic_control_flow" && gap.blocks_enforcement),
+        proof.parser_gaps.iter().any(|gap| gap.code
+            == SecurityParserGapCode::UnsupportedDynamicControlFlow
+            && gap.blocks_enforcement),
         "missing parser gap: {proof:#?}"
     );
     assert_eq!(proof.result.proof_status, SecurityProofStatus::ParserGap);
@@ -523,11 +531,9 @@ export async function GET() {
         "dynamic matcher should not prove coverage: {proof:#?}"
     );
     assert!(
-        proof
-            .parser_gaps
-            .iter()
-            .any(|gap| gap.code == "unsupported_dynamic_middleware_matcher"
-                && gap.blocks_enforcement),
+        proof.parser_gaps.iter().any(|gap| gap.code
+            == SecurityParserGapCode::UnsupportedDynamicMiddlewareMatcher
+            && gap.blocks_enforcement),
         "missing dynamic middleware parser gap: {proof:#?}"
     );
     assert_eq!(proof.result.proof_status, SecurityProofStatus::ParserGap);
@@ -734,7 +740,8 @@ export async function POST(request: Request) {
 
     assert_eq!(proof.result.proof_status, SecurityProofStatus::ParserGap);
     assert!(proof.parser_gaps.iter().any(|gap| {
-        gap.code == "unsupported_request_input_destructure" && gap.blocks_enforcement
+        gap.code == SecurityParserGapCode::UnsupportedRequestInputDestructure
+            && gap.blocks_enforcement
     }));
 }
 
@@ -763,7 +770,8 @@ export async function POST(request: Request) {
 
     assert!(
         proof.parser_gaps.iter().any(|gap| {
-            gap.code == "unsupported_request_input_spread" && gap.blocks_enforcement
+            gap.code == SecurityParserGapCode::UnsupportedRequestInputSpread
+                && gap.blocks_enforcement
         }),
         "missing unsupported request input spread parser gap: {proof:#?}"
     );

--- a/crates/drift-engine/tests/security_phase6.rs
+++ b/crates/drift-engine/tests/security_phase6.rs
@@ -2,11 +2,12 @@ use drift_engine::{
     AcceptedOutboundUrlHelper, AcceptedSecurityHelper, Phase6AcceptedHelper, Phase6CorsContract,
     Phase6RawSqlContract, Phase6SecurityContract, Phase6SecurityProof, Phase6SsrfContract,
     Phase6UrlSource, SecurityContractCapability, SecurityCorsContract, SecurityCsrfContract,
-    SecurityEnforcementMode, SecurityFindingResult, SecurityProofStatus, SecurityRateLimitContract,
-    SecurityRawSqlContract, SecuritySsrfContract, build_phase6_security_proof,
-    evaluate_api_route_cors_must_match_policy, evaluate_api_route_forbids_raw_sql_without_params,
-    evaluate_api_route_forbids_untrusted_ssrf, evaluate_api_route_requires_csrf_for_mutation,
-    evaluate_api_route_requires_rate_limit, phase6_proof_to_json,
+    SecurityEnforcementMode, SecurityFindingResult, SecurityParserGapCode, SecurityProofStatus,
+    SecurityRateLimitContract, SecurityRawSqlContract, SecuritySsrfContract,
+    build_phase6_security_proof, evaluate_api_route_cors_must_match_policy,
+    evaluate_api_route_forbids_raw_sql_without_params, evaluate_api_route_forbids_untrusted_ssrf,
+    evaluate_api_route_requires_csrf_for_mutation, evaluate_api_route_requires_rate_limit,
+    phase6_proof_to_json,
 };
 
 #[test]
@@ -299,7 +300,7 @@ export async function GET(request: Request) {
     assert_eq!(proof.result.proof_status, SecurityProofStatus::ParserGap);
     assert_eq!(
         proof.parser_gaps[0].code,
-        "unsupported_dynamic_outbound_url"
+        SecurityParserGapCode::UnsupportedDynamicOutboundUrl
     );
     assert!(proof.parser_gaps[0].blocks_enforcement);
     assert_eq!(proof.ssrf.missing_proof[0].code, "request_controlled_url");
@@ -393,7 +394,10 @@ export async function GET(request: Request) {
     let proof = phase6_proof("app/api/public/route.ts", source, phase6_cors_contract());
 
     assert_eq!(proof.result.proof_status, SecurityProofStatus::ParserGap);
-    assert_eq!(proof.parser_gaps[0].code, "unsupported_dynamic_cors_origin");
+    assert_eq!(
+        proof.parser_gaps[0].code,
+        SecurityParserGapCode::UnsupportedDynamicCorsOrigin
+    );
 }
 
 #[test]

--- a/crates/drift-engine/tests/security_rules.rs
+++ b/crates/drift-engine/tests/security_rules.rs
@@ -6,7 +6,7 @@ use drift_engine::{
     RequestValidatorKind, ResponseSerializerPolicy, SecurityAuthContract,
     SecurityAuthorizationContract, SecurityContractCapability, SecurityEnforcementMode,
     SecurityFindingResult, SecurityMiddlewareContract, SecurityPhase5Contract, SecurityProofStatus,
-    SecurityRequestValidationContract, SecurityTenantScopeContract,
+    SecurityRequestValidationContract, SecurityTenantScopeContract, TenantMissingReason,
     build_phase4_security_proof_with_policy, build_request_validation_proof,
     build_response_shape_proof, build_secret_exposure_proof,
     evaluate_api_route_forbids_secret_exposure,
@@ -696,7 +696,7 @@ export async function GET(request: Request) {
             .tenant
             .missing
             .iter()
-            .any(|missing| missing.reason == "tenant_source_untrusted"),
+            .any(|missing| missing.reason == TenantMissingReason::TenantSourceUntrusted),
         "tenant missing proof must include tenant_source_untrusted: {proof:#?}"
     );
 }
@@ -1074,7 +1074,7 @@ export async function GET(request: Request) {
             .tenant
             .missing
             .iter()
-            .any(|missing| missing.reason == "tenant_source_untrusted"),
+            .any(|missing| missing.reason == TenantMissingReason::TenantSourceUntrusted),
         "candidate tenant evidence must remain missing proof, not deterministic proof: {proof:#?}"
     );
 }

--- a/crates/drift-engine/tests/security_rules.rs
+++ b/crates/drift-engine/tests/security_rules.rs
@@ -2,12 +2,13 @@ use drift_engine::{
     AcceptedAuthHelper, AcceptedAuthorizationHelper, AcceptedPhase5Contract,
     AcceptedRequestValidator, AcceptedResponseSerializer, AcceptedSensitiveResponseField,
     AcceptedTenantHelper, AuthGuardBehavior, AuthorizationHelperBehavior, AuthorizationHelperKind,
-    Phase4SecurityPolicy, RequestValidatorBehavior, RequestValidatorKind, ResponseSerializerPolicy,
-    SecurityAuthContract, SecurityAuthorizationContract, SecurityContractCapability,
-    SecurityEnforcementMode, SecurityFindingResult, SecurityMiddlewareContract,
-    SecurityPhase5Contract, SecurityProofStatus, SecurityRequestValidationContract,
-    SecurityTenantScopeContract, build_phase4_security_proof_with_policy,
-    build_request_validation_proof, build_response_shape_proof, build_secret_exposure_proof,
+    AuthorizationMissingReason, Phase4SecurityPolicy, RequestValidatorBehavior,
+    RequestValidatorKind, ResponseSerializerPolicy, SecurityAuthContract,
+    SecurityAuthorizationContract, SecurityContractCapability, SecurityEnforcementMode,
+    SecurityFindingResult, SecurityMiddlewareContract, SecurityPhase5Contract, SecurityProofStatus,
+    SecurityRequestValidationContract, SecurityTenantScopeContract,
+    build_phase4_security_proof_with_policy, build_request_validation_proof,
+    build_response_shape_proof, build_secret_exposure_proof,
     evaluate_api_route_forbids_secret_exposure,
     evaluate_api_route_forbids_sensitive_response_fields, evaluate_api_route_requires_auth_helper,
     evaluate_api_route_requires_auth_helper_with_middleware,
@@ -683,7 +684,7 @@ export async function GET(request: Request) {
             .authorization
             .missing
             .iter()
-            .any(|missing| missing.reason == "session_not_trusted"),
+            .any(|missing| missing.reason == AuthorizationMissingReason::SessionNotTrusted),
         "authorization missing proof must include session_not_trusted: {proof:#?}"
     );
     assert!(

--- a/crates/drift-engine/tests/security_rules.rs
+++ b/crates/drift-engine/tests/security_rules.rs
@@ -5,10 +5,10 @@ use drift_engine::{
     AuthorizationMissingReason, Phase4SecurityPolicy, RequestValidatorBehavior,
     RequestValidatorKind, ResponseSerializerPolicy, SecurityAuthContract,
     SecurityAuthorizationContract, SecurityContractCapability, SecurityEnforcementMode,
-    SecurityFindingResult, SecurityMiddlewareContract, SecurityPhase5Contract, SecurityProofStatus,
-    SecurityRequestValidationContract, SecurityTenantScopeContract, TenantMissingReason,
-    build_phase4_security_proof_with_policy, build_request_validation_proof,
-    build_response_shape_proof, build_secret_exposure_proof,
+    SecurityFindingResult, SecurityMiddlewareContract, SecurityParserGapCode,
+    SecurityPhase5Contract, SecurityProofStatus, SecurityRequestValidationContract,
+    SecurityTenantScopeContract, TenantMissingReason, build_phase4_security_proof_with_policy,
+    build_request_validation_proof, build_response_shape_proof, build_secret_exposure_proof,
     evaluate_api_route_forbids_secret_exposure,
     evaluate_api_route_forbids_sensitive_response_fields, evaluate_api_route_requires_auth_helper,
     evaluate_api_route_requires_auth_helper_with_middleware,
@@ -209,7 +209,7 @@ export async function GET() {
         proof
             .parser_gaps
             .iter()
-            .any(|gap| gap.code == "unsupported_destructuring_or_spread"),
+            .any(|gap| gap.code == SecurityParserGapCode::UnsupportedDestructuringOrSpread),
         "{proof:#?}"
     );
 }

--- a/packages/core/src/security.ts
+++ b/packages/core/src/security.ts
@@ -76,7 +76,7 @@ export const SecurityParserGapCodeSchema = z.enum([
 // The kinds that carry a security boundary proof, from the one convention vocabulary. This list,
 // the identical one in @drift/engine-contract, and EXPERIMENTAL_SECURITY_CONVENTION_KINDS all claim
 // to be the same set; the third had twelve entries to these thirteen.
-import { SecurityContractKindSchema } from "@drift/vocabulary";
+import { SecurityContractKindSchema, SessionTrustReasonSchema } from "@drift/vocabulary";
 
 const Phase5SensitiveFieldSchema = z.object({
   field_path: z.string().min(1),
@@ -320,7 +320,9 @@ const SecuritySessionTrustProofSchema = z.object({
   missing_trust: z.array(z.object({
     fact_id: z.string().min(1),
     variable: z.string().min(1),
-    reason: z.enum(["derived_from_request", "unknown_helper", "missing_auth_guard", "parser_gap"])
+    // PROOF-level, from the one session_trust_reason vocabulary. This was a fourth
+    // hand-written copy of a list the engine emitted a non-member of (S1-01).
+    reason: SessionTrustReasonSchema
   }))
 });
 

--- a/packages/core/src/security.ts
+++ b/packages/core/src/security.ts
@@ -80,7 +80,8 @@ import {
   AuthorizationMissingReasonSchema,
   SecurityContractKindSchema,
   SessionTrustReasonSchema,
-  TenantMissingReasonSchema
+  TenantMissingReasonSchema,
+  UndominatedSinkReasonSchema
 } from "@drift/vocabulary";
 
 const Phase5SensitiveFieldSchema = z.object({
@@ -255,13 +256,10 @@ const SecurityAuthProofSchema = z.object({
   undominated_sinks: z.array(z.object({
     sink_id: z.string().min(1),
     sink_kind: z.string().min(1),
-    reason: z.enum([
-      "guard_after_sink",
-      "guard_only_in_one_branch",
-      "callback_boundary",
-      "unsupported_dynamic_control_flow",
-      "no_guard_call"
-    ]),
+    // PROOF-level, from the one undominated_sink_reason vocabulary. Two producers:
+    // security_proof.rs for the straight-line and dynamic cases, security_control_flow.rs
+    // for the path-sensitive ones.
+    reason: UndominatedSinkReasonSchema,
     fact_ids: z.array(z.string().min(1))
   }))
 });

--- a/packages/core/src/security.ts
+++ b/packages/core/src/security.ts
@@ -78,6 +78,8 @@ export const SecurityParserGapCodeSchema = z.enum([
 // to be the same set; the third had twelve entries to these thirteen.
 import {
   AuthorizationMissingReasonSchema,
+  MiddlewareMismatchReasonSchema,
+  RequestUnvalidatedReasonSchema,
   SecurityContractKindSchema,
   SessionTrustReasonSchema,
   TenantMissingReasonSchema,
@@ -275,7 +277,8 @@ const SecurityMiddlewareProofSchema = z.object({
   })),
   mismatches: z.array(z.object({
     middleware_id: z.string().min(1).optional(),
-    reason: z.enum(["path_not_matched", "method_not_matched", "dynamic_matcher", "unknown_framework"]),
+    // PROOF-level, from the one middleware_mismatch_reason vocabulary.
+    reason: MiddlewareMismatchReasonSchema,
     parser_gap_id: z.string().min(1).optional()
   }))
 });
@@ -307,7 +310,8 @@ const SecurityRequestValidationProofSchema = z.object({
     input_fact_id: z.string().min(1),
     sink_fact_id: z.string().min(1),
     sink_kind: z.enum(["data_operation", "response", "outbound_request", "raw_sql"]),
-    reason: z.enum(["request_input_not_validated", "validation_result_not_used", "unknown_validator"])
+    // PROOF-level, from the one request_unvalidated_reason vocabulary.
+    reason: RequestUnvalidatedReasonSchema
   }))
 });
 

--- a/packages/core/src/security.ts
+++ b/packages/core/src/security.ts
@@ -19,59 +19,30 @@ import { z } from "zod";
 export { SecurityCapabilityNameSchema } from "@drift/vocabulary";
 export type { SecurityCapabilityName } from "@drift/vocabulary";
 
-export const SecurityMissingProofCodeSchema = z.enum([
-  "missing_auth_guard",
-  "auth_guard_not_dominating_sink",
-  "middleware_not_covering_route",
-  "middleware_dynamic_matcher",
-  "request_input_not_validated",
-  "validation_result_not_used",
-  "unknown_validator",
-  "request_controlled_url",
-  "raw_sql_unparameterized",
-  "wildcard_origin_with_credentials",
-  "disallowed_origin",
-  "credentials_not_allowed",
-  "unsupported_dynamic_outbound_url",
-  "unsupported_dynamic_cors_origin",
-  "missing_csrf_guard",
-  "csrf_guard_not_dominating_sink",
-  "missing_rate_limit_guard",
-  "rate_limit_guard_not_dominating_sink",
-  "sensitive_response_field_unfiltered",
-  "dynamic_response_shape_missing_proof",
-  "secret_exposure_not_excluded",
-  "session_not_trusted",
-  "authorization_guard_missing",
-  "authorization_guard_not_dominating_sink",
-  "tenant_predicate_missing",
-  "tenant_source_untrusted",
-  "tenant_predicate_not_bound_to_query",
-  "unsupported_callback_boundary",
-  "unsupported_dynamic_control_flow",
-  "route_binding_unresolved",
-  "handler_unresolved"
-  ,// T-17: a code this build does not recognise, normalized at the engine parse boundary.
-  // Never readable as "proof satisfied" - not knowing why a proof failed is a refusal.
-  "unknown_reason_code"
-]);
+/**
+ * The FINDING-level codes, from the one security_missing_proof_code vocabulary.
+ *
+ * This was thirty-two members written out here and again, byte for byte, in
+ * @drift/engine-contract. Neither copy was reachable from the other, and the parity gate
+ * could not see the duplication: rule 2 catches a list that is a PROPER SUBSET of a
+ * vocabulary, and two identical full-size copies are not subsets of anything.
+ *
+ * `unknown_reason_code` is a member and is NOT an engine-emittable code. It is what the
+ * engine-contract parse boundary normalizes an unrecognized code to (T-17), so an engine
+ * newer than its CLI degrades the convention that produced it rather than failing the run.
+ * Never readable as "proof satisfied" - not knowing why a proof failed is a refusal.
+ */
+export { SecurityMissingProofCodeSchema };
 
-export const SecurityParserGapCodeSchema = z.enum([
-  "route_binding_unresolved",
-  "handler_unresolved",
-  "unsupported_dynamic_control_flow",
-  "unsupported_dynamic_middleware_matcher",
-  "unsupported_request_input_spread",
-  "unsupported_request_input_destructure",
-  "unsupported_dynamic_outbound_url",
-  "unsupported_dynamic_cors_origin",
-  "dynamic_response_shape",
-  "unsupported_destructuring_or_spread",
-  "unsupported_tenant_dynamic_property",
-  "unsupported_tenant_query_object_alias",
-  "unsupported_session_nested_destructure",
-  "unsupported_callback_boundary"
-]);
+/**
+ * The SECURITY parser gap codes, from the one security_parser_gap_code vocabulary.
+ *
+ * Not the same vocabulary as `parser_gap_kind`, despite the name. That one is the repo-wide
+ * taxonomy of why a REGION could not be understood; this one is the set of specific
+ * constructs a security proof gives up on. The lists are disjoint and the collision is in
+ * the English words, not the concept.
+ */
+export { SecurityParserGapCodeSchema };
 
 // The kinds that carry a security boundary proof, from the one convention vocabulary. This list,
 // the identical one in @drift/engine-contract, and EXPERIMENTAL_SECURITY_CONVENTION_KINDS all claim
@@ -80,6 +51,8 @@ import {
   AuthorizationMissingReasonSchema,
   MiddlewareMismatchReasonSchema,
   RequestUnvalidatedReasonSchema,
+  SecurityMissingProofCodeSchema,
+  SecurityParserGapCodeSchema,
   SecurityContractKindSchema,
   SessionTrustReasonSchema,
   TenantMissingReasonSchema,

--- a/packages/core/src/security.ts
+++ b/packages/core/src/security.ts
@@ -79,7 +79,8 @@ export const SecurityParserGapCodeSchema = z.enum([
 import {
   AuthorizationMissingReasonSchema,
   SecurityContractKindSchema,
-  SessionTrustReasonSchema
+  SessionTrustReasonSchema,
+  TenantMissingReasonSchema
 } from "@drift/vocabulary";
 
 const Phase5SensitiveFieldSchema = z.object({
@@ -367,7 +368,10 @@ const SecurityTenantProofSchema = z.object({
   })),
   missing: z.array(z.object({
     data_operation_fact_id: z.string().min(1),
-    reason: z.enum(["no_tenant_predicate", "untrusted_tenant_source", "predicate_not_bound_to_query", "parser_gap", "tenant_predicate_missing", "tenant_source_untrusted", "tenant_predicate_not_bound_to_query"])
+    // PROOF-level, from the one tenant_missing_reason vocabulary. Widened the same way
+    // authorization_missing_reason was: three design-doc spellings, three engine
+    // spellings, and a parser_gap member with no producer at all.
+    reason: TenantMissingReasonSchema
   }))
 });
 

--- a/packages/core/src/security.ts
+++ b/packages/core/src/security.ts
@@ -76,7 +76,11 @@ export const SecurityParserGapCodeSchema = z.enum([
 // The kinds that carry a security boundary proof, from the one convention vocabulary. This list,
 // the identical one in @drift/engine-contract, and EXPERIMENTAL_SECURITY_CONVENTION_KINDS all claim
 // to be the same set; the third had twelve entries to these thirteen.
-import { SecurityContractKindSchema, SessionTrustReasonSchema } from "@drift/vocabulary";
+import {
+  AuthorizationMissingReasonSchema,
+  SecurityContractKindSchema,
+  SessionTrustReasonSchema
+} from "@drift/vocabulary";
 
 const Phase5SensitiveFieldSchema = z.object({
   field_path: z.string().min(1),
@@ -338,7 +342,10 @@ const SecurityAuthorizationProofSchema = z.object({
     subject_var: z.string().min(1).optional()
   })),
   missing: z.array(z.object({
-    reason: z.enum(["no_authorization_guard", "guard_not_dominating_sink", "unknown_policy_helper", "session_not_trusted", "authorization_guard_missing", "authorization_guard_not_dominating_sink"]),
+    // PROOF-level, from the one authorization_missing_reason vocabulary. Two spellings of
+    // three concepts, because this enum was widened rather than migrated; only the newer
+    // one has a producer, and the older one is held for stored rows.
+    reason: AuthorizationMissingReasonSchema,
     sink_fact_id: z.string().min(1).optional()
   }))
 });

--- a/packages/engine-contract/src/index.ts
+++ b/packages/engine-contract/src/index.ts
@@ -6,7 +6,8 @@ import {
   SecurityCapabilityNameSchema,
   SecurityContractKindSchema,
   SessionTrustReasonSchema,
-  TenantMissingReasonSchema
+  TenantMissingReasonSchema,
+  UndominatedSinkReasonSchema
 } from "@drift/vocabulary";
 import {
   GraphEdgeSchema,
@@ -827,13 +828,8 @@ const EngineSecurityBoundaryProofSchema = z.object({
     undominated_sinks: z.array(z.object({
       sink_id: z.string().min(1),
       sink_kind: z.string().min(1),
-      reason: z.enum([
-        "guard_after_sink",
-        "guard_only_in_one_branch",
-        "callback_boundary",
-        "unsupported_dynamic_control_flow",
-        "no_guard_call"
-      ]),
+      // PROOF-level, from the one undominated_sink_reason vocabulary.
+      reason: UndominatedSinkReasonSchema,
       fact_ids: z.array(z.string().min(1))
     }))
   }),

--- a/packages/engine-contract/src/index.ts
+++ b/packages/engine-contract/src/index.ts
@@ -3,6 +3,8 @@ import {
   AuthorizationMissingReasonSchema,
   CandidateConventionKindSchema,
   FactKindSchema,
+  MiddlewareMismatchReasonSchema,
+  RequestUnvalidatedReasonSchema,
   SecurityCapabilityNameSchema,
   SecurityContractKindSchema,
   SessionTrustReasonSchema,
@@ -844,7 +846,8 @@ const EngineSecurityBoundaryProofSchema = z.object({
     })),
     mismatches: z.array(z.object({
       middleware_id: z.string().min(1).optional(),
-      reason: z.enum(["path_not_matched", "method_not_matched", "dynamic_matcher", "unknown_framework"]),
+      // PROOF-level, from the one middleware_mismatch_reason vocabulary.
+      reason: MiddlewareMismatchReasonSchema,
       parser_gap_id: z.string().min(1).optional()
     }))
   }).optional().default({
@@ -880,7 +883,8 @@ const EngineSecurityBoundaryProofSchema = z.object({
       input_fact_id: z.string().min(1),
       sink_fact_id: z.string().min(1),
       sink_kind: z.enum(["data_operation", "response", "outbound_request", "raw_sql"]),
-      reason: z.enum(["request_input_not_validated", "validation_result_not_used", "unknown_validator"])
+      // PROOF-level, from the one request_unvalidated_reason vocabulary.
+      reason: RequestUnvalidatedReasonSchema
     }))
   }).optional().default({
     required: false,

--- a/packages/engine-contract/src/index.ts
+++ b/packages/engine-contract/src/index.ts
@@ -1,5 +1,6 @@
 import { z } from "zod";
 import {
+  AuthorizationMissingReasonSchema,
   CandidateConventionKindSchema,
   FactKindSchema,
   SecurityCapabilityNameSchema,
@@ -982,7 +983,8 @@ const EngineSecurityBoundaryProofSchema = z.object({
       subject_var: z.string().min(1).optional()
     })),
     missing: z.array(z.object({
-      reason: z.enum(["no_authorization_guard", "guard_not_dominating_sink", "unknown_policy_helper", "session_not_trusted", "authorization_guard_missing", "authorization_guard_not_dominating_sink"]),
+      // PROOF-level, from the one authorization_missing_reason vocabulary.
+      reason: AuthorizationMissingReasonSchema,
       sink_fact_id: z.string().min(1).optional()
     }))
   }).optional().default({

--- a/packages/engine-contract/src/index.ts
+++ b/packages/engine-contract/src/index.ts
@@ -3,7 +3,8 @@ import {
   CandidateConventionKindSchema,
   FactKindSchema,
   SecurityCapabilityNameSchema,
-  SecurityContractKindSchema
+  SecurityContractKindSchema,
+  SessionTrustReasonSchema
 } from "@drift/vocabulary";
 import {
   GraphEdgeSchema,
@@ -959,7 +960,9 @@ const EngineSecurityBoundaryProofSchema = z.object({
     missing_trust: z.array(z.object({
       fact_id: z.string().min(1),
       variable: z.string().min(1),
-      reason: z.enum(["derived_from_request", "unknown_helper", "missing_auth_guard", "parser_gap"])
+      // PROOF-level, from the one session_trust_reason vocabulary. This was a fourth
+      // hand-written copy of a list the engine emitted a non-member of (S1-01).
+      reason: SessionTrustReasonSchema
     }))
   }).optional().default({
     required: false,

--- a/packages/engine-contract/src/index.ts
+++ b/packages/engine-contract/src/index.ts
@@ -5,6 +5,8 @@ import {
   FactKindSchema,
   MiddlewareMismatchReasonSchema,
   RequestUnvalidatedReasonSchema,
+  SecurityMissingProofCodeSchema,
+  SecurityParserGapCodeSchema,
   SecurityCapabilityNameSchema,
   SecurityContractKindSchema,
   SessionTrustReasonSchema,
@@ -605,40 +607,10 @@ export const EngineFindingSchema = z.object({
  * the convention that produced it instead of the entire run. Never to a pass: an unknown code
  * means Drift does not understand why the proof failed, which is a refusal.
  */
-const EngineSecurityKnownMissingProofCodeSchema = z.enum([
-  "missing_auth_guard",
-  "auth_guard_not_dominating_sink",
-  "middleware_not_covering_route",
-  "middleware_dynamic_matcher",
-  "request_input_not_validated",
-  "validation_result_not_used",
-  "unknown_validator",
-  "request_controlled_url",
-  "raw_sql_unparameterized",
-  "wildcard_origin_with_credentials",
-  "disallowed_origin",
-  "credentials_not_allowed",
-  "unsupported_dynamic_outbound_url",
-  "unsupported_dynamic_cors_origin",
-  "missing_csrf_guard",
-  "csrf_guard_not_dominating_sink",
-  "missing_rate_limit_guard",
-  "rate_limit_guard_not_dominating_sink",
-  "sensitive_response_field_unfiltered",
-  "dynamic_response_shape_missing_proof",
-  "secret_exposure_not_excluded",
-  "session_not_trusted",
-  "authorization_guard_missing",
-  "authorization_guard_not_dominating_sink",
-  "tenant_predicate_missing",
-  "tenant_source_untrusted",
-  "tenant_predicate_not_bound_to_query",
-  "unsupported_callback_boundary",
-  "unsupported_dynamic_control_flow",
-  "route_binding_unresolved",
-  "handler_unresolved"
-  ,"unknown_reason_code"
-]);
+// The known finding-level codes, from the one security_missing_proof_code vocabulary. This
+// was a byte-identical copy of the list in @drift/core; the preprocess below is the part
+// that is genuinely engine-contract's, and it survives unchanged.
+const EngineSecurityKnownMissingProofCodeSchema = SecurityMissingProofCodeSchema;
 
 /**
  * A known code, or any other non-empty string. Unknown codes survive parsing so the surrounding
@@ -664,22 +636,9 @@ const EngineSecurityContractKindSchema = SecurityContractKindSchema;
 const EngineSecurityParserGapSchema = z.object({
   parser_gap_id: z.string().min(1),
   capability: z.string().min(1),
-  code: z.enum([
-    "route_binding_unresolved",
-    "handler_unresolved",
-    "unsupported_dynamic_control_flow",
-    "unsupported_dynamic_middleware_matcher",
-    "unsupported_request_input_spread",
-    "unsupported_request_input_destructure",
-    "unsupported_dynamic_outbound_url",
-    "unsupported_dynamic_cors_origin",
-    "dynamic_response_shape",
-    "unsupported_destructuring_or_spread",
-    "unsupported_tenant_dynamic_property",
-    "unsupported_tenant_query_object_alias",
-    "unsupported_session_nested_destructure",
-    "unsupported_callback_boundary"
-  ]),
+  // The SECURITY parser gap codes, from the one security_parser_gap_code vocabulary.
+  // Deliberately NOT merged with parser_gap_kind - disjoint concepts, coincidental name.
+  code: SecurityParserGapCodeSchema,
   file_path: z.string().min(1),
   start_line: z.number().int().positive().optional(),
   end_line: z.number().int().positive().optional(),

--- a/packages/engine-contract/src/index.ts
+++ b/packages/engine-contract/src/index.ts
@@ -5,7 +5,8 @@ import {
   FactKindSchema,
   SecurityCapabilityNameSchema,
   SecurityContractKindSchema,
-  SessionTrustReasonSchema
+  SessionTrustReasonSchema,
+  TenantMissingReasonSchema
 } from "@drift/vocabulary";
 import {
   GraphEdgeSchema,
@@ -1010,7 +1011,8 @@ const EngineSecurityBoundaryProofSchema = z.object({
     })),
     missing: z.array(z.object({
       data_operation_fact_id: z.string().min(1),
-      reason: z.enum(["no_tenant_predicate", "untrusted_tenant_source", "predicate_not_bound_to_query", "parser_gap", "tenant_predicate_missing", "tenant_source_untrusted", "tenant_predicate_not_bound_to_query"])
+      // PROOF-level, from the one tenant_missing_reason vocabulary.
+      reason: TenantMissingReasonSchema
     }))
   }).optional().default({
     required: false,

--- a/packages/vocabulary/src/index.ts
+++ b/packages/vocabulary/src/index.ts
@@ -537,3 +537,73 @@ export const REQUEST_UNVALIDATED_REASONS = [
 export const RequestUnvalidatedReasonSchema = z.enum(REQUEST_UNVALIDATED_REASONS);
 
 export type RequestUnvalidatedReason = (typeof REQUEST_UNVALIDATED_REASONS)[number];
+
+/**
+ * The FINDING-level code a user reads: why this proof could not be completed. Distinct from every PROOF-level reason vocabulary above, which say why a particular sub-proof failed; the proof-level reasons are mapped onto these codes by phase4_missing_code and missing_proof_code, and the two sets deliberately do not match.
+ *
+ * DELIBERATELY TYPESCRIPT-ONLY: there is no rust_enum, and adding one would be wrong. `unknown_reason_code` is not an engine-emittable code at all - it is what the engine-contract parse boundary NORMALIZES an unrecognized code to, so that an engine newer than its CLI degrades the one convention that produced it instead of failing the whole run. Giving Rust a variant for it would make the engine able to emit "this build does not recognise the code" about its own output, which inverts the meaning. The engine builds these codes from several places - security_phase6.rs, security_proof.rs, check_command.rs - by mapping proof-level reasons, and those reason vocabularies ARE typed, which is where the compile-time guarantee belongs.
+ */
+export const SECURITY_MISSING_PROOF_CODES = [
+  "missing_auth_guard",
+  "auth_guard_not_dominating_sink",
+  "middleware_not_covering_route",
+  "middleware_dynamic_matcher",
+  "request_input_not_validated",
+  "validation_result_not_used",
+  "unknown_validator",
+  "request_controlled_url",
+  "raw_sql_unparameterized",
+  "wildcard_origin_with_credentials",
+  "disallowed_origin",
+  "credentials_not_allowed",
+  "unsupported_dynamic_outbound_url",
+  "unsupported_dynamic_cors_origin",
+  "missing_csrf_guard",
+  "csrf_guard_not_dominating_sink",
+  "missing_rate_limit_guard",
+  "rate_limit_guard_not_dominating_sink",
+  "sensitive_response_field_unfiltered",
+  "dynamic_response_shape_missing_proof",
+  "secret_exposure_not_excluded",
+  "session_not_trusted",
+  "authorization_guard_missing",
+  "authorization_guard_not_dominating_sink",
+  "tenant_predicate_missing",
+  "tenant_source_untrusted",
+  "tenant_predicate_not_bound_to_query",
+  "unsupported_callback_boundary",
+  "unsupported_dynamic_control_flow",
+  "route_binding_unresolved",
+  "handler_unresolved",
+  "unknown_reason_code",
+] as const;
+
+export const SecurityMissingProofCodeSchema = z.enum(SECURITY_MISSING_PROOF_CODES);
+
+export type SecurityMissingProofCode = (typeof SECURITY_MISSING_PROOF_CODES)[number];
+
+/**
+ * Why a SECURITY proof could not be completed because a construct could not be analysed. Carried on `parser_gaps[].code` inside a security boundary proof, and produced by build_phase4_security_proof, the phase5/phase6 builders and phase4_parser_gap.
+ *
+ * NOT the same vocabulary as `parser_gap_kind`, despite the name. That one is the repo-wide taxonomy of why a REGION of the repo could not be understood - unresolved_import, parser_error, partial_parse - derived CLI-side from engine diagnostic codes and named by the semantic capability contracts. This one is the set of specific TypeScript constructs a security proof gives up on. The two lists are disjoint and the collision is in the English word `parser gap`, not in the concept; merging them would put `unresolved_import` where a security proof expects `unsupported_request_input_spread`.
+ */
+export const SECURITY_PARSER_GAP_CODES = [
+  "route_binding_unresolved",
+  "handler_unresolved",
+  "unsupported_dynamic_control_flow",
+  "unsupported_dynamic_middleware_matcher",
+  "unsupported_request_input_spread",
+  "unsupported_request_input_destructure",
+  "unsupported_dynamic_outbound_url",
+  "unsupported_dynamic_cors_origin",
+  "dynamic_response_shape",
+  "unsupported_destructuring_or_spread",
+  "unsupported_tenant_dynamic_property",
+  "unsupported_tenant_query_object_alias",
+  "unsupported_session_nested_destructure",
+  "unsupported_callback_boundary",
+] as const;
+
+export const SecurityParserGapCodeSchema = z.enum(SECURITY_PARSER_GAP_CODES);
+
+export type SecurityParserGapCode = (typeof SECURITY_PARSER_GAP_CODES)[number];

--- a/packages/vocabulary/src/index.ts
+++ b/packages/vocabulary/src/index.ts
@@ -462,3 +462,19 @@ export const SESSION_TRUST_REASONS = [
 export const SessionTrustReasonSchema = z.enum(SESSION_TRUST_REASONS);
 
 export type SessionTrustReason = (typeof SESSION_TRUST_REASONS)[number];
+
+/**
+ * Why an authorization proof could not be completed. PROOF-LEVEL vocabulary, on `authorization.missing[].reason`. The list carries two spellings of the same three concepts - an older `no_authorization_guard`/`guard_not_dominating_sink` pair and the newer `authorization_guard_missing`/`authorization_guard_not_dominating_sink` - because the enum was WIDENED rather than migrated when the engine's wording changed. Only the newer spelling has a producer today; the older one is reserved, because the schema is applied on read and stored rows may still hold it.
+ */
+export const AUTHORIZATION_MISSING_REASONS = [
+  "no_authorization_guard",
+  "guard_not_dominating_sink",
+  "unknown_policy_helper",
+  "session_not_trusted",
+  "authorization_guard_missing",
+  "authorization_guard_not_dominating_sink",
+] as const;
+
+export const AuthorizationMissingReasonSchema = z.enum(AUTHORIZATION_MISSING_REASONS);
+
+export type AuthorizationMissingReason = (typeof AUTHORIZATION_MISSING_REASONS)[number];

--- a/packages/vocabulary/src/index.ts
+++ b/packages/vocabulary/src/index.ts
@@ -478,3 +478,20 @@ export const AUTHORIZATION_MISSING_REASONS = [
 export const AuthorizationMissingReasonSchema = z.enum(AUTHORIZATION_MISSING_REASONS);
 
 export type AuthorizationMissingReason = (typeof AUTHORIZATION_MISSING_REASONS)[number];
+
+/**
+ * Why a tenant-scope proof could not be completed. PROOF-LEVEL vocabulary, on `tenant.missing[].reason`. Widened the same way authorization_missing_reason was: the first three members are the spelling the original design named, the last three are the spelling the engine emits, and `parser_gap` is a fourth concept with no producer at all. Only the newer three are constructed; the rest are reserved rather than deleted, because the schema is applied on read.
+ */
+export const TENANT_MISSING_REASONS = [
+  "no_tenant_predicate",
+  "untrusted_tenant_source",
+  "predicate_not_bound_to_query",
+  "parser_gap",
+  "tenant_predicate_missing",
+  "tenant_source_untrusted",
+  "tenant_predicate_not_bound_to_query",
+] as const;
+
+export const TenantMissingReasonSchema = z.enum(TENANT_MISSING_REASONS);
+
+export type TenantMissingReason = (typeof TENANT_MISSING_REASONS)[number];

--- a/packages/vocabulary/src/index.ts
+++ b/packages/vocabulary/src/index.ts
@@ -495,3 +495,18 @@ export const TENANT_MISSING_REASONS = [
 export const TenantMissingReasonSchema = z.enum(TENANT_MISSING_REASONS);
 
 export type TenantMissingReason = (typeof TENANT_MISSING_REASONS)[number];
+
+/**
+ * Why an auth guard does not dominate a sink. PROOF-LEVEL vocabulary, on `auth.undominated_sinks[].reason`. Unlike the other proof reason vocabularies this one has TWO producers: the straight-line and dynamic-control-flow cases are decided in security_proof.rs, and the path-sensitive ones - a guard in only one branch, a guard behind a callback boundary - in security_control_flow.rs. Every member is produced.
+ */
+export const UNDOMINATED_SINK_REASONS = [
+  "guard_after_sink",
+  "guard_only_in_one_branch",
+  "callback_boundary",
+  "unsupported_dynamic_control_flow",
+  "no_guard_call",
+] as const;
+
+export const UndominatedSinkReasonSchema = z.enum(UNDOMINATED_SINK_REASONS);
+
+export type UndominatedSinkReason = (typeof UNDOMINATED_SINK_REASONS)[number];

--- a/packages/vocabulary/src/index.ts
+++ b/packages/vocabulary/src/index.ts
@@ -510,3 +510,30 @@ export const UNDOMINATED_SINK_REASONS = [
 export const UndominatedSinkReasonSchema = z.enum(UNDOMINATED_SINK_REASONS);
 
 export type UndominatedSinkReason = (typeof UNDOMINATED_SINK_REASONS)[number];
+
+/**
+ * Why a middleware does not cover a route. PROOF-LEVEL vocabulary, on `middleware.mismatches[].reason`, produced by static_middleware_coverage in security_control_flow.rs. `dynamic_matcher` has no producer: a dynamic matcher is reported as a parser gap and drives proof_status == ParserGap rather than as a coverage mismatch, so the mismatch spelling of it was declared and never built.
+ */
+export const MIDDLEWARE_MISMATCH_REASONS = [
+  "path_not_matched",
+  "method_not_matched",
+  "dynamic_matcher",
+  "unknown_framework",
+] as const;
+
+export const MiddlewareMismatchReasonSchema = z.enum(MIDDLEWARE_MISMATCH_REASONS);
+
+export type MiddlewareMismatchReason = (typeof MIDDLEWARE_MISMATCH_REASONS)[number];
+
+/**
+ * Why a request input reaching a sink is not covered by a validation proof. PROOF-LEVEL vocabulary, on `request_validation.unvalidated_uses[].reason`. Every member is produced by request_unvalidated_uses in security_proof.rs, and all three are also members of the finding-level SecurityMissingProofCodeSchema, so the two vocabularies agree here and need no bridge.
+ */
+export const REQUEST_UNVALIDATED_REASONS = [
+  "request_input_not_validated",
+  "validation_result_not_used",
+  "unknown_validator",
+] as const;
+
+export const RequestUnvalidatedReasonSchema = z.enum(REQUEST_UNVALIDATED_REASONS);
+
+export type RequestUnvalidatedReason = (typeof REQUEST_UNVALIDATED_REASONS)[number];

--- a/packages/vocabulary/src/index.ts
+++ b/packages/vocabulary/src/index.ts
@@ -448,3 +448,17 @@ export const SECURITY_SCAN_CAPABILITIES = [
 export const SecurityCapabilityNameSchema = z.enum(SECURITY_SCAN_CAPABILITIES);
 
 export type SecurityCapabilityName = (typeof SECURITY_SCAN_CAPABILITIES)[number];
+
+/**
+ * Why a session object could not be proven trusted. PROOF-LEVEL vocabulary: it says why the proof failed. The FINDING-level code a user sees (SecurityMissingProofCodeSchema) is separate and is derived from this by the phase4 finding-reason mapping in check_command.rs. The two are deliberately different vocabularies; mapping between them must be total.
+ */
+export const SESSION_TRUST_REASONS = [
+  "derived_from_request",
+  "unknown_helper",
+  "missing_auth_guard",
+  "parser_gap",
+] as const;
+
+export const SessionTrustReasonSchema = z.enum(SESSION_TRUST_REASONS);
+
+export type SessionTrustReason = (typeof SESSION_TRUST_REASONS)[number];

--- a/scripts/stored-proof-census.mjs
+++ b/scripts/stored-proof-census.mjs
@@ -1,0 +1,282 @@
+#!/usr/bin/env node
+/**
+ * What is actually stored in the security proof reason/code fields, across every database this
+ * machine can reach.
+ *
+ * WHY THIS EXISTS, AND WHY IT RUNS BEFORE ANYTHING IS DELETED
+ *
+ * `packages/storage` parses `security_boundary_proofs.proof_json` and
+ * `security_boundary_proof_runs.proof_json` with `SecurityBoundaryProofSchema` ON READ. Those
+ * reason and code fields are closed `z.enum`s. Shrinking one of them does not fail at the next
+ * write - it fails at the next READ of a row that was written before the shrink, and it fails as a
+ * ZodError from `listSecurityBoundaryProofs`, which is to say the row becomes unreadable and the
+ * repo's stored history becomes unloadable. There is no migration path back once the enum has
+ * shipped narrower than the data.
+ *
+ * Several of these vocabularies were WIDENED at some point - `authorization.missing[].reason` and
+ * `tenant.missing[].reason` each carry two spellings of the same three concepts, an older set and a
+ * newer one. A producer audit run against today's engine will report the older spelling as dead,
+ * because today's engine does not emit it. That audit is correct about the producer and wrong about
+ * the consequence: rows written by the older engine are still on disk and are still parsed with
+ * today's schema.
+ *
+ * So: a member this census finds in a stored row is RESERVED, never deleted, whatever the producer
+ * audit says about it.
+ *
+ * WHAT IT DOES
+ *
+ * Walks every proof JSON blob and records the distinct string value at every path whose leaf key is
+ * `reason` or `code`, keyed by the path with array indices collapsed to `[]`. The walk is structural
+ * rather than a list of known field paths on purpose: the schema is what is under audit here, so
+ * enumerating it from the schema would inherit whatever the schema already gets wrong, and a field
+ * added later would silently escape the census.
+ *
+ * Free-text `reason` fields are in the output too - `parser_gaps[].reason` and the control-flow
+ * reasons are prose, not vocabulary. They are reported rather than filtered because deciding which
+ * paths are closed vocabularies is the judgement this census exists to inform, not a premise it
+ * gets to assume. Paths with many distinct long values read as prose at a glance.
+ *
+ * NO DATABASES IS NOT NO DATA. If nothing is reachable, this exits 1 and says so. An empty report
+ * that exits 0 would read as "nothing is stored, delete freely", which is the exact wrong answer
+ * and the reason this script is separate from the gates.
+ *
+ *   node scripts/stored-proof-census.mjs                  every ~/.drift/repos/<id>/drift.sqlite
+ *   node scripts/stored-proof-census.mjs --db PATH ...    those databases as well
+ *   node scripts/stored-proof-census.mjs --json           machine-readable, for diffing over time
+ */
+
+import { existsSync, readdirSync, statSync } from "node:fs";
+import { createRequire } from "node:module";
+import { homedir } from "node:os";
+import { join } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const repoRoot = fileURLToPath(new URL("..", import.meta.url));
+
+/**
+ * better-sqlite3 is a dependency of packages/storage, not of the repo root.
+ *
+ * Resolving it from there rather than adding a root dependency keeps the native module in exactly
+ * one place. A second copy would be a second version, and a second version of a native sqlite
+ * binding reading the same file is its own failure mode.
+ */
+function loadDatabase() {
+  const require = createRequire(join(repoRoot, "packages/storage/package.json"));
+  try {
+    return require("better-sqlite3");
+  } catch (error) {
+    console.error(
+      "stored-proof census: cannot load better-sqlite3 from packages/storage " +
+        `(${error instanceof Error ? error.message : String(error)}).\n` +
+        "Run `pnpm install` first. Without it this script cannot open a database, which is not the " +
+        "same as finding no rows - see the header."
+    );
+    process.exit(1);
+  }
+}
+
+/** The default state root the CLI uses when `--db` is not given: ~/.drift/repos/<id>/drift.sqlite. */
+function defaultDatabases() {
+  const root = join(homedir(), ".drift", "repos");
+  if (!existsSync(root)) {
+    return [];
+  }
+  const found = [];
+  for (const entry of readdirSync(root)) {
+    const path = join(root, entry, "drift.sqlite");
+    if (existsSync(path) && statSync(path).isFile()) {
+      found.push(path);
+    }
+  }
+  return found.sort();
+}
+
+function parseArgs(argv) {
+  const extra = [];
+  let json = false;
+  for (let index = 0; index < argv.length; index += 1) {
+    if (argv[index] === "--json") {
+      json = true;
+    } else if (argv[index] === "--db") {
+      const path = argv[index + 1];
+      if (!path) {
+        console.error("stored-proof census: --db needs a path.");
+        process.exit(1);
+      }
+      extra.push(path);
+      index += 1;
+    }
+  }
+  return { extra, json };
+}
+
+/**
+ * Every string at a path whose leaf key is `reason` or `code`, with array indices collapsed.
+ *
+ * `session_trust.missing_trust[3].reason` and `session_trust.missing_trust[7].reason` are the same
+ * field with two rows in it; keeping the index would produce one census entry per array element and
+ * bury the answer.
+ */
+function collectFields(value, path, into) {
+  if (Array.isArray(value)) {
+    for (const entry of value) {
+      collectFields(entry, `${path}[]`, into);
+    }
+    return;
+  }
+  if (value === null || typeof value !== "object") {
+    return;
+  }
+  for (const [key, child] of Object.entries(value)) {
+    const childPath = path ? `${path}.${key}` : key;
+    if ((key === "reason" || key === "code") && typeof child === "string") {
+      const bucket = into.get(childPath) ?? new Map();
+      bucket.set(child, (bucket.get(child) ?? 0) + 1);
+      into.set(childPath, bucket);
+      continue;
+    }
+    collectFields(child, childPath, into);
+  }
+}
+
+const PROOF_TABLES = ["security_boundary_proofs", "security_boundary_proof_runs"];
+
+function tableExists(db, table) {
+  return (
+    db
+      .prepare("SELECT name FROM sqlite_master WHERE type = 'table' AND name = ?")
+      .get(table) !== undefined
+  );
+}
+
+function censusOfDatabase(Database, path) {
+  const result = { path, rows: 0, tables: [], unreadable: [], fields: new Map() };
+  let db;
+  try {
+    db = new Database(path, { readonly: true, fileMustExist: true });
+  } catch (error) {
+    result.error = error instanceof Error ? error.message : String(error);
+    return result;
+  }
+  try {
+    for (const table of PROOF_TABLES) {
+      if (!tableExists(db, table)) {
+        continue;
+      }
+      result.tables.push(table);
+      for (const row of db.prepare(`SELECT proof_json FROM ${table}`).all()) {
+        result.rows += 1;
+        let parsed;
+        try {
+          parsed = JSON.parse(row.proof_json);
+        } catch {
+          // A blob that is not JSON is a corruption finding, not a census finding, but it must not
+          // be silently skipped: a row that cannot be read is a row whose members are unknown.
+          result.unreadable.push(table);
+          continue;
+        }
+        collectFields(parsed, "", result.fields);
+      }
+    }
+  } finally {
+    db.close();
+  }
+  return result;
+}
+
+function merge(into, from) {
+  for (const [path, values] of from) {
+    const bucket = into.get(path) ?? new Map();
+    for (const [value, count] of values) {
+      bucket.set(value, (bucket.get(value) ?? 0) + count);
+    }
+    into.set(path, bucket);
+  }
+}
+
+function main() {
+  const { extra, json } = parseArgs(process.argv.slice(2));
+  const databases = [...new Set([...defaultDatabases(), ...extra])];
+
+  if (databases.length === 0) {
+    console.error(
+      "stored-proof census: NO DATABASES REACHABLE.\n" +
+        "\n" +
+        "  Looked under ~/.drift/repos/<repo_id>/drift.sqlite and found none, and no --db was given.\n" +
+        "\n" +
+        "  This is NOT the same result as 'no proof rows store these members'. It is the absence of\n" +
+        "  evidence, and it must not be read as evidence of absence: a vocabulary member shrunk out\n" +
+        "  of the schema on the strength of an empty census bricks the read path for every row that\n" +
+        "  still holds it, on a machine this census never saw.\n" +
+        "\n" +
+        "  Run `drift scan` against any repo first, or pass --db PATH."
+    );
+    process.exit(1);
+  }
+
+  const Database = loadDatabase();
+  const perDatabase = databases.map((path) => censusOfDatabase(Database, path));
+  const combined = new Map();
+  let rows = 0;
+  let opened = 0;
+  const failures = [];
+  for (const entry of perDatabase) {
+    if (entry.error) {
+      failures.push(entry);
+      continue;
+    }
+    opened += 1;
+    rows += entry.rows;
+    merge(combined, entry.fields);
+  }
+
+  const paths = [...combined.keys()].sort();
+
+  if (json) {
+    console.log(
+      JSON.stringify(
+        {
+          databases_found: databases.length,
+          databases_opened: opened,
+          proof_rows: rows,
+          unopenable: failures.map((entry) => ({ path: entry.path, error: entry.error })),
+          fields: Object.fromEntries(
+            paths.map((path) => [
+              path,
+              Object.fromEntries([...combined.get(path)].sort(([left], [right]) => left.localeCompare(right)))
+            ])
+          )
+        },
+        null,
+        2
+      )
+    );
+    return;
+  }
+
+  console.log(
+    `stored-proof census: ${opened} of ${databases.length} database(s) opened, ${rows} proof row(s), ` +
+      `${paths.length} reason/code field path(s).`
+  );
+  for (const entry of failures) {
+    console.log(`  ! could not open ${entry.path}: ${entry.error}`);
+  }
+  if (rows === 0) {
+    console.log(
+      "\n  Databases opened, but they hold NO proof rows. Nothing here licenses shrinking an enum:\n" +
+        "  this machine has simply never run a security check that produced a proof."
+    );
+    return;
+  }
+  console.log("");
+  for (const path of paths) {
+    const values = [...combined.get(path)].sort((left, right) => right[1] - left[1] || left[0].localeCompare(right[0]));
+    console.log(`  ${path}  (${values.length} distinct)`);
+    for (const [value, count] of values) {
+      const shown = value.length > 100 ? `${value.slice(0, 97)}...` : value;
+      console.log(`      ${String(count).padStart(6)}  ${JSON.stringify(shown)}`);
+    }
+  }
+}
+
+main();

--- a/scripts/vocabulary-parity-baseline.json
+++ b/scripts/vocabulary-parity-baseline.json
@@ -135,6 +135,24 @@
       "member": "dynamic_matcher",
       "gap": "no_producer",
       "reason": "S2-03. Declared as a coverage mismatch and never built as one. `static_middleware_coverage` in security_control_flow.rs emits path_not_matched, method_not_matched and unknown_framework; a dynamic middleware matcher is handled somewhere else entirely - build_middleware_coverage_proof in security_proof.rs turns it into a SecurityParserGap with code `unsupported_dynamic_middleware_matcher`, which drives proof_status == ParserGap. So the concept is covered and this spelling of it is not, which is a real distinction rather than a gap: a parser gap says the matcher could not be analysed, and a mismatch would say it was analysed and does not cover the route. Answering the second when only the first is known would be a claim the engine cannot support. RETAINED because SecurityBoundaryProofSchema is applied ON READ and the stored-proof census cannot prove no row holds it. If a producer is ever added, it must be a case where the matcher IS understood and genuinely does not match."
+    },
+    {
+      "vocabulary": "security_missing_proof_code",
+      "member": "unsupported_callback_boundary",
+      "gap": "unreferenced",
+      "reason": "S2-03, and found BY generating this vocabulary rather than before it. The member existed only inside the two byte-identical hand-written copies of this list - one in @drift/core, one in @drift/engine-contract - and in docs/internal/architecture/security-boundary-enforcement-100-tdd.md:1012. Nothing in either language produces it and nothing reads it, which nothing could see while the only two places it appeared were copies of each other. The CONCEPT is handled: a guard behind a callback boundary produces the proof-level undominated_sink_reason `callback_boundary`, which missing_proof_code maps to `auth_guard_not_dominating_sink` - the honest answer, since a guard does exist and does not dominate the sink. So this finding-level code is a second, unused way of saying it. Retained rather than removed because SecurityBoundaryProofSchema is applied ON READ and the stored-proof census cannot prove no row holds it."
+    },
+    {
+      "vocabulary": "security_parser_gap_code",
+      "member": "unsupported_callback_boundary",
+      "gap": "unreferenced",
+      "reason": "S2-03, the parser-gap half of the same discovery, and the same shape: declared in both hand-written copies and in the design document, produced and consumed by nothing. A callback boundary is not a parser gap in this engine - it is analysed successfully and reported as a dominance failure - so a producer here would be claiming the construct could not be understood when it was. Retained for the stored-row reason."
+    },
+    {
+      "vocabulary": "security_parser_gap_code",
+      "member": "dynamic_response_shape",
+      "gap": "unreferenced",
+      "reason": "S2-03, found the same way. Declared in both hand-written copies and at docs/internal/architecture/security-boundary-enforcement-100-tdd.md:1030, and emitted by nothing. The response-shape proof does have a code for the dynamic case - `dynamic_response_shape_missing_proof` - but that is a FINDING-level code in security_missing_proof_code, produced by security_rules.rs and read by run-check.ts. The parser-gap spelling was declared alongside it and never built, so the two look like one mechanism and only one of them exists. Retained for the stored-row reason."
     }
   ]
 }

--- a/scripts/vocabulary-parity-baseline.json
+++ b/scripts/vocabulary-parity-baseline.json
@@ -129,6 +129,12 @@
       "member": "parser_gap",
       "gap": "no_producer",
       "reason": "S2-03, and the one member here that is NOT a renamed sibling. The design gave the tenant proof a way to say 'the tenant scope could not be analysed', and the engine never built it: a tenant parser gap travels on the separate parser_gaps surface and drives proof_status == ParserGap instead, so this reason has no construction site and no path to one. It is also not a member of the finding-level SecurityMissingProofCodeSchema, so if it were ever emitted it would normalize to unknown_reason_code and the finding would stop saying why the proof failed - the same latent shape as session_trust_reason.parser_gap. Retained for the stored-row reason and because deleting it would erase the record that the case is unhandled. If a producer is ever added, decide the finding-level mapping FIRST."
+    },
+    {
+      "vocabulary": "middleware_mismatch_reason",
+      "member": "dynamic_matcher",
+      "gap": "no_producer",
+      "reason": "S2-03. Declared as a coverage mismatch and never built as one. `static_middleware_coverage` in security_control_flow.rs emits path_not_matched, method_not_matched and unknown_framework; a dynamic middleware matcher is handled somewhere else entirely - build_middleware_coverage_proof in security_proof.rs turns it into a SecurityParserGap with code `unsupported_dynamic_middleware_matcher`, which drives proof_status == ParserGap. So the concept is covered and this spelling of it is not, which is a real distinction rather than a gap: a parser gap says the matcher could not be analysed, and a mismatch would say it was analysed and does not cover the route. Answering the second when only the first is known would be a claim the engine cannot support. RETAINED because SecurityBoundaryProofSchema is applied ON READ and the stored-proof census cannot prove no row holds it. If a producer is ever added, it must be a case where the matcher IS understood and genuinely does not match."
     }
   ]
 }

--- a/scripts/vocabulary-parity-baseline.json
+++ b/scripts/vocabulary-parity-baseline.json
@@ -105,6 +105,30 @@
       "member": "unknown_policy_helper",
       "gap": "no_producer",
       "reason": "S2-03, the third of the design-doc trio, and the one with no newer counterpart at all: no reason in this vocabulary means 'the policy helper was not recognised'. The engine has no such arm - an unrecognised authorization helper simply fails to produce a guard, which surfaces as authorization_guard_missing instead. So this is a concept the design declared and the engine never implemented, not a renamed one. Kept for the same stored-row reason and because deleting it would erase the record that the case is unhandled."
+    },
+    {
+      "vocabulary": "tenant_missing_reason",
+      "member": "no_tenant_predicate",
+      "gap": "no_producer",
+      "reason": "S2-03, and the same widening as authorization_missing_reason, from the same document: docs/internal/architecture/security-boundary-enforcement-100-tdd.md:957 declares this field as `no_tenant_predicate | untrusted_tenant_source | predicate_not_bound_to_query | parser_gap`. The engine emits tenant_predicate_missing, tenant_source_untrusted and tenant_predicate_not_bound_to_query instead, and the enum was WIDENED to hold both sets rather than migrated. Seven members, three producers. No consumer beyond the schema. RETAINED because SecurityBoundaryProofSchema is applied ON READ and a row written by an engine that used the design-doc spelling stops parsing if this is removed; the stored-proof census cannot prove no such row exists (18 databases, 0 proof rows here). Removing the set is a migration, not a cleanup."
+    },
+    {
+      "vocabulary": "tenant_missing_reason",
+      "member": "untrusted_tenant_source",
+      "gap": "no_producer",
+      "reason": "S2-03, the design-doc spelling of what the engine now emits as tenant_source_untrusted. Same widening, same stored-row reason - see no_tenant_predicate."
+    },
+    {
+      "vocabulary": "tenant_missing_reason",
+      "member": "predicate_not_bound_to_query",
+      "gap": "no_producer",
+      "reason": "S2-03, the design-doc spelling of what the engine now emits as tenant_predicate_not_bound_to_query. Same widening, same stored-row reason - see no_tenant_predicate."
+    },
+    {
+      "vocabulary": "tenant_missing_reason",
+      "member": "parser_gap",
+      "gap": "no_producer",
+      "reason": "S2-03, and the one member here that is NOT a renamed sibling. The design gave the tenant proof a way to say 'the tenant scope could not be analysed', and the engine never built it: a tenant parser gap travels on the separate parser_gaps surface and drives proof_status == ParserGap instead, so this reason has no construction site and no path to one. It is also not a member of the finding-level SecurityMissingProofCodeSchema, so if it were ever emitted it would normalize to unknown_reason_code and the finding would stop saying why the proof failed - the same latent shape as session_trust_reason.parser_gap. Retained for the stored-row reason and because deleting it would erase the record that the case is unhandled. If a producer is ever added, decide the finding-level mapping FIRST."
     }
   ]
 }

--- a/scripts/vocabulary-parity-baseline.json
+++ b/scripts/vocabulary-parity-baseline.json
@@ -87,6 +87,24 @@
       "member": "parser_gap",
       "gap": "no_producer",
       "reason": "S2-02, and the sharper of the pair. No producer for the same reason as missing_auth_guard, but unlike it this member is NOT in the finding-level vocabulary, so if it were ever emitted the finding would normalize to `unknown_reason_code` at the engine parse boundary and stop saying why the proof failed. It is named explicitly in phase4_missing_code's exhaustive match, pinned by phase4_missing_code_tests, and left unfixed on purpose: choosing a finding-level code for a parser-gapped session-trust proof is a product decision, not a mechanical one - a parser gap travels on the separate parser_gaps surface and drives proof_status == ParserGap, so answering session_not_trusted would assert a trust failure that was never established. Retained for the same stored-row reason as its sibling. If a producer is ever added, decide the finding-level mapping FIRST."
+    },
+    {
+      "vocabulary": "authorization_missing_reason",
+      "member": "no_authorization_guard",
+      "gap": "no_producer",
+      "reason": "S2-03. The ORIGINAL spelling, from the design this feature was built to: docs/internal/architecture/security-boundary-enforcement-100-tdd.md:950 declares this field as exactly `no_authorization_guard | guard_not_dominating_sink | unknown_policy_helper`. The engine shipped different words - authorization_guard_missing, authorization_guard_not_dominating_sink - and the enum was WIDENED to hold both rather than migrated, so six spellings of three concepts sit in one list and only three have a producer. This one has no producer and no consumer beyond the schema. RETAINED because SecurityBoundaryProofSchema is applied ON READ: a row written by an engine that emitted the design-doc spelling stops parsing if this is removed, and scripts/stored-proof-census.mjs cannot prove no such row exists - 18 databases, 0 proof rows, which is one machine's silence and not a licence. Removing the trio is a migration, not a cleanup."
+    },
+    {
+      "vocabulary": "authorization_missing_reason",
+      "member": "guard_not_dominating_sink",
+      "gap": "no_producer",
+      "reason": "S2-03, the second of the design-doc trio. `authorization_guard_not_dominating_sink` is the spelling the engine actually emits for this concept; this is the one the design named. Same widening, same stored-row reason for keeping it - see no_authorization_guard."
+    },
+    {
+      "vocabulary": "authorization_missing_reason",
+      "member": "unknown_policy_helper",
+      "gap": "no_producer",
+      "reason": "S2-03, the third of the design-doc trio, and the one with no newer counterpart at all: no reason in this vocabulary means 'the policy helper was not recognised'. The engine has no such arm - an unrecognised authorization helper simply fails to produce a guard, which surfaces as authorization_guard_missing instead. So this is a concept the design declared and the engine never implemented, not a renamed one. Kept for the same stored-row reason and because deleting it would erase the record that the case is unhandled."
     }
   ]
 }

--- a/scripts/vocabulary-parity-baseline.json
+++ b/scripts/vocabulary-parity-baseline.json
@@ -75,6 +75,18 @@
       "member": "reflection_or_magic_detected",
       "gap": "unreferenced",
       "reason": "Declared in the parser-gap vocabulary and referenced nowhere in either language: no diagnostic maps to it, no capability contract names it, nothing filters on it. Reserved for the reflection case the TypeScript adapter does not attempt."
+    },
+    {
+      "vocabulary": "session_trust_reason",
+      "member": "missing_auth_guard",
+      "gap": "no_producer",
+      "reason": "S2-02. A FINDING-level code (SecurityMissingProofCodeSchema) copied into the PROOF-level enum when the two vocabularies were confused for one - the same confusion that produced S1-01, seen from the other side. `build_session_trust_proof_from_facts` emits only derived_from_request and unknown_helper, so nothing constructs this. RETAINED, not deleted, for stored-row compatibility: SecurityBoundaryProofSchema is applied ON READ in listSecurityBoundaryProofs, so narrowing this enum makes any row already holding the member unparseable, and there is no migration back. scripts/stored-proof-census.mjs reports 18 of 18 databases opened and 0 proof rows on the machine this was written on - an absence of evidence, not evidence of absence, and not a licence to shrink. CONSUMED by phase4_missing_code in check_command.rs, which names it in an explicit arm and passes it through unchanged; it is a member of the finding-level vocabulary too, so that pass-through is correct rather than accidental. Adding a producer closes this entry."
+    },
+    {
+      "vocabulary": "session_trust_reason",
+      "member": "parser_gap",
+      "gap": "no_producer",
+      "reason": "S2-02, and the sharper of the pair. No producer for the same reason as missing_auth_guard, but unlike it this member is NOT in the finding-level vocabulary, so if it were ever emitted the finding would normalize to `unknown_reason_code` at the engine parse boundary and stop saying why the proof failed. It is named explicitly in phase4_missing_code's exhaustive match, pinned by phase4_missing_code_tests, and left unfixed on purpose: choosing a finding-level code for a parser-gapped session-trust proof is a product decision, not a mechanical one - a parser gap travels on the separate parser_gaps surface and drives proof_status == ParserGap, so answering session_not_trusted would assert a trust failure that was never established. Retained for the same stored-row reason as its sibling. If a producer is ever added, decide the finding-level mapping FIRST."
     }
   ]
 }

--- a/scripts/vocabulary-parity.mjs
+++ b/scripts/vocabulary-parity.mjs
@@ -59,6 +59,7 @@ const PRISMA_SOURCE = join(repoRoot, "crates/drift-engine/src/prisma.rs");
 const MAIN_SOURCE = join(repoRoot, "crates/drift-engine/src/main.rs");
 const FACTGRAPH_SOURCE = join(repoRoot, "packages/factgraph/src/index.ts");
 const SECURITY_PROOF_SOURCE = join(repoRoot, "crates/drift-engine/src/security_proof.rs");
+const SECURITY_CONTROL_FLOW_SOURCE = join(repoRoot, "crates/drift-engine/src/security_control_flow.rs");
 
 /**
  * The comment that opens the arm in `check_repo`'s match which skips kinds the engine does not own.
@@ -336,6 +337,19 @@ const PRODUCER_PATTERNS = {
     {
       file: SECURITY_PROOF_SOURCE,
       pattern: new RegExp(`TenantMissingProof\\s*\\{[^}]*?reason:\\s*TenantMissingReason::${variant}\\b`)
+    }
+  ],
+  // The only vocabulary here with two construction sites. The straight-line and
+  // dynamic-control-flow reasons are decided in security_proof.rs; the path-sensitive ones
+  // - guard in one branch only, guard behind a callback boundary - in
+  // security_control_flow.rs, which returns them rather than building the proof itself.
+  // Both files are searched, and only these two: naming the variant in a match arm
+  // elsewhere is a consumer, not a producer.
+  undominated_sink_reason: (variant) => [
+    { file: SECURITY_PROOF_SOURCE, pattern: new RegExp(`UndominatedSinkReason::${variant}\\b`) },
+    {
+      file: SECURITY_CONTROL_FLOW_SOURCE,
+      pattern: new RegExp(`UndominatedSinkReason::${variant}\\b`)
     }
   ]
 };

--- a/scripts/vocabulary-parity.mjs
+++ b/scripts/vocabulary-parity.mjs
@@ -331,6 +331,12 @@ const PRODUCER_PATTERNS = {
       file: SECURITY_PROOF_SOURCE,
       pattern: new RegExp(`AuthorizationMissingProof\\s*\\{\\s*reason:\\s*AuthorizationMissingReason::${variant}\\b`)
     }
+  ],
+  tenant_missing_reason: (variant) => [
+    {
+      file: SECURITY_PROOF_SOURCE,
+      pattern: new RegExp(`TenantMissingProof\\s*\\{[^}]*?reason:\\s*TenantMissingReason::${variant}\\b`)
+    }
   ]
 };
 

--- a/scripts/vocabulary-parity.mjs
+++ b/scripts/vocabulary-parity.mjs
@@ -325,6 +325,12 @@ const PRODUCER_PATTERNS = {
   // problem in rule 3.
   session_trust_reason: (variant) => [
     { file: SECURITY_PROOF_SOURCE, pattern: new RegExp(`SessionTrustReason::${variant}\\b`) }
+  ],
+  authorization_missing_reason: (variant) => [
+    {
+      file: SECURITY_PROOF_SOURCE,
+      pattern: new RegExp(`AuthorizationMissingProof\\s*\\{\\s*reason:\\s*AuthorizationMissingReason::${variant}\\b`)
+    }
   ]
 };
 

--- a/scripts/vocabulary-parity.mjs
+++ b/scripts/vocabulary-parity.mjs
@@ -27,9 +27,11 @@
  *
  *   1. The generated files match vocabulary/vocabulary.json. Editing one side of a mirror is what
  *      this whole change exists to make impossible, and a stale generated file restores it.
- *   2. No hand-written list anywhere is a proper subset of a vocabulary. This is the D-M4 / D-M4b /
- *      GraphNodeRecordSchema shape: a closed enum written from memory, always short, always stale.
- *      A legitimate subset is baselined WITH ITS REASON.
+ *   2. No hand-written list anywhere is drawn entirely from a vocabulary - subset OR exact copy.
+ *      The subset case is the D-M4 / D-M4b / GraphNodeRecordSchema shape: a closed enum written
+ *      from memory, always short, always stale. The exact-copy case was excluded until S2-04 and
+ *      is how two thirty-and-fourteen-member security code lists sat duplicated across two
+ *      packages under a green gate. A legitimate subset is baselined WITH ITS REASON.
  *   3. The convention dispatch table matches the two evaluators' source. `engine_direct` and
  *      `engine_phase6` kinds must appear in check_command.rs, `cli` kinds in run-check.ts, and
  *      `none` kinds in neither - which is what makes "accepted and enforcing nothing" detectable.
@@ -131,11 +133,20 @@ function checkGeneratedFilesAreCurrent(manifest, failures) {
 }
 
 /**
- * 2. Hand-written enum literals that are proper subsets of a vocabulary.
+ * 2. Hand-written enum literals drawn entirely from a vocabulary.
  *
  * Matches TypeScript `z.enum([...])`, JSON-schema `enum: [...]` and Rust `matches!(x, "a" | "b")`.
  * Three or more members, because a two-member list is as likely to be an unrelated pair as a stale
  * copy, and a gate that cries wolf gets muted.
+ *
+ * SUBSETS AND EXACT COPIES BOTH FIRE. Until S2-04 this excluded a list the same size as the
+ * vocabulary (`members.length !== set.size`), on the reasoning that a complete copy is at least not
+ * STALE. That reasoning was wrong, and it cost two of the seven vocabularies S2 generated: the
+ * thirty-two-member `security_missing_proof_code` and the fourteen-member
+ * `security_parser_gap_code` each existed as two byte-identical hand-written copies, one in
+ * @drift/core and one in @drift/engine-contract, and this gate stayed green across both of them for
+ * as long as they agreed. A complete copy is not a smaller problem than a stale one, it is the same
+ * problem before anybody has edited one side - which is the moment to catch it.
  */
 function subsetOffenders(vocabularies) {
   const offenders = [];
@@ -151,7 +162,7 @@ function subsetOffenders(vocabularies) {
           continue;
         }
         for (const [name, set] of vocabularies) {
-          if (members.every((member) => set.has(member)) && members.length !== set.size) {
+          if (members.every((member) => set.has(member))) {
             offenders.push({
               key: `${relative(repoRoot, file)}:${name}`,
               file: relative(repoRoot, file),
@@ -470,10 +481,15 @@ function main() {
   for (const offender of subsets) {
     if (!baselinedSubsets.has(offender.key)) {
       failures.push(
-        `NEW hand-written vocabulary subset: ${offender.file}:${offender.line} declares ` +
-          `${offender.declared} of the ${offender.total} ${offender.vocabulary} members, missing ` +
-          `${offender.missing.join(", ")}. Build it from the generated list, or baseline it with the ` +
-          "reason the subset is deliberate."
+        offender.declared === offender.total
+          ? `NEW hand-written vocabulary COPY: ${offender.file}:${offender.line} declares all ` +
+              `${offender.total} ${offender.vocabulary} members by hand. Import the generated ` +
+              "schema. A complete copy is not a smaller problem than a stale one - it is the same " +
+              "problem, caught before either side has been edited."
+          : `NEW hand-written vocabulary subset: ${offender.file}:${offender.line} declares ` +
+              `${offender.declared} of the ${offender.total} ${offender.vocabulary} members, missing ` +
+              `${offender.missing.join(", ")}. Build it from the generated list, or baseline it with ` +
+              "the reason the subset is deliberate."
       );
     }
   }

--- a/scripts/vocabulary-parity.mjs
+++ b/scripts/vocabulary-parity.mjs
@@ -58,6 +58,7 @@ const SECURITY_FACTS_SOURCE = join(repoRoot, "crates/drift-engine/src/security_f
 const PRISMA_SOURCE = join(repoRoot, "crates/drift-engine/src/prisma.rs");
 const MAIN_SOURCE = join(repoRoot, "crates/drift-engine/src/main.rs");
 const FACTGRAPH_SOURCE = join(repoRoot, "packages/factgraph/src/index.ts");
+const SECURITY_PROOF_SOURCE = join(repoRoot, "crates/drift-engine/src/security_proof.rs");
 
 /**
  * The comment that opens the arm in `check_repo`'s match which skips kinds the engine does not own.
@@ -311,8 +312,60 @@ const PRODUCER_PATTERNS = {
   graph_edge_kind: (variant, member) => [
     { file: MAIN_SOURCE, pattern: new RegExp(`GraphEdgeKind::${variant}\\b`) },
     { file: FACTGRAPH_SOURCE, pattern: new RegExp(`edge\\(\\s*"${member}"`) }
+  ],
+  // The proof-level session trust reason has exactly one construction site:
+  // `build_session_trust_proof_from_facts` in security_proof.rs. That makes the producer
+  // question decidable here in the strong sense, unlike the vocabularies that fall through
+  // to the reference check - so this one is asked precisely, and two of its four members
+  // answer "nobody", which is the honest answer and is baselined as such.
+  //
+  // Deliberately NOT a repo-wide search for the variant. `phase4_missing_code` matches on
+  // every member exhaustively, so a whole-repo search would report all four as produced and
+  // the gate would assert the opposite of what it means to - the same shape as the skip-arm
+  // problem in rule 3.
+  session_trust_reason: (variant) => [
+    { file: SECURITY_PROOF_SOURCE, pattern: new RegExp(`SessionTrustReason::${variant}\\b`) }
   ]
 };
+
+/**
+ * A Rust source with its `#[cfg(test)]` modules removed.
+ *
+ * A test that CONSTRUCTS a vocabulary member is not a producer of it. Without this, the producer
+ * question answers itself: `security_proof.rs` asserts on `SessionTrustReason::UnknownHelper` in its
+ * own test module, so deleting the real emission site left the gate still reporting the member as
+ * produced - a gate that cannot fail, which is the artefact this whole file exists to not be. It is
+ * the same shape as the skip-arm exclusion in rule 3, and it is excluded for the same reason.
+ *
+ * Brace-matched rather than "everything after the first #[cfg(test)]", because a test module is only
+ * conventionally last, and a gate that silently stops reading the second half of a file when someone
+ * moves one is worse than one that never read it.
+ */
+function withoutTestModules(source) {
+  let result = "";
+  let index = 0;
+  for (;;) {
+    const marker = source.indexOf("#[cfg(test)]", index);
+    if (marker === -1) {
+      return result + source.slice(index);
+    }
+    const open = source.indexOf("{", marker);
+    if (open === -1) {
+      return result + source.slice(index);
+    }
+    let depth = 0;
+    let cursor = open;
+    for (; cursor < source.length; cursor += 1) {
+      if (source[cursor] === "{") depth += 1;
+      else if (source[cursor] === "}") {
+        depth -= 1;
+        if (depth === 0) break;
+      }
+    }
+    result += source.slice(index, marker);
+    index = cursor === source.length ? cursor : cursor + 1;
+  }
+}
 
 function rustVariantOf(member) {
   return member
@@ -323,10 +376,10 @@ function rustVariantOf(member) {
 }
 
 function coverageOffenders(vocabularies) {
-  const sources = [...sourceFiles()].map((file) => ({
-    path: file,
-    text: readFileSync(file, "utf8")
-  }));
+  const sources = [...sourceFiles()].map((file) => {
+    const raw = readFileSync(file, "utf8");
+    return { path: file, text: file.endsWith(".rs") ? withoutTestModules(raw) : raw };
+  });
   const byPath = new Map(sources.map((entry) => [entry.path, entry.text]));
   const offenders = [];
 

--- a/scripts/vocabulary-parity.mjs
+++ b/scripts/vocabulary-parity.mjs
@@ -351,6 +351,18 @@ const PRODUCER_PATTERNS = {
       file: SECURITY_CONTROL_FLOW_SOURCE,
       pattern: new RegExp(`UndominatedSinkReason::${variant}\\b`)
     }
+  ],
+  middleware_mismatch_reason: (variant) => [
+    {
+      file: SECURITY_CONTROL_FLOW_SOURCE,
+      pattern: new RegExp(`MiddlewareMismatch\\s*\\{[^}]*?reason:\\s*MiddlewareMismatchReason::${variant}\\b`)
+    }
+  ],
+  request_unvalidated_reason: (variant) => [
+    {
+      file: SECURITY_PROOF_SOURCE,
+      pattern: new RegExp(`RequestUnvalidatedUseProof\\s*\\{[^}]*?reason:\\s*RequestUnvalidatedReason::${variant}\\b`)
+    }
   ]
 };
 

--- a/scripts/vocabulary-parity.test.mjs
+++ b/scripts/vocabulary-parity.test.mjs
@@ -12,12 +12,19 @@ const GENERATED_RS = join(repoRoot, "crates/drift-engine/src/vocabulary.rs");
 const MCP_TOOLS = join(repoRoot, "packages/mcp/src/tools.ts");
 const SEMANTIC_CAPABILITIES = join(repoRoot, "packages/core/src/semantic-capabilities.ts");
 const CHECK_COMMAND = join(repoRoot, "crates/drift-engine/src/check_command.rs");
+const SECURITY_PROOF = join(repoRoot, "crates/drift-engine/src/security_proof.rs");
 
 const originals = new Map(
-  [BASELINE, MANIFEST, GENERATED_TS, GENERATED_RS, MCP_TOOLS, SEMANTIC_CAPABILITIES, CHECK_COMMAND].map((path) => [
-    path,
-    readFileSync(path, "utf8")
-  ])
+  [
+    BASELINE,
+    MANIFEST,
+    GENERATED_TS,
+    GENERATED_RS,
+    MCP_TOOLS,
+    SEMANTIC_CAPABILITIES,
+    CHECK_COMMAND,
+    SECURITY_PROOF
+  ].map((path) => [path, readFileSync(path, "utf8")])
 );
 
 function runGate() {
@@ -211,6 +218,60 @@ describe("vocabulary parity gate", () => {
     const result = runGate();
     expect(result.exitCode).toBe(1);
     expect(result.output).toContain("STALE baseline entry: fact_kind:file_detected is now referenced");
+  });
+
+  /**
+   * S2-02: every member of the PROOF-LEVEL session trust vocabulary is produced, or reserved.
+   *
+   * `session_trust.missing_trust[].reason` is a different vocabulary from the FINDING-level code the
+   * user reads, and the two overlap enough to be confused for one. S1-01 is what that confusion
+   * costs: the builder wrote `session_not_trusted` - a finding-level code, a non-member of the
+   * proof-level enum - into the proof-level field, and the CLI's parse threw on the engine's own
+   * output.
+   *
+   * Two things have to hold for that class to be closed rather than the instance.
+   *
+   * FIRST, the split has to be written down: exactly two of the four members are produced today, and
+   * the other two are reserved with a reason. `missing_auth_guard` and `parser_gap` were widened
+   * into this enum from the finding-level list and never given a producer here. They are held, not
+   * deleted - the schema is applied on read, and scripts/stored-proof-census.mjs found no rows that
+   * would license shrinking it (18 databases, 0 proof rows: an absence of evidence on one machine,
+   * not evidence of absence).
+   *
+   * SECOND, the producer analysis has to be REAL. A gate that reports "produced" from a text search
+   * that cannot fail is the two-hand-written-lists problem with a green tick on it. Removing the one
+   * emission site must make the gate say so by name.
+   */
+  it("session_trust_reason_members_all_have_producers", () => {
+    const manifest = JSON.parse(originals.get(MANIFEST));
+    const members = manifest.vocabularies.session_trust_reason.members;
+    const reserved = JSON.parse(originals.get(BASELINE)).reserved_members.filter(
+      (entry) => entry.vocabulary === "session_trust_reason"
+    );
+
+    expect(reserved.map((entry) => entry.member).sort()).toEqual(["missing_auth_guard", "parser_gap"]);
+    for (const entry of reserved) {
+      expect(entry.gap).toBe("no_producer");
+      // A reserved member with a one-word reason is an unexplained member with extra steps.
+      expect(entry.reason.length).toBeGreaterThan(80);
+    }
+    expect(members.filter((member) => !reserved.some((entry) => entry.member === member))).toEqual([
+      "derived_from_request",
+      "unknown_helper"
+    ]);
+
+    writeFileSync(
+      SECURITY_PROOF,
+      originals
+        .get(SECURITY_PROOF)
+        .replace("SessionTrustReason::UnknownHelper", "SessionTrustReason::DerivedFromRequest")
+    );
+
+    const result = runGate();
+    expect(result.exitCode).toBe(1);
+    expect(result.output).toContain(
+      "NEW vocabulary member with no producer: session_trust_reason.unknown_helper"
+    );
   });
 
   /**

--- a/scripts/vocabulary-parity.test.mjs
+++ b/scripts/vocabulary-parity.test.mjs
@@ -13,6 +13,35 @@ const MCP_TOOLS = join(repoRoot, "packages/mcp/src/tools.ts");
 const SEMANTIC_CAPABILITIES = join(repoRoot, "packages/core/src/semantic-capabilities.ts");
 const CHECK_COMMAND = join(repoRoot, "crates/drift-engine/src/check_command.rs");
 const SECURITY_PROOF = join(repoRoot, "crates/drift-engine/src/security_proof.rs");
+const CORE_SECURITY = join(repoRoot, "packages/core/src/security.ts");
+const ENGINE_CONTRACT = join(repoRoot, "packages/engine-contract/src/index.ts");
+
+/**
+ * The eight proof reason/code vocabularies S2 generated, and the schema each field now imports.
+ *
+ * Every one of these was an inline `z.enum([...])` in BOTH files below, written out twice and
+ * agreeing by hand. The list is spelled out rather than derived from the manifest on purpose: the
+ * manifest is what this asserts ABOUT, so deriving the expectation from it would let a vocabulary
+ * be renamed out of both files and still pass.
+ */
+const PROOF_VOCABULARIES = [
+  ["session_trust_reason", "SessionTrustReasonSchema"],
+  ["authorization_missing_reason", "AuthorizationMissingReasonSchema"],
+  ["tenant_missing_reason", "TenantMissingReasonSchema"],
+  ["undominated_sink_reason", "UndominatedSinkReasonSchema"],
+  ["middleware_mismatch_reason", "MiddlewareMismatchReasonSchema"],
+  ["request_unvalidated_reason", "RequestUnvalidatedReasonSchema"],
+  ["security_missing_proof_code", "SecurityMissingProofCodeSchema"],
+  ["security_parser_gap_code", "SecurityParserGapCodeSchema"]
+];
+
+/** Every `z.enum([...])` literal in a source, as its member list. */
+function inlineEnums(source) {
+  return [...source.matchAll(/z\.enum\(\[([^\]]*)\]/g)].map((match) => ({
+    line: source.slice(0, match.index).split("\n").length,
+    members: [...match[1].matchAll(/"([^"]+)"/g)].map((entry) => entry[1])
+  }));
+}
 
 const originals = new Map(
   [
@@ -280,6 +309,75 @@ describe("vocabulary parity gate", () => {
    * the file without excluding that arm would report every unimplemented kind as implemented, which
    * is the failure this gate exists to catch, produced by the gate itself.
    */
+  /**
+   * S2-04: the duplication is gone, and stays gone.
+   *
+   * Eight closed vocabularies crossed the engine boundary as `z.enum([...])` literals written out
+   * twice - once in @drift/core's SecurityBoundaryProofSchema and once in @drift/engine-contract's
+   * parse boundary - and agreeing only because somebody kept them agreeing. S1-01 is what that
+   * costs: the engine emitted a word neither copy contained, and the failure was a runtime parse
+   * error in a user's terminal.
+   *
+   * This is asserted here rather than left to the gate because the gate could not see it. Rule 2
+   * compares hand-written lists against vocabularies, and until S2-04 it excluded a list the same
+   * SIZE as the vocabulary on the reasoning that a complete copy is at least not stale. Two of
+   * these eight - the thirty-two-member missing-proof codes and the fourteen-member parser-gap
+   * codes - were exactly that: complete, duplicated, and invisible. Rule 2 now fires on exact
+   * copies too; this test is the direct statement of the property, so a future loosening of rule 2
+   * cannot quietly take it away.
+   */
+  it("neither security schema file declares a proof reason or code enum by hand", () => {
+    const manifest = JSON.parse(originals.get(MANIFEST));
+
+    for (const [path, label] of [
+      [CORE_SECURITY, "packages/core/src/security.ts"],
+      [ENGINE_CONTRACT, "packages/engine-contract/src/index.ts"]
+    ]) {
+      const source = readFileSync(path, "utf8");
+      const enums = inlineEnums(source);
+
+      for (const [vocabulary, schema] of PROOF_VOCABULARIES) {
+        const members = new Set(manifest.vocabularies[vocabulary].members);
+
+        // No inline list may be drawn from this vocabulary - not a copy, not a subset.
+        for (const declared of enums) {
+          if (declared.members.length === 0) {
+            continue;
+          }
+          const drawnFrom = declared.members.every((member) => members.has(member));
+          expect(
+            drawnFrom,
+            `${label}:${declared.line} declares ${declared.members.length} of the ${members.size} ` +
+              `${vocabulary} members inline. Import ${schema} from @drift/vocabulary instead.`
+          ).toBe(false);
+        }
+
+        // And the field is actually wired to the generated schema, so the absence above is
+        // because the vocabulary is imported and not because the field was deleted.
+        expect(source, `${label} does not reference ${schema}`).toContain(schema);
+      }
+    }
+  });
+
+  /**
+   * The `unknown_reason_code` normalization is engine-contract's own and must survive the move to
+   * a generated enum.
+   *
+   * It is the reason an engine newer than its CLI degrades the one convention that produced an
+   * unrecognized code, instead of failing the whole run - and it is NEVER readable as "proof
+   * satisfied", because not knowing why a proof failed is a refusal. Generating the enum it wraps
+   * is exactly the kind of change that quietly takes a wrapper with it.
+   */
+  it("keeps the unknown-code normalization at the engine parse boundary", () => {
+    const source = readFileSync(ENGINE_CONTRACT, "utf8");
+
+    expect(source).toContain("z.preprocess(");
+    expect(source).toContain('? "unknown_reason_code"');
+    expect(source).toContain("EngineSecurityKnownMissingProofCodeSchema.safeParse(value).success");
+    expect(JSON.parse(originals.get(MANIFEST)).vocabularies.security_missing_proof_code.members)
+      .toContain("unknown_reason_code");
+  });
+
   it("fails loudly when it can no longer find the engine's skip arm", () => {
     writeFileSync(
       CHECK_COMMAND,

--- a/vocabulary/vocabulary.json
+++ b/vocabulary/vocabulary.json
@@ -313,6 +313,21 @@
       "ts_const": "SESSION_TRUST_REASONS",
       "ts_schema": "SessionTrustReasonSchema",
       "members": ["derived_from_request", "unknown_helper", "missing_auth_guard", "parser_gap"]
+    },
+
+    "authorization_missing_reason": {
+      "doc": "Why an authorization proof could not be completed. PROOF-LEVEL vocabulary, on `authorization.missing[].reason`. The list carries two spellings of the same three concepts - an older `no_authorization_guard`/`guard_not_dominating_sink` pair and the newer `authorization_guard_missing`/`authorization_guard_not_dominating_sink` - because the enum was WIDENED rather than migrated when the engine's wording changed. Only the newer spelling has a producer today; the older one is reserved, because the schema is applied on read and stored rows may still hold it.",
+      "rust_enum": "AuthorizationMissingReason",
+      "ts_const": "AUTHORIZATION_MISSING_REASONS",
+      "ts_schema": "AuthorizationMissingReasonSchema",
+      "members": [
+        "no_authorization_guard",
+        "guard_not_dominating_sink",
+        "unknown_policy_helper",
+        "session_not_trusted",
+        "authorization_guard_missing",
+        "authorization_guard_not_dominating_sink"
+      ]
     }
   }
 }

--- a/vocabulary/vocabulary.json
+++ b/vocabulary/vocabulary.json
@@ -358,6 +358,22 @@
         "unsupported_dynamic_control_flow",
         "no_guard_call"
       ]
+    },
+
+    "middleware_mismatch_reason": {
+      "doc": "Why a middleware does not cover a route. PROOF-LEVEL vocabulary, on `middleware.mismatches[].reason`, produced by static_middleware_coverage in security_control_flow.rs. `dynamic_matcher` has no producer: a dynamic matcher is reported as a parser gap and drives proof_status == ParserGap rather than as a coverage mismatch, so the mismatch spelling of it was declared and never built.",
+      "rust_enum": "MiddlewareMismatchReason",
+      "ts_const": "MIDDLEWARE_MISMATCH_REASONS",
+      "ts_schema": "MiddlewareMismatchReasonSchema",
+      "members": ["path_not_matched", "method_not_matched", "dynamic_matcher", "unknown_framework"]
+    },
+
+    "request_unvalidated_reason": {
+      "doc": "Why a request input reaching a sink is not covered by a validation proof. PROOF-LEVEL vocabulary, on `request_validation.unvalidated_uses[].reason`. Every member is produced by request_unvalidated_uses in security_proof.rs, and all three are also members of the finding-level SecurityMissingProofCodeSchema, so the two vocabularies agree here and need no bridge.",
+      "rust_enum": "RequestUnvalidatedReason",
+      "ts_const": "REQUEST_UNVALIDATED_REASONS",
+      "ts_schema": "RequestUnvalidatedReasonSchema",
+      "members": ["request_input_not_validated", "validation_result_not_used", "unknown_validator"]
     }
   }
 }

--- a/vocabulary/vocabulary.json
+++ b/vocabulary/vocabulary.json
@@ -305,6 +305,14 @@
         { "wire": "graph_evidence", "engine_certified": false, "security": false },
         { "wire": "deterministic_enforcement", "engine_certified": false, "security": false }
       ]
+    },
+
+    "session_trust_reason": {
+      "doc": "Why a session object could not be proven trusted. PROOF-LEVEL vocabulary: it says why the proof failed. The FINDING-level code a user sees (SecurityMissingProofCodeSchema) is separate and is derived from this by the phase4 finding-reason mapping in check_command.rs. The two are deliberately different vocabularies; mapping between them must be total.",
+      "rust_enum": "SessionTrustReason",
+      "ts_const": "SESSION_TRUST_REASONS",
+      "ts_schema": "SessionTrustReasonSchema",
+      "members": ["derived_from_request", "unknown_helper", "missing_auth_guard", "parser_gap"]
     }
   }
 }

--- a/vocabulary/vocabulary.json
+++ b/vocabulary/vocabulary.json
@@ -328,6 +328,22 @@
         "authorization_guard_missing",
         "authorization_guard_not_dominating_sink"
       ]
+    },
+
+    "tenant_missing_reason": {
+      "doc": "Why a tenant-scope proof could not be completed. PROOF-LEVEL vocabulary, on `tenant.missing[].reason`. Widened the same way authorization_missing_reason was: the first three members are the spelling the original design named, the last three are the spelling the engine emits, and `parser_gap` is a fourth concept with no producer at all. Only the newer three are constructed; the rest are reserved rather than deleted, because the schema is applied on read.",
+      "rust_enum": "TenantMissingReason",
+      "ts_const": "TENANT_MISSING_REASONS",
+      "ts_schema": "TenantMissingReasonSchema",
+      "members": [
+        "no_tenant_predicate",
+        "untrusted_tenant_source",
+        "predicate_not_bound_to_query",
+        "parser_gap",
+        "tenant_predicate_missing",
+        "tenant_source_untrusted",
+        "tenant_predicate_not_bound_to_query"
+      ]
     }
   }
 }

--- a/vocabulary/vocabulary.json
+++ b/vocabulary/vocabulary.json
@@ -374,6 +374,77 @@
       "ts_const": "REQUEST_UNVALIDATED_REASONS",
       "ts_schema": "RequestUnvalidatedReasonSchema",
       "members": ["request_input_not_validated", "validation_result_not_used", "unknown_validator"]
+    },
+
+    "security_missing_proof_code": {
+      "doc": [
+        "The FINDING-level code a user reads: why this proof could not be completed. Distinct from every PROOF-level reason vocabulary above, which say why a particular sub-proof failed; the proof-level reasons are mapped onto these codes by phase4_missing_code and missing_proof_code, and the two sets deliberately do not match.",
+        "",
+        "DELIBERATELY TYPESCRIPT-ONLY: there is no rust_enum, and adding one would be wrong. `unknown_reason_code` is not an engine-emittable code at all - it is what the engine-contract parse boundary NORMALIZES an unrecognized code to, so that an engine newer than its CLI degrades the one convention that produced it instead of failing the whole run. Giving Rust a variant for it would make the engine able to emit \"this build does not recognise the code\" about its own output, which inverts the meaning. The engine builds these codes from several places - security_phase6.rs, security_proof.rs, check_command.rs - by mapping proof-level reasons, and those reason vocabularies ARE typed, which is where the compile-time guarantee belongs."
+      ],
+      "ts_const": "SECURITY_MISSING_PROOF_CODES",
+      "ts_schema": "SecurityMissingProofCodeSchema",
+      "members": [
+        "missing_auth_guard",
+        "auth_guard_not_dominating_sink",
+        "middleware_not_covering_route",
+        "middleware_dynamic_matcher",
+        "request_input_not_validated",
+        "validation_result_not_used",
+        "unknown_validator",
+        "request_controlled_url",
+        "raw_sql_unparameterized",
+        "wildcard_origin_with_credentials",
+        "disallowed_origin",
+        "credentials_not_allowed",
+        "unsupported_dynamic_outbound_url",
+        "unsupported_dynamic_cors_origin",
+        "missing_csrf_guard",
+        "csrf_guard_not_dominating_sink",
+        "missing_rate_limit_guard",
+        "rate_limit_guard_not_dominating_sink",
+        "sensitive_response_field_unfiltered",
+        "dynamic_response_shape_missing_proof",
+        "secret_exposure_not_excluded",
+        "session_not_trusted",
+        "authorization_guard_missing",
+        "authorization_guard_not_dominating_sink",
+        "tenant_predicate_missing",
+        "tenant_source_untrusted",
+        "tenant_predicate_not_bound_to_query",
+        "unsupported_callback_boundary",
+        "unsupported_dynamic_control_flow",
+        "route_binding_unresolved",
+        "handler_unresolved",
+        "unknown_reason_code"
+      ]
+    },
+
+    "security_parser_gap_code": {
+      "doc": [
+        "Why a SECURITY proof could not be completed because a construct could not be analysed. Carried on `parser_gaps[].code` inside a security boundary proof, and produced by build_phase4_security_proof, the phase5/phase6 builders and phase4_parser_gap.",
+        "",
+        "NOT the same vocabulary as `parser_gap_kind`, despite the name. That one is the repo-wide taxonomy of why a REGION of the repo could not be understood - unresolved_import, parser_error, partial_parse - derived CLI-side from engine diagnostic codes and named by the semantic capability contracts. This one is the set of specific TypeScript constructs a security proof gives up on. The two lists are disjoint and the collision is in the English word `parser gap`, not in the concept; merging them would put `unresolved_import` where a security proof expects `unsupported_request_input_spread`."
+      ],
+      "rust_enum": "SecurityParserGapCode",
+      "ts_const": "SECURITY_PARSER_GAP_CODES",
+      "ts_schema": "SecurityParserGapCodeSchema",
+      "members": [
+        "route_binding_unresolved",
+        "handler_unresolved",
+        "unsupported_dynamic_control_flow",
+        "unsupported_dynamic_middleware_matcher",
+        "unsupported_request_input_spread",
+        "unsupported_request_input_destructure",
+        "unsupported_dynamic_outbound_url",
+        "unsupported_dynamic_cors_origin",
+        "dynamic_response_shape",
+        "unsupported_destructuring_or_spread",
+        "unsupported_tenant_dynamic_property",
+        "unsupported_tenant_query_object_alias",
+        "unsupported_session_nested_destructure",
+        "unsupported_callback_boundary"
+      ]
     }
   }
 }

--- a/vocabulary/vocabulary.json
+++ b/vocabulary/vocabulary.json
@@ -344,6 +344,20 @@
         "tenant_source_untrusted",
         "tenant_predicate_not_bound_to_query"
       ]
+    },
+
+    "undominated_sink_reason": {
+      "doc": "Why an auth guard does not dominate a sink. PROOF-LEVEL vocabulary, on `auth.undominated_sinks[].reason`. Unlike the other proof reason vocabularies this one has TWO producers: the straight-line and dynamic-control-flow cases are decided in security_proof.rs, and the path-sensitive ones - a guard in only one branch, a guard behind a callback boundary - in security_control_flow.rs. Every member is produced.",
+      "rust_enum": "UndominatedSinkReason",
+      "ts_const": "UNDOMINATED_SINK_REASONS",
+      "ts_schema": "UndominatedSinkReasonSchema",
+      "members": [
+        "guard_after_sink",
+        "guard_only_in_one_branch",
+        "callback_boundary",
+        "unsupported_dynamic_control_flow",
+        "no_guard_call"
+      ]
     }
   }
 }


### PR DESCRIPTION
Sprint 2 of the security-convention pipeline refactor. Turns the class of bug Sprint 1 fixed at runtime into a **compile error**.

Rebased onto main after #128 merged.

## Why

Sprint 1 fixed the engine emitting `session_not_trusted` into a field whose Zod enum doesn't contain it. That bug was possible because eight closed vocabularies crossed the engine boundary as hand-maintained mirrors: a plain `String` on the Rust side, and two byte-identical inline `z.enum([...])` copies on the TypeScript side. Nothing connected them, so the only way to catch a mismatch was to run the engine and watch the parse throw — which is what Sprint 1's gate now does.

This removes the need for that gate to ever fire on this class. All eight are generated from `vocabulary/vocabulary.json`, so the Rust field is a typed enum and both TS copies import one generated schema.

**The invariant, verified per vocabulary.** Re-introducing the Sprint 1 regression no longer fails a test — it fails to build:

```
error[E0308]: mismatched types
     reason: "session_not_trusted".to_string(),
             expected `SessionTrustReason`, found `String`
```

and spelled as a variant, `E0599: no variant named SessionNotTrusted`.

## Commits

| Commit | What |
|---|---|
| `d560577f` | Census stored proof rows before deciding anything is dead |
| `8581eb28` | `session_trust_reason` |
| `64a4d71e` | `authorization_missing_reason` — 3 reserved |
| `d1cc8d2f` | `tenant_missing_reason` — 4 reserved |
| `69074718` | `undominated_sink_reason` |
| `baf7d3f1` | `middleware_mismatch_reason` + `request_unvalidated_reason` |
| `c4383071` | `security_missing_proof_code` + `security_parser_gap_code` — 3 reserved |
| `474e32db` | The duplication test, + a gate tightening |
| `a0a5b302` | A rebase artifact of mine, not the sprint's |

`pnpm check:vocabulary`: **16 vocabularies, 238 members, 23 reserved, 23 baselined.**

## Nothing was deleted

`packages/storage` parses proof rows **on read**, so shrinking an enum bricks reads of existing data. The census ran first: 18 of 18 databases opened, **0 proof rows** — a null result, verified non-vacuous both ways (a seeded DB reports its field paths; an empty `HOME` takes the refusal path and exits 1). Every member without a producer is reserved with a written reason rather than removed.

Two things that surfaced only once the vocabularies existed:

- **The "widenings" were never renames.** The reserved authorization and tenant spellings trace to `security-boundary-enforcement-100-tdd.md:950/957` — they are the *original design*. The engine shipped different words and the enums were widened around it, never migrated.
- **Three members are referenced by nothing in either language:** `security_missing_proof_code.unsupported_callback_boundary`, `security_parser_gap_code.unsupported_callback_boundary`, `security_parser_gap_code.dynamic_response_shape`. They existed only inside the two copies of themselves. Reserved, not deleted.

## Two gates that could not fail, found while building on them

- **The producer regex matched test code.** The new pattern matched `SessionTrustReason::UnknownHelper` inside `security_proof.rs`'s own `#[cfg(test)]` module, so deleting the real emission site still read as "produced." `coverageOffenders` now strips test modules before matching. No existing verdict changed.
- **Rule 2 excluded exact copies.** It skipped hand-written lists the same size as the vocabulary — which is precisely how the 32- and 14-member lists stayed duplicated under a green gate. Now fires on exact copies. Still green.

## Two deliberate deviations

- **`security_missing_proof_code` is TypeScript-only, no `rust_enum`.** `unknown_reason_code` is not engine-emittable — it is what the parse boundary normalizes *to*. A Rust variant would let the engine emit "this build does not recognise the code" about its own output. The compile-time guarantee sits one level down, on the proof-level reasons it maps from, and those are all typed.
- **The `parser_gap` product decision was not forced, so it was not escalated.** `phase4_missing_code` is now exhaustive with **no catch-all**; its `ParserGap` arm passes the wire string through — byte-identical to the old `_` arm, nothing invented, Sprint 1's characterization tests unchanged. Adding a member now fails the build until someone decides where it lands. The live `.unwrap_or_else` defect below it is unchanged and still tracked as #129.

## Review round

Adversarial review found one blocker, independently reproduced before fixing.

**Typing the fields silently changed sort order, and that changes what a finding says.**

Every sort over these reason/code fields is *textually unchanged* by this PR — and every one changed behavior. Deriving `Ord` orders variants by their position in `vocabulary/vocabulary.json`; a `String` sorted lexicographically by wire value. The two disagree.

Not cosmetic: consumers read `.first()` off these sorted lists — `phase4_missing_code` for a finding's `missing_code`, `security_rules.rs` for its `actual_layer`. When a route has more than one true reason, this order decides which the user sees.

```
enum Ord   : ["session_not_trusted", "authorization_guard_not_dominating_sink"]
String Ord : ["authorization_guard_not_dominating_sink", "session_not_trusted"]
```

Driven through the public evaluator, the emitted finding's `actual_layer` moved. The same class applies to the parser-gap, tenant, and undominated-sink sorts, and the array order lands verbatim in `proof_json`, which storage persists.

The whole engine suite stayed green through all of it — no test pinned the order. Four sorts now key on `as_wire()`, restoring the pre-typing order exactly, with a test that also asserts the two orders still genuinely disagree so it cannot quietly become vacuous.

## Known gaps

- **26 byte-identical `z.enum([...])` lists remain duplicated** between `packages/core/src/security.ts` and `packages/engine-contract/src/index.ts` — not two, as an earlier draft of this description said. This PR generates 8 of roughly 34 closed vocabularies. Rule 2 and the S2-04 test only see lists drawn from a *declared* vocabulary, so neither covers the rest; "still green" is not evidence about them.
- Two of those remaining are single-member proof reasons still typed `String` on the Rust side — the S1-01 shape at n=1.
- **Six commits** carry an unused import from my conflict resolution and do not lint standalone (`64a4d71e, d1cc8d2f, 69074718, baf7d3f1, c4383071, 474e32db`) — not two. `a0a5b302` removes it; the tip lints clean, and all nine pass `check:vocabulary`.
- The new test-module stripper in `vocabulary-parity.mjs` is not lexer-aware and can be defeated by a brace inside a string literal, or by `#[cfg(test)]` on a non-`mod` item. Filed as #133.

## Verification

- `pnpm verify:ci` — **exit 0**, including `check:vocabulary` and `check:engine-schema-parity`
- `cargo test -p drift-engine` — 40 binaries green; `clippy -D warnings` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)
