### PR TITLE
fix(engine): a helper contract is satisfied by module identity, not by how the import was spelled

### DIFF
--- a/crates/drift-engine/src/check_command.rs
+++ b/crates/drift-engine/src/check_command.rs
@@ -12,22 +12,22 @@ use drift_engine::{
     AuthorizationHelperBehavior, AuthorizationHelperKind, AuthorizationMissingReason,
     BaselineStatus, BaselineViolation, ConventionDispatch, ConventionKind, DiffFile, DiffScope,
     DirectDataAccessRule, EnforcementMode, Fact, FactKind, FindingStatus, GraphEdgeKind,
-    GraphNodeKind, ParsedDiff, Phase4SecurityPolicy, Phase6AcceptedHelper, Phase6CorsContract,
-    Phase6RawSqlContract, Phase6SecurityContract, Phase6SecurityProof, Phase6SsrfContract,
-    RequestValidatorBehavior, RequestValidatorKind, RouteSecurityBoundaryProof, RuleFinding,
-    ScanCapability, SecurityBoundaryProof, SecurityProofStatus, SessionTrustReason, Severity,
-    TenantMissingReason, accepted_phase5_contract_from_requires,
-    build_auth_boundary_proofs_for_file, build_phase4_security_proof_with_policy,
-    build_phase6_security_proofs_for_file, classify_findings_against_diff,
-    materialize_direct_data_access_findings_with_sources, phase6_proof_to_json,
-    sensitive_field_source_is_trusted, sensitive_response_field_rejections,
+    GraphNodeKind, HelperModuleIdentity, HelperResolutionMode, ParsedDiff, Phase4SecurityPolicy,
+    Phase6AcceptedHelper, Phase6CorsContract, Phase6RawSqlContract, Phase6SecurityContract,
+    Phase6SecurityProof, Phase6SsrfContract, RequestValidatorBehavior, RequestValidatorKind,
+    RouteSecurityBoundaryProof, RuleFinding, ScanCapability, SecurityBoundaryProof,
+    SecurityProofStatus, SessionTrustReason, Severity, TenantMissingReason,
+    accepted_phase5_contract_from_requires, build_auth_boundary_proofs_for_file,
+    build_phase4_security_proof_with_policy, build_phase6_security_proofs_for_file,
+    classify_findings_against_diff, materialize_direct_data_access_findings_with_sources,
+    phase6_proof_to_json, sensitive_field_source_is_trusted, sensitive_response_field_rejections,
 };
 use serde_json::json;
 
 use crate::protocol::{
-    CheckBaselineViolation, CheckEvidence, CheckFact, CheckFinding, CheckGraphData, CheckRequest,
-    CheckResult, ENGINE_CHECK_RESULT_SCHEMA_VERSION, EngineCompleteness, GraphEdge, GraphNode,
-    adapter_versions, capability_stats, engine_stats,
+    AcceptedHelperResolutionMode, CheckBaselineViolation, CheckEvidence, CheckFact, CheckFinding,
+    CheckGraphData, CheckRequest, CheckResult, ENGINE_CHECK_RESULT_SCHEMA_VERSION,
+    EngineCompleteness, GraphEdge, GraphNode, adapter_versions, capability_stats, engine_stats,
 };
 
 pub fn check_repo(request: CheckRequest) -> CheckResult {
@@ -2328,9 +2328,54 @@ fn accepted_auth_helpers_for_convention(
     helpers.into_values().collect()
 }
 
+/// The resolved-identity table the CLI ships on the matcher, keyed the way it was built.
+///
+/// **`(requires_key, symbol)`, never `symbol` alone.** The six requires lists can each carry the
+/// same name, and this engine already reads them separately -
+/// `accepted_auth_helpers_for_convention`, `phase6_helpers_from_requires` and
+/// `security_helpers_from_requires` each build their own map, so a symbol is unique within one
+/// list and never across them. Collapsing the key destroys a mode: an auth helper with a resolved
+/// file identity, overwritten by an `external` serializer of the same name, silently downgrades
+/// the auth helper back to specifier matching.
+///
+/// Absent for an older CLI, and absent for a helper whose contract gave no module at all. Both
+/// leave the matchers at their pre-Sprint-4 behaviour rather than at some invented default.
+fn helper_module_identities(
+    convention: &crate::protocol::CheckConvention,
+) -> BTreeMap<(String, String), HelperModuleIdentity> {
+    convention
+        .matcher
+        .accepted_helper_module_files
+        .iter()
+        .flatten()
+        .map(|entry| {
+            (
+                (entry.requires_key.clone(), entry.symbol.clone()),
+                HelperModuleIdentity {
+                    specifier: entry.specifier.clone(),
+                    mode: match entry.mode {
+                        AcceptedHelperResolutionMode::RepoResolved => {
+                            HelperResolutionMode::RepoResolved
+                        }
+                        AcceptedHelperResolutionMode::External => HelperResolutionMode::External,
+                        AcceptedHelperResolutionMode::Unresolved => {
+                            HelperResolutionMode::Unresolved
+                        }
+                    },
+                    files: entry.files.clone(),
+                    package_specifier_resolves_in_repo: entry
+                        .package_specifier_resolves_in_repo
+                        .unwrap_or(false),
+                },
+            )
+        })
+        .collect()
+}
+
 fn phase4_policy_for_convention(
     convention: &crate::protocol::CheckConvention,
 ) -> Phase4SecurityPolicy {
+    let identities = helper_module_identities(convention);
     let mut helpers = BTreeMap::<String, AcceptedAuthHelper>::new();
     let mut helper_imports = BTreeMap::<String, AcceptedHelperImport>::new();
     if let Some(auth_helpers) = convention
@@ -2380,6 +2425,9 @@ fn phase4_policy_for_convention(
                             .or_else(|| helper.get("import_source"))
                             .and_then(|value| value.as_str())
                             .map(str::to_string),
+                        identity: identities
+                            .get(&("auth_helpers".to_string(), symbol.to_string()))
+                            .cloned(),
                     },
                 );
             }
@@ -3747,6 +3795,7 @@ fn phase4_proof_json(
     convention: &crate::protocol::CheckConvention,
     finding_id: &str,
 ) -> serde_json::Value {
+    let identities = helper_module_identities(convention);
     let missing_code = phase4_missing_code(proof, &convention.kind);
     let missing_proof_ids = if proof.result.proof_status == SecurityProofStatus::Proven {
         Vec::new()
@@ -3858,12 +3907,38 @@ fn phase4_proof_json(
         "session_trust": {
             "required": proof.session_trust.required,
             "proven": proof.session_trust.proven,
-            "trusted_sessions": proof.session_trust.trusted_sessions.iter().map(|session| json!({
-                "fact_id": session.fact_id,
-                "variable": session.variable,
-                "trust": session.trust,
-                "source": session.derived_from
-            })).collect::<Vec<_>>(),
+            "trusted_sessions": proof.session_trust.trusted_sessions.iter().map(|session| {
+                let mut object = serde_json::Map::new();
+                object.insert("fact_id".to_string(), json!(session.fact_id));
+                object.insert("variable".to_string(), json!(session.variable));
+                object.insert("trust".to_string(), json!(session.trust));
+                object.insert("source".to_string(), json!(session.derived_from));
+                // S4-01: how the helper behind this session was identified. Omitted entirely when
+                // the CLI shipped no table, which is what an older CLI looks like - an absent key
+                // says "not asked", where a defaulted one would claim an answer nobody gave.
+                //
+                // On `trusted_sessions[]` specifically because that is the one object in this
+                // document both consumer schemas parse with `.passthrough()`
+                // (packages/core/src/security.ts, packages/engine-contract/src/index.ts). Every
+                // other slot strips unknown keys, so a field added there would reach the wire and
+                // then be deleted on the way to storage - present in the engine's output, absent
+                // from anything a user can read, which is the "wired to nothing" shape this
+                // refactor keeps finding.
+                if let Some(identity) = session
+                    .helper_symbol
+                    .as_ref()
+                    .and_then(|symbol| identities.get(&("auth_helpers".to_string(), symbol.clone())))
+                {
+                    object.insert("helper_resolution".to_string(), json!({
+                        "symbol": session.helper_symbol,
+                        "specifier": identity.specifier,
+                        "mode": identity.mode.as_wire(),
+                        "files": identity.files,
+                        "package_specifier_resolves_in_repo": identity.package_specifier_resolves_in_repo
+                    }));
+                }
+                serde_json::Value::Object(object)
+            }).collect::<Vec<_>>(),
             "missing_trust": proof.session_trust.missing_trust.iter().map(|missing| json!({
                 "fact_id": missing.fact_id,
                 "variable": missing.variable,

--- a/crates/drift-engine/src/check_command.rs
+++ b/crates/drift-engine/src/check_command.rs
@@ -1478,6 +1478,7 @@ fn security_helpers_from_requires(
     convention: &crate::protocol::CheckConvention,
     key: &str,
 ) -> Vec<AcceptedSecurityHelper> {
+    let identities = helper_module_identities(convention);
     convention
         .requires
         .as_ref()
@@ -1486,10 +1487,14 @@ fn security_helpers_from_requires(
         .into_iter()
         .flatten()
         .filter_map(|helper| {
+            let symbol = helper.get("symbol")?.as_str()?.to_string();
             Some(AcceptedSecurityHelper {
                 helper_id: helper.get("helper_id")?.as_str()?.to_string(),
                 module: helper.get("module")?.as_str()?.to_string(),
-                symbol: helper.get("symbol")?.as_str()?.to_string(),
+                // Keyed by the list this helper came from, so a symbol two lists share cannot
+                // borrow the other list's resolution.
+                identity: identities.get(&(key.to_string(), symbol.clone())).cloned(),
+                symbol,
             })
         })
         .collect()

--- a/crates/drift-engine/src/check_command.rs
+++ b/crates/drift-engine/src/check_command.rs
@@ -1457,6 +1457,7 @@ fn phase6_helpers_from_requires(
     convention: &crate::protocol::CheckConvention,
     key: &str,
 ) -> Vec<Phase6AcceptedHelper> {
+    let identities = helper_module_identities(convention);
     convention
         .requires
         .as_ref()
@@ -1465,10 +1466,14 @@ fn phase6_helpers_from_requires(
         .into_iter()
         .flatten()
         .filter_map(|helper| {
+            let symbol = helper.get("symbol")?.as_str()?.to_string();
             Some(Phase6AcceptedHelper {
                 helper_id: helper.get("helper_id")?.as_str()?.to_string(),
                 module: helper.get("module")?.as_str()?.to_string(),
-                symbol: helper.get("symbol")?.as_str()?.to_string(),
+                // Keyed by the list this helper came from, so a symbol two lists share cannot
+                // borrow the other list's resolution.
+                identity: identities.get(&(key.to_string(), symbol.clone())).cloned(),
+                symbol,
             })
         })
         .collect()

--- a/crates/drift-engine/src/lib.rs
+++ b/crates/drift-engine/src/lib.rs
@@ -60,10 +60,11 @@ pub use security_patterns::{
     AcceptedAuthHelper, AcceptedAuthorizationHelper, AcceptedHelperImport, AcceptedPhase5Contract,
     AcceptedRequestValidator, AcceptedResponseSerializer, AcceptedSensitiveResponseField,
     AcceptedTenantHelper, AuthGuardBehavior, AuthorizationHelperBehavior, AuthorizationHelperKind,
-    Phase4SecurityPolicy, RequestValidatorBehavior, RequestValidatorKind, ResponseSerializerPolicy,
-    SCHEMA_METHOD_VALIDATOR_SYMBOLS, SENSITIVE_FIELD_CLASSIFICATIONS, SENSITIVE_FIELD_SOURCES,
+    HelperModuleIdentity, HelperResolutionMode, Phase4SecurityPolicy, RequestValidatorBehavior,
+    RequestValidatorKind, ResponseSerializerPolicy, SCHEMA_METHOD_VALIDATOR_SYMBOLS,
+    SENSITIVE_FIELD_CLASSIFICATIONS, SENSITIVE_FIELD_SOURCES,
     accepted_phase5_contract_from_requires, accepted_response_serializer_for_call,
-    dynamic_middleware_matcher_line, is_schema_method_validator_symbol,
+    dynamic_middleware_matcher_line, helper_module_matches, is_schema_method_validator_symbol,
     is_validation_candidate_symbol, sensitive_response_field_rejections,
 };
 pub use security_phase6::{

--- a/crates/drift-engine/src/protocol.rs
+++ b/crates/drift-engine/src/protocol.rs
@@ -560,22 +560,17 @@ pub struct CheckMatcher {
     /// `Option<Value>`, so a CLI derivation placed there would both blur contract with derivation
     /// and lose its shape on the way. Typed here, a rename fails the build instead of shipping.
     ///
-    /// Accepted and ignored as of this sprint: nothing reads it, and no engine behaviour depends on
-    /// it. It exists so the next sprint can replace name-only and specifier-string helper matching
-    /// with resolved module identity.
+    /// Read as of Sprint 4 by `helper_module_identities` (`check_command.rs`), which keys it by
+    /// `(requires_key, symbol)` and hands each helper's identity to the matchers. The
+    /// `allow(dead_code)` that held this field inert for one sprint is gone with its consumer's
+    /// arrival, which is exactly the signal it was left here to give.
     ///
-    /// `allow(dead_code)` is load-bearing rather than lazy, and it is temporary. `lint:engine` runs
-    /// clippy with `-D warnings`, so an unread field fails the build - correctly, in general. Here
-    /// the field is deliberately inert for exactly one sprint: shipping the wire shape first means
-    /// the consumer lands against a field the CLI already populates over a round trip that is
-    /// already exercised, rather than both arriving together untested. That the CLI really does
-    /// populate it on a real run is pinned by `accepted-helper-identity-dispatch.test.ts`, which
-    /// reads the JSON that actually crossed this boundary - the first wiring of this field went to
-    /// a dispatch loop whose only kind carries no helpers, so it was never emitted at all, and no
-    /// unit test of the request builder could see that. Delete this attribute when helper matching
-    /// starts reading the field; if it is still here after that, the consumer never landed.
+    /// That the CLI really does populate it on a real run is pinned by
+    /// `accepted-helper-identity-dispatch.test.ts`, which reads the JSON that actually crossed this
+    /// boundary. That the ENGINE really reads it on a real run is pinned by
+    /// `barrel_imported_auth_helper_satisfies_session_trust` and its neighbours, which drive the
+    /// `check-repo` binary rather than any inner function.
     #[serde(default)]
-    #[allow(dead_code)]
     pub accepted_helper_module_files: Option<Vec<AcceptedHelperModuleFiles>>,
     // `allowed_delegate_imports` was here, read by nothing. It was the only configurable field
     // of api_route_requires_service_delegation's matcher, and that kind's evaluator took it as
@@ -619,9 +614,7 @@ pub struct CheckMatcher {
 ///
 /// Reading an empty `files` as "this helper matches nothing" would therefore flag every route that
 /// correctly uses an external auth helper - the most common real-world contract there is.
-/// Inert for one sprint by design - see `CheckMatcher::accepted_helper_module_files`.
 #[derive(Debug, Deserialize)]
-#[allow(dead_code)]
 pub struct AcceptedHelperModuleFiles {
     /// Which `requires` list this helper came from - `auth_helpers`, `csrf_helpers`, and so on.
     ///
@@ -650,9 +643,8 @@ pub struct AcceptedHelperModuleFiles {
 }
 
 /// How a helper's module identity was arrived at. See `AcceptedHelperModuleFiles::mode`.
-#[derive(Debug, Deserialize, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, Deserialize, PartialEq, Eq)]
 #[serde(rename_all = "snake_case")]
-#[allow(dead_code)]
 pub enum AcceptedHelperResolutionMode {
     /// Resolved inside the repo; `files` is the identity.
     RepoResolved,

--- a/crates/drift-engine/src/protocol.rs
+++ b/crates/drift-engine/src/protocol.rs
@@ -605,10 +605,20 @@ pub struct CheckMatcher {
 ///     the module that exports the symbol - but the filter compares symbol NAMES, so a barrel
 ///     re-exporting one name from two modules yields both. `files` means "modules that plausibly
 ///     supply this helper", not "modules proven to be it".
-///   - `external` - a bare package specifier that resolved to nothing, which is not a failure:
-///     `resolve_import` filters to paths inside the scan snapshot, so `next-auth` and everything
-///     else under `node_modules` never produces an edge. `files` is empty and always will be.
-///     Match on the exact specifier, plus a local-shadow check.
+///   - `external` - a specifier the CLI's `isBarePackageSpecifier` accepted, which resolved to
+///     nothing. Usually that is a real package: `resolve_import` filters to paths inside the scan
+///     snapshot, so `next-auth` and everything else under `node_modules` never produces an edge,
+///     and an empty `files` there is by design rather than by failure.
+///
+///     Read the name narrowly, though. That predicate rejects only `.`, `/`, `@/`, `~` and `#`
+///     starts, so a scoped path alias (`@app/auth`), a `$lib/...` alias, or an ordinary `baseUrl`
+///     import that failed to resolve all land here too. `external` therefore means "bare-LOOKING,
+///     and resolved to nothing" - it is not a guarantee that the module lives outside the repo,
+///     and must not be read as one.
+///
+///     Matching is exact-specifier equality, which is what this engine did for every helper
+///     before Sprint 4, so nothing in this mode can accept an import that was not already
+///     accepted or reject one that was.
 ///   - `unresolved` - a repo-relative specifier that resolved to nothing. Also empty `files`, but
 ///     this one is a degradation and belongs in the proof as one.
 ///
@@ -636,8 +646,16 @@ pub struct AcceptedHelperModuleFiles {
     ///
     /// A fact, not a verdict. It is the tsconfig-paths hijack shape, and equally the shape of a
     /// pnpm workspace package or a scoped path alias (`"@app/*": ["src/*"]`) - the same mechanism,
-    /// different intent, and nothing available here separates them. Input to the local-shadow check
-    /// the `External` mode calls for, never a finding on its own.
+    /// different intent, and nothing available here separates them.
+    ///
+    /// It is NOT input to a check on the `external` path, and the earlier comment saying so was
+    /// wrong twice over: `external` matching is exact-specifier equality with nothing else in it,
+    /// and the CLI sets this field only in its `repo_resolved` branch, so it is absent under
+    /// `external` by construction and could never have been that input.
+    ///
+    /// What it is for: the engine carries it into the emitted proof, next to the mode, so a
+    /// reader can see that a package-shaped specifier resolved to a file this repo controls.
+    /// Surfacing it is the whole job - deciding what it means is a person's.
     #[serde(default)]
     pub package_specifier_resolves_in_repo: Option<bool>,
 }
@@ -648,7 +666,9 @@ pub struct AcceptedHelperModuleFiles {
 pub enum AcceptedHelperResolutionMode {
     /// Resolved inside the repo; `files` is the identity.
     RepoResolved,
-    /// A bare package specifier that resolved to nothing - by design, not by failure.
+    /// A bare-LOOKING specifier that resolved to nothing - usually a real package, and by design
+    /// rather than by failure. Not a guarantee the module is outside the repo; see the mode list
+    /// on `AcceptedHelperModuleFiles`.
     External,
     /// A repo-relative specifier that resolved to nothing. A degradation, and belongs in the proof.
     Unresolved,

--- a/crates/drift-engine/src/security_patterns.rs
+++ b/crates/drift-engine/src/security_patterns.rs
@@ -577,8 +577,23 @@ pub fn helper_module_matches(
     }
     match identity {
         Some(identity) if identity.mode == HelperResolutionMode::RepoResolved => {
+            // The mapping is derived ONCE, from the whole (specifier, files) pair, and then used
+            // to read the spelling. Deriving it per candidate file instead made the re-export
+            // closure unreachable: `files` for a contract naming `@/lib` is
+            // `["lib/auth.ts", "lib/index.ts"]`, and `lib/auth.ts` - the entry the closure exists
+            // to supply - shares no trailing segment with `@/lib`, so the per-file derivation
+            // found no mapping and refused a file it was literally holding in the list.
+            let Some(candidate) = candidate_module_path(
+                importing_file,
+                spelling,
+                expected_specifier,
+                &identity.files,
+            ) else {
+                return false;
+            };
             identity.files.iter().any(|file| {
-                spelling_denotes_module(importing_file, spelling, expected_specifier, file)
+                let target = module_key(file);
+                target == candidate || target.starts_with(&format!("{candidate}/"))
             })
         }
         _ => false,
@@ -615,24 +630,21 @@ pub fn helper_module_matches(
 ///     some OTHER `requireUser` - not the one in `lib/auth.ts` - this accepts it. A contract that
 ///     names the barrel itself does better, because then the CLI's re-export closure supplies the
 ///     real answer in `files` and the equality relation carries it.
-fn spelling_denotes_module(
+fn candidate_module_path(
     importing_file: &str,
     spelling: &str,
     expected_specifier: &str,
-    file: &str,
-) -> bool {
-    let target = module_key(file);
-    let Some(candidate) = (if is_relative_specifier(spelling) {
-        repo_path_for_relative_specifier(importing_file, spelling)
+    files: &[String],
+) -> Option<String> {
+    let candidate = if is_relative_specifier(spelling) {
+        repo_path_for_relative_specifier(importing_file, spelling)?
     } else {
-        rewrite_through_contract_alias(spelling, expected_specifier, &target)
-    }) else {
-        return false;
+        let (head, root) = contract_alias_mapping(expected_specifier, files)?;
+        module_key(spelling)
+            .strip_prefix(head.as_str())
+            .map(|tail| format!("{root}{tail}"))?
     };
-    if candidate.is_empty() {
-        return false;
-    }
-    candidate == target || target.starts_with(&format!("{candidate}/"))
+    (!candidate.is_empty()).then_some(candidate)
 }
 
 fn is_relative_specifier(specifier: &str) -> bool {
@@ -675,28 +687,49 @@ fn repo_path_for_relative_specifier(importing_file: &str, spelling: &str) -> Opt
     Some(module_key(&parts.join("/")))
 }
 
-/// Read `spelling` in repo-path space, using the contract's own specifier and the file it
-/// resolved to as the worked example of the alias mapping.
+/// What the contract's alias head corresponds to in repo-path space, as `(head, root)`.
 ///
-/// `@/lib/auth` beside `lib/auth` shares the suffix `lib/auth`, leaving `@/` against the empty
-/// string: that pairing is the mapping, derived from this repo rather than assumed. `@/lib` then
-/// reads as `lib`. A `spelling` outside the contract's namespace, or a contract specifier that
-/// shares no path segment with the file it resolved to, yields no mapping and no match.
-fn rewrite_through_contract_alias(
-    spelling: &str,
-    expected_specifier: &str,
-    target: &str,
-) -> Option<String> {
+/// The engine has no tsconfig and cannot resolve an alias. What it has is the contract's own
+/// specifier beside the files that specifier resolved to, which is a worked example of the
+/// mapping: `@/lib/auth` next to `lib/auth.ts` says `@/` and the repo root are the same place.
+///
+/// **One mapping, derived from the whole list, not one per candidate.** `files` is a re-export
+/// closure, and its members are chosen by what they EXPORT, not by what they are called - so for
+/// a contract naming `@/lib` the list is `["lib/auth.ts", "lib/index.ts"]` and only the second
+/// has anything in common with the specifier. Asking each file in turn to explain the alias, and
+/// refusing the ones that cannot, threw away every closure member: `@/lib/auth` denotes
+/// `lib/auth.ts`, `lib/auth.ts` is right there in `files`, and the route was still reported as
+/// using an unknown helper - while the same file spelled `../../../lib/auth` was accepted, which
+/// is the one-module-two-verdicts defect this sprint exists to remove, reintroduced one layer
+/// down.
+///
+/// The anchor is whichever file shares the LONGEST trailing run of segments with the specifier.
+/// Longest rather than first because a closure can contain a decoy: for `@/server/auth` over
+/// `["server/auth.ts", "vendor/auth.ts"]` both share `auth`, and only the first shares
+/// `server/auth`. Ties keep the earlier file, and `files` arrives sorted, so the answer is stable.
+///
+/// `None` when no file shares a segment with the specifier. That means the contract's spelling
+/// and the repo's paths have nothing in common - a bare package name against an unrelated path -
+/// and there is no example to reason from, so no non-relative spelling matches.
+fn contract_alias_mapping(expected_specifier: &str, files: &[String]) -> Option<(String, String)> {
     let specifier_key = module_key(expected_specifier);
-    let shared = shared_path_suffix(&specifier_key, target);
-    if shared.is_empty() {
-        return None;
+    let mut best: Option<(usize, String, String)> = None;
+    for file in files {
+        let target = module_key(file);
+        let shared = shared_path_suffix(&specifier_key, &target);
+        if shared.is_empty() {
+            continue;
+        }
+        let segments = shared.split('/').count();
+        if best.as_ref().is_none_or(|(best, _, _)| segments > *best) {
+            best = Some((
+                segments,
+                specifier_key[..specifier_key.len() - shared.len()].to_string(),
+                target[..target.len() - shared.len()].to_string(),
+            ));
+        }
     }
-    let head = &specifier_key[..specifier_key.len() - shared.len()];
-    let root = &target[..target.len() - shared.len()];
-    let tail = module_key(spelling);
-    let tail = tail.strip_prefix(head)?;
-    Some(format!("{root}{tail}"))
+    best.map(|(_, head, root)| (head, root))
 }
 
 /// The longest suffix the two paths share, cut at a `/` boundary.
@@ -989,12 +1022,59 @@ mod tests {
     }
 
     fn identity(mode: HelperResolutionMode, files: &[&str]) -> HelperModuleIdentity {
+        identity_for("@/lib/auth", mode, files)
+    }
+
+    fn identity_for(
+        specifier: &str,
+        mode: HelperResolutionMode,
+        files: &[&str],
+    ) -> HelperModuleIdentity {
         HelperModuleIdentity {
-            specifier: "@/lib/auth".to_string(),
+            specifier: specifier.to_string(),
             mode,
             files: files.iter().map(|file| (*file).to_string()).collect(),
             package_specifier_resolves_in_repo: false,
         }
+    }
+
+    /// B1: the alias mapping comes from the file that best explains the specifier, not from
+    /// whichever file happens to share a segment with it.
+    ///
+    /// `files` is a re-export closure and can hold a decoy: `vendor/auth.ts` shares `auth` with
+    /// `@/server/auth`, and `server/auth.ts` shares `server/auth`. Anchoring on the decoy makes
+    /// the head `@/server/` and the root `vendor/`, a mapping that explains the contract's own
+    /// specifier only by accident and refuses every other spelling in the namespace - including
+    /// `@/vendor/auth`, which names a file sitting in `files`.
+    ///
+    /// This is the assertion the `>`-to-`<` mutation on the anchor comparison survived when the
+    /// first round of these tests went in, which is why it is here.
+    #[test]
+    fn the_anchor_is_the_file_that_best_explains_the_specifier() {
+        let route = "app/api/projects/route.ts";
+        let decoyed = identity_for(
+            "@/server/auth",
+            HelperResolutionMode::RepoResolved,
+            &["server/auth.ts", "vendor/auth.ts"],
+        );
+        assert!(
+            helper_module_matches(
+                route,
+                Some("@/vendor/auth"),
+                "@/server/auth",
+                Some(&decoyed)
+            ),
+            "a closure member must be reachable through the mapping the specifier really licenses"
+        );
+        assert!(
+            helper_module_matches(
+                route,
+                Some("@/server/auth"),
+                "@/server/auth",
+                Some(&decoyed)
+            ),
+            "the contract's own specifier must still match"
+        );
     }
 
     /// S4-02: the guarantee that makes this sprint revertible by reverting the CLI field alone.

--- a/crates/drift-engine/src/security_patterns.rs
+++ b/crates/drift-engine/src/security_patterns.rs
@@ -57,8 +57,15 @@ pub struct AcceptedHelperImport {
 pub enum HelperResolutionMode {
     /// Resolved inside the repo. `files` is the identity and matching compares resolved modules.
     RepoResolved,
-    /// A bare package specifier that resolved to nothing - by design, not by failure. Matching
-    /// stays on the exact specifier.
+    /// A bare-LOOKING specifier that resolved to nothing. Usually a real package, and empty
+    /// `files` there is by design rather than by failure.
+    ///
+    /// Do not read this as "the module is outside the repo". The CLI's `isBarePackageSpecifier`
+    /// rejects only `.`, `/`, `@/`, `~` and `#` starts, so a scoped path alias (`@app/auth`), a
+    /// `$lib/...` alias and an unresolved `baseUrl` import all arrive here as well. Matching is
+    /// exact-specifier equality - byte for byte what this engine did before Sprint 4 - so the
+    /// mode's imprecision costs nothing in behaviour; it costs only a reader who takes the label
+    /// literally, which is why the label is spelled out here.
     External,
     /// A repo-relative specifier that resolved to nothing. Matching stays on the exact specifier
     /// too, but this one is a degradation and the proof says so.

--- a/crates/drift-engine/src/security_patterns.rs
+++ b/crates/drift-engine/src/security_patterns.rs
@@ -33,6 +33,64 @@ impl Phase4SecurityPolicy {
 pub struct AcceptedHelperImport {
     pub symbol: String,
     pub import_source: Option<String>,
+    /// S4: what the CLI resolved this helper's specifier to, and how it got there.
+    ///
+    /// `None` means the CLI shipped no table for this helper - an older CLI, or a helper the
+    /// contract gave no module for at all. Matching then behaves exactly as it did before this
+    /// sprint, which is what makes the whole change revertible by reverting the TypeScript field
+    /// (`unresolved_mode_falls_back_and_says_so`).
+    pub identity: Option<HelperModuleIdentity>,
+}
+
+/// How an accepted helper's module identity was arrived at.
+///
+/// The engine mirror of `protocol::AcceptedHelperResolutionMode`. Separate from the wire type on
+/// purpose: `protocol` is what deserialises, this is what the matchers reason over, and the
+/// matchers live in a module that must not depend on request shapes.
+///
+/// **Dispatch on this, never on whether `files` is empty.** `resolve_import` only resolves into
+/// the scan snapshot, so every helper that legitimately lives in `node_modules` - `next-auth`,
+/// `@clerk/nextjs`, the most common real-world auth contract there is - arrives with an empty
+/// `files` and always will. "Empty table, fall back to strings" would therefore retain the tier-1
+/// semantics this sprint exists to remove, permanently and silently, for exactly those helpers.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum HelperResolutionMode {
+    /// Resolved inside the repo. `files` is the identity and matching compares resolved modules.
+    RepoResolved,
+    /// A bare package specifier that resolved to nothing - by design, not by failure. Matching
+    /// stays on the exact specifier.
+    External,
+    /// A repo-relative specifier that resolved to nothing. Matching stays on the exact specifier
+    /// too, but this one is a degradation and the proof says so.
+    Unresolved,
+}
+
+impl HelperResolutionMode {
+    /// The spelling this mode takes in an emitted proof - the same one the CLI sent.
+    pub fn as_wire(self) -> &'static str {
+        match self {
+            HelperResolutionMode::RepoResolved => "repo_resolved",
+            HelperResolutionMode::External => "external",
+            HelperResolutionMode::Unresolved => "unresolved",
+        }
+    }
+}
+
+/// One accepted helper's resolved module identity.
+///
+/// `files` means "modules that plausibly supply this helper", NOT "modules proven to be it": the
+/// re-export closure that produced it compares symbol NAMES, so a barrel re-exporting one name
+/// from two modules contributes both.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct HelperModuleIdentity {
+    /// The specifier as the contract typed it. What `External` and `Unresolved` match on.
+    pub specifier: String,
+    pub mode: HelperResolutionMode,
+    pub files: Vec<String>,
+    /// A package-shaped specifier that resolves to a repo file. A fact, not a verdict - it is the
+    /// tsconfig-paths hijack shape and equally the shape of a workspace package or a scoped alias.
+    /// Carried into the proof so a reader can see it; never a finding on its own.
+    pub package_specifier_resolves_in_repo: bool,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -85,8 +143,7 @@ pub fn accepted_phase4_auth_helper_for_call<'a>(
                     policy
                         .auth_helper_imports
                         .iter()
-                        .find(|contract| contract.symbol == helper.symbol)
-                        .and_then(|contract| contract.import_source.as_deref()),
+                        .find(|contract| contract.symbol == helper.symbol),
                 )
         })
     })
@@ -466,12 +523,194 @@ fn imported_symbol_matches_with_source(
         fact.kind == FactKind::ImportUsed
             && fact.name == local_name
             && fact.imported_name.as_deref() == Some(accepted_symbol)
-            && helper_import_matches(fact, import_source)
+            && import_source.is_none_or(|expected| {
+                // No identity is available on this path: `AcceptedAuthorizationHelper` carries a
+                // specifier of its own and `authorization_helpers` is not one of the requires
+                // lists the CLI resolves, so there is nothing to dispatch on. Tier 1, honestly.
+                helper_module_matches(&fact.file_path, fact.value.as_deref(), expected, None)
+            })
     })
 }
 
-fn helper_import_matches(fact: &Fact, import_source: Option<&str>) -> bool {
-    import_source.is_none_or(|expected| fact.value.as_deref() == Some(expected))
+fn helper_import_matches(fact: &Fact, contract: Option<&AcceptedHelperImport>) -> bool {
+    let Some(contract) = contract else {
+        return true;
+    };
+    let Some(expected) = contract.import_source.as_deref() else {
+        return true;
+    };
+    helper_module_matches(
+        &fact.file_path,
+        fact.value.as_deref(),
+        expected,
+        contract.identity.as_ref(),
+    )
+}
+
+/// Does this import spelling name the accepted helper's module?
+///
+/// The one question every accepted-helper matcher in this engine asks, and the one it used to
+/// answer with `spelling == expected`. That answer is right only when the contract's spelling and
+/// the route author's spelling are the same string, which is why `../../lib/auth` and `@/lib/auth`
+/// - one file - were two different helpers, and why a barrel was a third.
+///
+/// The rules, dispatched on `mode` and never on whether `files` is empty:
+///
+///   - no identity, `External`, `Unresolved`: exact specifier equality. Byte for byte what this
+///     engine did before Sprint 4, so none of those three can produce a finding that did not
+///     already exist, and none can accept an import that was not already accepted.
+///   - `RepoResolved`: exact equality, or the spelling denotes one of the resolved `files`.
+///
+/// Callers pass the accepted specifier and the identity separately because the identity is
+/// optional and the specifier is not: an accepted helper always has a spelling to fall back to.
+pub fn helper_module_matches(
+    importing_file: &str,
+    spelling: Option<&str>,
+    expected_specifier: &str,
+    identity: Option<&HelperModuleIdentity>,
+) -> bool {
+    let Some(spelling) = spelling else {
+        return false;
+    };
+    if spelling == expected_specifier {
+        return true;
+    }
+    match identity {
+        Some(identity) if identity.mode == HelperResolutionMode::RepoResolved => {
+            identity.files.iter().any(|file| {
+                spelling_denotes_module(importing_file, spelling, expected_specifier, file)
+            })
+        }
+        _ => false,
+    }
+}
+
+/// Does `spelling`, written in `importing_file`, denote the module at `file`?
+///
+/// Two spellings, two relations, and they are not the same question:
+///
+///   - relative (`../../lib/auth`): pure path arithmetic against the importing file. Exact, and
+///     it needs nothing the engine does not have.
+///   - anything else (`@/lib/auth`, `~/lib`): the engine has no tsconfig and cannot resolve an
+///     alias. What it does have is the contract's OWN specifier next to the file that specifier
+///     resolved to, which is a worked example of the alias mapping: `@/lib/auth` beside
+///     `lib/auth.ts` says `@/` and the repo root are the same place. `spelling` is rewritten
+///     through that correspondence and compared as a path. A spelling in a different namespace
+///     than the contract's shares no such example and does not match.
+///
+/// Either way, two path relations count, and the second is the one to be careful about:
+///
+///   - **equal**: the spelling names the resolved module. Nothing is widened.
+///   - **ancestor**: the spelling names a DIRECTORY the resolved module lives under - the barrel
+///     case, `@/lib` reaching `lib/auth.ts` through `lib/index.ts`. This is the one deliberately
+///     broadened acceptance in this sprint, and it is broadened in the safe direction only:
+///     the route's spelling is wider than the contract's, never the other way round. It is NOT
+///     the subpath relation the forbidden-import path uses. That one widens the CONTRACT, so a
+///     helper accepted at `@/lib` would absorb `@/lib/attacker-controlled` and any module a
+///     caller can add under that prefix becomes an accepted helper. Here the contract still names
+///     exactly one module and the question is only whether the author reached it through a
+///     barrel above it.
+///
+///     The residual it does admit, stated rather than assumed away: if `lib/index.ts` re-exports
+///     some OTHER `requireUser` - not the one in `lib/auth.ts` - this accepts it. A contract that
+///     names the barrel itself does better, because then the CLI's re-export closure supplies the
+///     real answer in `files` and the equality relation carries it.
+fn spelling_denotes_module(
+    importing_file: &str,
+    spelling: &str,
+    expected_specifier: &str,
+    file: &str,
+) -> bool {
+    let target = module_key(file);
+    let Some(candidate) = (if is_relative_specifier(spelling) {
+        repo_path_for_relative_specifier(importing_file, spelling)
+    } else {
+        rewrite_through_contract_alias(spelling, expected_specifier, &target)
+    }) else {
+        return false;
+    };
+    if candidate.is_empty() {
+        return false;
+    }
+    candidate == target || target.starts_with(&format!("{candidate}/"))
+}
+
+fn is_relative_specifier(specifier: &str) -> bool {
+    specifier.starts_with("./") || specifier.starts_with("../")
+}
+
+/// A module path with the parts that are spelling rather than identity removed: the extension,
+/// and the `/index` that a directory import resolves through.
+fn module_key(path: &str) -> String {
+    let path = path.replace('\\', "/");
+    let stripped = [
+        ".d.ts", ".ts", ".tsx", ".mts", ".cts", ".js", ".jsx", ".mjs", ".cjs",
+    ]
+    .iter()
+    .find_map(|extension| path.strip_suffix(extension))
+    .unwrap_or(path.as_str());
+    stripped
+        .strip_suffix("/index")
+        .unwrap_or(stripped)
+        .to_string()
+}
+
+/// `app/api/projects/route.ts` + `../../../lib/auth` = `lib/auth`.
+///
+/// `None` when the specifier climbs out of the repo root, which cannot denote a file the CLI
+/// resolved inside it.
+fn repo_path_for_relative_specifier(importing_file: &str, spelling: &str) -> Option<String> {
+    let importing_file = importing_file.replace('\\', "/");
+    let directory = importing_file.rsplit_once('/').map_or("", |(head, _)| head);
+    let mut parts: Vec<&str> = Vec::new();
+    for segment in directory.split('/').chain(spelling.split('/')) {
+        match segment {
+            "" | "." => {}
+            ".." => {
+                parts.pop()?;
+            }
+            segment => parts.push(segment),
+        }
+    }
+    Some(module_key(&parts.join("/")))
+}
+
+/// Read `spelling` in repo-path space, using the contract's own specifier and the file it
+/// resolved to as the worked example of the alias mapping.
+///
+/// `@/lib/auth` beside `lib/auth` shares the suffix `lib/auth`, leaving `@/` against the empty
+/// string: that pairing is the mapping, derived from this repo rather than assumed. `@/lib` then
+/// reads as `lib`. A `spelling` outside the contract's namespace, or a contract specifier that
+/// shares no path segment with the file it resolved to, yields no mapping and no match.
+fn rewrite_through_contract_alias(
+    spelling: &str,
+    expected_specifier: &str,
+    target: &str,
+) -> Option<String> {
+    let specifier_key = module_key(expected_specifier);
+    let shared = shared_path_suffix(&specifier_key, target);
+    if shared.is_empty() {
+        return None;
+    }
+    let head = &specifier_key[..specifier_key.len() - shared.len()];
+    let root = &target[..target.len() - shared.len()];
+    let tail = module_key(spelling);
+    let tail = tail.strip_prefix(head)?;
+    Some(format!("{root}{tail}"))
+}
+
+/// The longest suffix the two paths share, cut at a `/` boundary.
+fn shared_path_suffix(left: &str, right: &str) -> String {
+    let left_parts = left.split('/').collect::<Vec<_>>();
+    let right_parts = right.split('/').collect::<Vec<_>>();
+    let mut shared = 0;
+    while shared < left_parts.len()
+        && shared < right_parts.len()
+        && left_parts[left_parts.len() - 1 - shared] == right_parts[right_parts.len() - 1 - shared]
+    {
+        shared += 1;
+    }
+    right_parts[right_parts.len() - shared..].join("/")
 }
 
 fn receiver_root(receiver: &str) -> &str {

--- a/crates/drift-engine/src/security_patterns.rs
+++ b/crates/drift-engine/src/security_patterns.rs
@@ -591,45 +591,50 @@ pub fn helper_module_matches(
             ) else {
                 return false;
             };
-            identity.files.iter().any(|file| {
-                let target = module_key(file);
-                target == candidate || target.starts_with(&format!("{candidate}/"))
-            })
+            identity
+                .files
+                .iter()
+                .any(|file| module_key(file) == candidate)
         }
         _ => false,
     }
 }
 
-/// Does `spelling`, written in `importing_file`, denote the module at `file`?
+/// Read `spelling`, written in `importing_file`, as a repo path - or refuse.
 ///
-/// Two spellings, two relations, and they are not the same question:
+/// Two spellings, two ways to read them:
 ///
 ///   - relative (`../../lib/auth`): pure path arithmetic against the importing file. Exact, and
 ///     it needs nothing the engine does not have.
 ///   - anything else (`@/lib/auth`, `~/lib`): the engine has no tsconfig and cannot resolve an
-///     alias. What it does have is the contract's OWN specifier next to the file that specifier
-///     resolved to, which is a worked example of the alias mapping: `@/lib/auth` beside
-///     `lib/auth.ts` says `@/` and the repo root are the same place. `spelling` is rewritten
-///     through that correspondence and compared as a path. A spelling in a different namespace
-///     than the contract's shares no such example and does not match.
+///     alias. What it does have is the contract's own specifier next to the files that specifier
+///     resolved to - see `contract_alias_mapping`. A spelling in a different namespace than the
+///     contract's has no such example and is refused.
 ///
-/// Either way, two path relations count, and the second is the one to be careful about:
+/// The answer is then compared to `files` by EQUALITY, and only equality.
 ///
-///   - **equal**: the spelling names the resolved module. Nothing is widened.
-///   - **ancestor**: the spelling names a DIRECTORY the resolved module lives under - the barrel
-///     case, `@/lib` reaching `lib/auth.ts` through `lib/index.ts`. This is the one deliberately
-///     broadened acceptance in this sprint, and it is broadened in the safe direction only:
-///     the route's spelling is wider than the contract's, never the other way round. It is NOT
-///     the subpath relation the forbidden-import path uses. That one widens the CONTRACT, so a
-///     helper accepted at `@/lib` would absorb `@/lib/attacker-controlled` and any module a
-///     caller can add under that prefix becomes an accepted helper. Here the contract still names
-///     exactly one module and the question is only whether the author reached it through a
-///     barrel above it.
+/// There used to be a second relation here: the spelling naming a DIRECTORY that a resolved file
+/// lives under, so `@/lib` would reach `lib/auth.ts` through the barrel at `lib/index.ts`. It is
+/// gone, and it is worth saying why, because the argument for it sounded reasonable.
 ///
-///     The residual it does admit, stated rather than assumed away: if `lib/index.ts` re-exports
-///     some OTHER `requireUser` - not the one in `lib/auth.ts` - this accepts it. A contract that
-///     names the barrel itself does better, because then the CLI's re-export closure supplies the
-///     real answer in `files` and the equality relation carries it.
+/// It was defended as widening in the safe direction - the ROUTE's spelling wider than the
+/// contract's, never the reverse - and as costing one narrow residual. Both halves were wrong.
+/// The reach was every ancestor directory, so a contract at `@/src/server/auth/session` was
+/// satisfied by `@/src`; and the cost was not a residual but a true positive. Put
+/// `export { requireUser } from "./no-op-auth";` in `lib/index.ts` and a route importing `@/lib`
+/// gets a helper that authenticates nobody, which `main` reports and that relation did not.
+/// Removing a finding from a security check is the one direction a false-positive fix must not
+/// move, and "probably the same helper" is not a proof however few cases it is wrong in.
+///
+/// Nothing available here could have bounded it. `files` is the OUTBOUND closure - what the
+/// contract's module re-exports - so a barrel that re-exports INTO it appears nowhere in the
+/// evidence, and no amount of string arithmetic invents it.
+///
+/// The barrel case is not lost, it just needs the contract to name the barrel: then `files` is
+/// the closure `["lib/auth.ts", "lib/index.ts"]` and equality carries every spelling of both,
+/// with evidence. `barrel_contract_matches_the_module_it_reexports` pins that. The remaining
+/// shape - contract names the narrow module, route imports a barrel above it - wants the INBOUND
+/// closure, which is computable only where the whole graph lives, in the CLI.
 fn candidate_module_path(
     importing_file: &str,
     spelling: &str,
@@ -1109,10 +1114,6 @@ mod tests {
                 "{label}: the exact specifier must still match"
             );
             assert!(
-                !helper_module_matches(route, Some("@/lib"), "@/lib/auth", supplied.as_ref()),
-                "{label}: a barrel must not match without a repo_resolved identity"
-            );
-            assert!(
                 !helper_module_matches(
                     route,
                     Some("../../../lib/auth"),
@@ -1122,10 +1123,30 @@ mod tests {
                 "{label}: a relative spelling must not match without a repo_resolved identity"
             );
         }
+
+        // The same three modes over the CLOSURE shape, which is the one the equality relation
+        // licenses and therefore the one that discriminates the modes now that the ancestor guess
+        // is gone. `files` here is deliberately non-empty for the two non-resolved modes, because
+        // an implementation dispatching on `files.is_empty()` rather than on `mode` passes every
+        // other assertion in this file and only fails where the two disagree.
+        for (label, mode) in [
+            ("unresolved", HelperResolutionMode::Unresolved),
+            ("external", HelperResolutionMode::External),
+        ] {
+            let supplied = identity_for("@/lib", mode, &["lib/auth.ts", "lib/index.ts"]);
+            assert!(
+                helper_module_matches(route, Some("@/lib"), "@/lib", Some(&supplied)),
+                "{label}: the exact specifier must still match"
+            );
+            assert!(
+                !helper_module_matches(route, Some("@/lib/auth"), "@/lib", Some(&supplied)),
+                "{label}: a closure member must not be reachable without a repo_resolved identity"
+            );
+        }
     }
 
-    /// The same three spellings, with the identity that licenses two of them. Without this the
-    /// test above passes trivially on an implementation that never matches anything.
+    /// The spellings with the identity that licenses them. Without this the test above passes
+    /// trivially on an implementation that never matches anything.
     #[test]
     fn repo_resolved_identity_is_what_licenses_the_other_spellings() {
         let route = "app/api/projects/route.ts";
@@ -1138,15 +1159,75 @@ mod tests {
         ));
         assert!(helper_module_matches(
             route,
-            Some("@/lib"),
-            "@/lib/auth",
-            Some(&resolved)
-        ));
-        assert!(helper_module_matches(
-            route,
             Some("../../../lib/auth"),
             "@/lib/auth",
             Some(&resolved)
+        ));
+        // The closure shape, which is what makes a barrel work: the contract names the barrel and
+        // the route names the module the barrel re-exports.
+        let barrel = identity_for(
+            "@/lib",
+            HelperResolutionMode::RepoResolved,
+            &["lib/auth.ts", "lib/index.ts"],
+        );
+        assert!(helper_module_matches(
+            route,
+            Some("@/lib/auth"),
+            "@/lib",
+            Some(&barrel)
+        ));
+    }
+
+    /// B2: an ancestor directory is not evidence, and the relation that said otherwise reached
+    /// much further than the one-level barrel it was written for.
+    ///
+    /// For a contract at `@/src/server/auth/session` the accepting spellings numbered as many as
+    /// the module had ancestor directories - `@/src` among them, which accepts any `requireUser`
+    /// imported from anywhere under the source root. Nothing checked that a module existed at the
+    /// named directory, that it was a barrel, or that it re-exported the accepted symbol;
+    /// `candidate_module_path` is string arithmetic and has nothing to check with.
+    ///
+    /// The equality relation that remains does not need this bound written down, because it never
+    /// had this reach. It is pinned because the deleted relation was defended in a comment as
+    /// covering one case, and a bound argued in prose is not a bound.
+    #[test]
+    fn an_ancestor_directory_is_not_evidence_of_anything() {
+        let route = "app/api/projects/route.ts";
+        let deep = identity_for(
+            "@/src/server/auth/session",
+            HelperResolutionMode::RepoResolved,
+            &["src/server/auth/session.ts"],
+        );
+        for spelling in [
+            "@/src",
+            "@/src/server",
+            "@/src/server/auth",
+            "../../../src",
+            "../../../src/server",
+            "../../../src/server/auth",
+        ] {
+            assert!(
+                !helper_module_matches(
+                    route,
+                    Some(spelling),
+                    "@/src/server/auth/session",
+                    Some(&deep)
+                ),
+                "{spelling} names a directory above the helper and proves nothing about it"
+            );
+        }
+        // The module itself, by either spelling, still matches.
+        assert!(helper_module_matches(
+            route,
+            Some("@/src/server/auth/session"),
+            "@/src/server/auth/session",
+            Some(&deep)
+        ));
+        assert!(helper_module_matches(
+            route,
+            Some("../../../src/server/auth/session"),
+            "@/src/server/auth/session",
+            Some(&deep)
         ));
     }
 

--- a/crates/drift-engine/src/security_patterns.rs
+++ b/crates/drift-engine/src/security_patterns.rs
@@ -987,4 +987,124 @@ mod tests {
         assert_eq!(serializer.serializer_id, "serializePublicUser");
         assert_eq!(serializer.filtered_fields, ["user.email"]);
     }
+
+    fn identity(mode: HelperResolutionMode, files: &[&str]) -> HelperModuleIdentity {
+        HelperModuleIdentity {
+            specifier: "@/lib/auth".to_string(),
+            mode,
+            files: files.iter().map(|file| (*file).to_string()).collect(),
+            package_specifier_resolves_in_repo: false,
+        }
+    }
+
+    /// S4-02: the guarantee that makes this sprint revertible by reverting the CLI field alone.
+    ///
+    /// With no table, matching is byte-for-byte what it was before Sprint 4: the exact specifier
+    /// and nothing else. Every spelling the resolved path accepts is refused here, so a repo whose
+    /// CLI stops sending the field goes back to the old answers rather than to some third
+    /// behaviour that exists in neither version.
+    ///
+    /// `Unresolved` is the same fallback, said out loud rather than inferred. The two cases with a
+    /// deliberately NON-empty `files` are the important half of this test: they are contradictory
+    /// input - a mode that resolved nothing, carrying resolved files - and they are here because
+    /// dispatching on `files.is_empty()` instead of on `mode` would pass every other assertion in
+    /// this suite while silently retaining tier-1 matching for every external helper. Only a case
+    /// where the two disagree can tell those implementations apart.
+    #[test]
+    fn unresolved_mode_falls_back_and_says_so() {
+        let route = "app/api/projects/route.ts";
+        for (label, supplied) in [
+            ("no table at all", None),
+            (
+                "unresolved, with files it has no business having",
+                Some(identity(HelperResolutionMode::Unresolved, &["lib/auth.ts"])),
+            ),
+            (
+                "external, with files it has no business having",
+                Some(identity(HelperResolutionMode::External, &["lib/auth.ts"])),
+            ),
+        ] {
+            assert!(
+                helper_module_matches(route, Some("@/lib/auth"), "@/lib/auth", supplied.as_ref()),
+                "{label}: the exact specifier must still match"
+            );
+            assert!(
+                !helper_module_matches(route, Some("@/lib"), "@/lib/auth", supplied.as_ref()),
+                "{label}: a barrel must not match without a repo_resolved identity"
+            );
+            assert!(
+                !helper_module_matches(
+                    route,
+                    Some("../../../lib/auth"),
+                    "@/lib/auth",
+                    supplied.as_ref()
+                ),
+                "{label}: a relative spelling must not match without a repo_resolved identity"
+            );
+        }
+    }
+
+    /// The same three spellings, with the identity that licenses two of them. Without this the
+    /// test above passes trivially on an implementation that never matches anything.
+    #[test]
+    fn repo_resolved_identity_is_what_licenses_the_other_spellings() {
+        let route = "app/api/projects/route.ts";
+        let resolved = identity(HelperResolutionMode::RepoResolved, &["lib/auth.ts"]);
+        assert!(helper_module_matches(
+            route,
+            Some("@/lib/auth"),
+            "@/lib/auth",
+            Some(&resolved)
+        ));
+        assert!(helper_module_matches(
+            route,
+            Some("@/lib"),
+            "@/lib/auth",
+            Some(&resolved)
+        ));
+        assert!(helper_module_matches(
+            route,
+            Some("../../../lib/auth"),
+            "@/lib/auth",
+            Some(&resolved)
+        ));
+    }
+
+    /// The acceptance is not widened downwards, in any mode.
+    ///
+    /// A helper accepted at `@/lib/auth` covers `@/lib/auth`. It does not cover
+    /// `@/lib/auth/attacker-controlled`, and it does not cover a sibling that merely shares a
+    /// parent. That relation - the specifier plus everything beneath it - belongs to the FORBIDDEN
+    /// import path, where widening only ever bans more. Reused here it would mean any module a
+    /// caller can add under an accepted prefix becomes an accepted auth helper.
+    #[test]
+    fn an_accepted_helper_does_not_absorb_the_modules_beneath_it() {
+        let route = "app/api/projects/route.ts";
+        let resolved = identity(HelperResolutionMode::RepoResolved, &["lib/auth.ts"]);
+        for spelling in [
+            "@/lib/auth/attacker-controlled",
+            "../../../lib/auth/attacker-controlled",
+            "@/lib/auth-lookalike",
+            "../../../lib/authorization",
+        ] {
+            assert!(
+                !helper_module_matches(route, Some(spelling), "@/lib/auth", Some(&resolved)),
+                "{spelling} must not satisfy a helper accepted at @/lib/auth"
+            );
+        }
+    }
+
+    /// A spelling that climbs out of the repo cannot denote a file the CLI resolved inside it, and
+    /// a spelling in a namespace the contract never demonstrated has nothing to be read against.
+    #[test]
+    fn spellings_the_repo_cannot_account_for_do_not_match() {
+        let route = "app/api/projects/route.ts";
+        let resolved = identity(HelperResolutionMode::RepoResolved, &["lib/auth.ts"]);
+        for spelling in ["../../../../../lib/auth", "~/lib/auth", "some-package/auth"] {
+            assert!(
+                !helper_module_matches(route, Some(spelling), "@/lib/auth", Some(&resolved)),
+                "{spelling} must not match"
+            );
+        }
+    }
 }

--- a/crates/drift-engine/src/security_phase6.rs
+++ b/crates/drift-engine/src/security_phase6.rs
@@ -3,9 +3,9 @@ use std::collections::{BTreeMap, BTreeSet};
 use serde_json::json;
 
 use crate::{
-    AcceptedSecurityHelper, Fact, FactExtractError, FactKind, SecurityParserGap,
-    SecurityParserGapCode, SecurityProofResult, SecurityProofStatus, extract_typescript_facts,
-    next_routes::next_api_route_identity,
+    AcceptedSecurityHelper, Fact, FactExtractError, FactKind, HelperModuleIdentity,
+    SecurityParserGap, SecurityParserGapCode, SecurityProofResult, SecurityProofStatus,
+    extract_typescript_facts, helper_module_matches, next_routes::next_api_route_identity,
 };
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -13,6 +13,9 @@ pub struct Phase6AcceptedHelper {
     pub helper_id: String,
     pub module: String,
     pub symbol: String,
+    /// S4: what the CLI resolved `module` to, and how. `None` keeps the pre-Sprint-4 behaviour -
+    /// the exact specifier and nothing else.
+    pub identity: Option<HelperModuleIdentity>,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -715,6 +718,12 @@ fn classify_outbound_argument(
     }
 }
 
+/// The accepted allowlist helpers this file imports, keyed by the LOCAL name it binds them to.
+///
+/// The key was already the local binding, which is why a renamed import never confused this path
+/// the way it confused `security_rules.rs`. What was wrong was the module test: an exact string
+/// comparison, so a route reaching the accepted helper by a relative path or through a barrel was
+/// not importing it as far as this map was concerned, and the guard it called did not count.
 fn accepted_imports(
     facts: &[Fact],
     helpers: &[Phase6AcceptedHelper],
@@ -725,8 +734,13 @@ fn accepted_imports(
         .filter(|fact| fact.kind == FactKind::ImportUsed)
     {
         for helper in helpers {
-            if fact.value.as_deref() == Some(helper.module.as_str())
-                && fact.imported_name.as_deref() == Some(helper.symbol.as_str())
+            if fact.imported_name.as_deref() == Some(helper.symbol.as_str())
+                && helper_module_matches(
+                    &fact.file_path,
+                    fact.value.as_deref(),
+                    &helper.module,
+                    helper.identity.as_ref(),
+                )
             {
                 imports.insert(fact.name.clone(), helper.clone());
             }
@@ -735,6 +749,7 @@ fn accepted_imports(
     imports
 }
 
+/// The CSRF and rate-limit equivalent of `accepted_imports`, over the other helper type.
 fn accepted_security_imports(
     facts: &[Fact],
     helpers: &[AcceptedSecurityHelper],
@@ -745,8 +760,13 @@ fn accepted_security_imports(
         .filter(|fact| fact.kind == FactKind::ImportUsed)
     {
         for helper in helpers {
-            if fact.value.as_deref() == Some(helper.module.as_str())
-                && fact.imported_name.as_deref() == Some(helper.symbol.as_str())
+            if fact.imported_name.as_deref() == Some(helper.symbol.as_str())
+                && helper_module_matches(
+                    &fact.file_path,
+                    fact.value.as_deref(),
+                    &helper.module,
+                    helper.identity.as_ref(),
+                )
             {
                 imports.insert(fact.name.clone(), helper.clone());
             }

--- a/crates/drift-engine/src/security_proof.rs
+++ b/crates/drift-engine/src/security_proof.rs
@@ -104,6 +104,16 @@ pub struct SessionTrustBoundaryProof {
     pub variable: String,
     pub trust: String,
     pub derived_from: String,
+    /// S4-01: WHICH accepted auth helper made this session trusted.
+    ///
+    /// Carried so the emitted proof can say how that helper's module was identified - resolved
+    /// file, external package, or unresolved. A reader who cannot tell those apart cannot tell a
+    /// tier-2 answer from the tier-1 string comparison this sprint replaced. The join back to the
+    /// contract's identity table is `("auth_helpers", helper_symbol)`, and the symbol is the only
+    /// half of that key the proof did not already have.
+    ///
+    /// `None` for a session whose fact carries no imported name.
+    pub helper_symbol: Option<String>,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -1495,6 +1505,9 @@ fn build_session_trust_proof_from_facts(facts: &[Fact]) -> SessionTrustProof {
                     variable,
                     trust: "trusted".to_string(),
                     derived_from: "auth_guard".to_string(),
+                    // The accepted helper's symbol, stamped onto the SessionRead fact by
+                    // `extract_security_facts_with_policy_and_phase5` when it matched the helper.
+                    helper_symbol: fact.imported_name.clone(),
                 });
             }
             (source, Some("untrusted")) => {

--- a/crates/drift-engine/src/security_rules.rs
+++ b/crates/drift-engine/src/security_rules.rs
@@ -2,12 +2,12 @@ use crate::{
     AcceptedAuthHelper, AcceptedAuthorizationHelper, AcceptedPhase5Contract,
     AcceptedRequestValidator, AcceptedTenantHelper, AuthorizationHelperBehavior,
     AuthorizationHelperKind, AuthorizationMissingReason, Fact, FactExtractError, FactKind,
-    Phase4SecurityPolicy, RequestValidationProofScope, SecurityProofStatus, TenantMissingReason,
-    UndominatedSinkReason, build_auth_boundary_proof, build_middleware_coverage_proof,
-    build_phase4_security_proof_with_policy, build_request_validation_proof_with_scope,
-    build_response_shape_proof, build_secret_exposure_proof,
-    extract_security_facts_with_validation, extract_typescript_facts,
-    next_routes::next_api_route_identity,
+    HelperModuleIdentity, Phase4SecurityPolicy, RequestValidationProofScope, SecurityProofStatus,
+    TenantMissingReason, UndominatedSinkReason, build_auth_boundary_proof,
+    build_middleware_coverage_proof, build_phase4_security_proof_with_policy,
+    build_request_validation_proof_with_scope, build_response_shape_proof,
+    build_secret_exposure_proof, extract_security_facts_with_validation, extract_typescript_facts,
+    helper_module_matches, next_routes::next_api_route_identity,
 };
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -116,6 +116,9 @@ pub struct AcceptedSecurityHelper {
     pub helper_id: String,
     pub module: String,
     pub symbol: String,
+    /// S4: what the CLI resolved `module` to, and how. `None` keeps the pre-Sprint-4 behaviour -
+    /// the exact specifier and nothing else.
+    pub identity: Option<HelperModuleIdentity>,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -123,6 +126,8 @@ pub struct AcceptedOutboundUrlHelper {
     pub helper_id: String,
     pub module: String,
     pub symbol: String,
+    /// See `AcceptedSecurityHelper::identity`.
+    pub identity: Option<HelperModuleIdentity>,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -825,6 +830,20 @@ fn is_mutation_method(source: &str) -> bool {
     )
 }
 
+/// Is one of the accepted helpers imported here and called?
+///
+/// Two things were wrong with the way this used to ask.
+///
+/// It required `fact.name == helper.symbol` AND `fact.imported_name == helper.symbol`. For a plain
+/// import those are the same test written twice; for `import { assertCsrf as checkCsrf }` they are
+/// a test no import can pass, because the local name is `checkCsrf` and the imported name is
+/// `assertCsrf`. It then looked for a call to `helper.symbol` - a name a renaming file never
+/// writes. So a route that imported the accepted guard, called it, and was compliant in every
+/// respect was reported as having no proof, for renaming a binding.
+///
+/// The imported name is the identity; the local name is this file's spelling of it, and the call
+/// site has to be looked for under that spelling. And the module is now a place rather than a
+/// string - see `helper_module_matches`.
 fn accepted_helper_called(
     file_path: &std::path::Path,
     source: &str,
@@ -835,16 +854,23 @@ fn accepted_helper_called(
     }
     let facts = extract_typescript_facts(file_path, source)?;
     Ok(helpers.iter().any(|helper| {
-        let imported = facts.iter().any(|fact| {
-            fact.kind == FactKind::ImportUsed
-                && fact.name == helper.symbol
-                && fact.imported_name.as_deref() == Some(helper.symbol.as_str())
-                && fact.value.as_deref() == Some(helper.module.as_str())
-        });
-        let called = facts
+        facts
             .iter()
-            .any(|fact| fact.kind == FactKind::SymbolCalled && fact.name == helper.symbol);
-        imported && called
+            .filter(|fact| {
+                fact.kind == FactKind::ImportUsed
+                    && fact.imported_name.as_deref() == Some(helper.symbol.as_str())
+                    && helper_module_matches(
+                        &fact.file_path,
+                        fact.value.as_deref(),
+                        &helper.module,
+                        helper.identity.as_ref(),
+                    )
+            })
+            .any(|import| {
+                facts
+                    .iter()
+                    .any(|fact| fact.kind == FactKind::SymbolCalled && fact.name == import.name)
+            })
     }))
 }
 
@@ -872,19 +898,27 @@ fn ssrf_allowlist_proves_outbound_urls(
     }
     let base_facts = extract_typescript_facts(file_path, source)?;
     let security_facts = extract_security_facts_with_validation(file_path, source, &[], &[])?;
-    let imported_helpers = contract
-        .accepted_allowlist_helpers
-        .iter()
-        .filter(|helper| {
-            base_facts.iter().any(|fact| {
-                fact.kind == FactKind::ImportUsed
-                    && fact.name == helper.symbol
-                    && fact.imported_name.as_deref() == Some(helper.symbol.as_str())
-                    && fact.value.as_deref() == Some(helper.module.as_str())
-            })
-        })
-        .collect::<Vec<_>>();
-    if imported_helpers.is_empty() {
+    // The LOCAL names the accepted helpers are bound to in this file, not the names the contract
+    // uses. `import { requireAllowedOutboundUrl as allowOutbound }` writes `allowOutbound(` at the
+    // call site and never writes the accepted symbol at all, so searching for the accepted symbol
+    // found nothing and withdrew the proof from a route that had one.
+    let mut allowed_locals = Vec::new();
+    for helper in &contract.accepted_allowlist_helpers {
+        for fact in &base_facts {
+            if fact.kind == FactKind::ImportUsed
+                && fact.imported_name.as_deref() == Some(helper.symbol.as_str())
+                && helper_module_matches(
+                    &fact.file_path,
+                    fact.value.as_deref(),
+                    &helper.module,
+                    helper.identity.as_ref(),
+                )
+            {
+                allowed_locals.push(fact.name.clone());
+            }
+        }
+    }
+    if allowed_locals.is_empty() {
         return Ok(false);
     }
     let lines = source.lines().collect::<Vec<_>>();
@@ -892,9 +926,9 @@ fn ssrf_allowlist_proves_outbound_urls(
         .iter()
         .filter_map(|line| {
             let assigned = assigned_variable_for_rule(line)?;
-            imported_helpers
+            allowed_locals
                 .iter()
-                .any(|helper| line.contains(&format!("{}(", helper.symbol)))
+                .any(|local| line.contains(&format!("{local}(")))
                 .then_some(assigned)
         })
         .collect::<Vec<_>>();

--- a/crates/drift-engine/tests/security_check_repo_phase4.rs
+++ b/crates/drift-engine/tests/security_check_repo_phase4.rs
@@ -821,6 +821,88 @@ fn external_mode_records_its_degradation_in_the_proof() {
     );
 }
 
+/// B1 RED: a contract that names a barrel must match the module the barrel re-exports.
+///
+/// `files` is a re-export CLOSURE. When the contract names `@/lib`, the CLI resolves that to
+/// `lib/index.ts` and then follows the re-exports that carry `requireUser` onward, so `files` is
+/// `["lib/auth.ts", "lib/index.ts"]` - and `lib/auth.ts`, the entry that matters, shares no
+/// trailing path segment with the specifier `@/lib` at all. Deriving the alias mapping from each
+/// candidate file in turn therefore fails on exactly the closure members the closure exists to
+/// supply: `shared_path_suffix("@/lib", "lib/auth")` compares `lib` against `auth`, finds nothing,
+/// and gives up.
+///
+/// The two spellings below denote one file and are asserted together, because the whole claim of
+/// this sprint is that one module cannot have two verdicts. Before the fix the relative spelling
+/// was proven and the aliased one - naming a file literally present in `files` - was not.
+#[test]
+fn barrel_contract_matches_the_module_it_reexports() {
+    for spelling in ["@/lib/auth", "../../../lib/auth"] {
+        let repo_root = temp_repo(&format!(
+            "phase4_barrel_contract_{}",
+            spelling.replace(['@', '/', '.'], "_")
+        ));
+        write_route(
+            &repo_root,
+            "app/api/projects/route.ts",
+            &[
+                &format!("import {{ requireUser }} from '{spelling}';"),
+                "export async function GET(request: Request) {",
+                "  const session = await requireUser(request);",
+                "  return Response.json({ ok: Boolean(session) });",
+                "}",
+                "",
+            ],
+        );
+
+        let payload = run_check_repo(json!({
+            "repo": { "repo_id": "repo_phase4", "repo_root": repo_root.to_string_lossy() },
+            "scan": { "scan_id": "scan_phase4", "facts": [
+                fact("file_role_detected", "api_route", 1, 5, None, None),
+                fact("import_used", "requireUser", 1, 1, Some(spelling), Some("requireUser")),
+                fact("route_declared", "GET", 2, 5, None, None),
+                fact("symbol_called", "requireUser", 3, 3, None, None),
+                fact("route_returns_response", "json", 4, 4, Some("Response"), None)
+            ]},
+            "contract": session_trust_contract(
+                json!({ "symbol": "requireUser", "import": "@/lib", "behavior": "returns_session" }),
+                Some(json!([{
+                    "requires_key": "auth_helpers",
+                    "symbol": "requireUser",
+                    "specifier": "@/lib",
+                    "mode": "repo_resolved",
+                    // The closure, exactly as `resolvedHelperIdentities` builds it: the module the
+                    // specifier names, plus the module a re-export carries the symbol to.
+                    "files": ["lib/auth.ts", "lib/index.ts"]
+                }])),
+            ),
+            "baseline": [],
+            "diff": { "mode": "full", "files": [] }
+        }));
+
+        let session_trust = &payload["security_boundary_proofs"][0]["session_trust"];
+        let trusted = session_trust["trusted_sessions"]
+            .as_array()
+            .expect("trusted_sessions");
+        assert_eq!(trusted.len(), 1, "spelling {spelling}: {payload:#?}");
+        assert_eq!(
+            payload["findings"].as_array().expect("findings").len(),
+            0,
+            "spelling {spelling}: {payload:#?}"
+        );
+        // The gap the first round left: `helper_resolution` was asserted for `external` only, so
+        // nothing pinned that a repo-resolved helper reports its files and mode at all.
+        assert_eq!(
+            trusted[0]["helper_resolution"]["mode"], "repo_resolved",
+            "spelling {spelling}: {payload:#?}"
+        );
+        assert_eq!(
+            trusted[0]["helper_resolution"]["files"],
+            json!(["lib/auth.ts", "lib/index.ts"]),
+            "spelling {spelling}: {payload:#?}"
+        );
+    }
+}
+
 /// A `session_object_must_come_from_trusted_helper` contract with one accepted auth helper, and
 /// optionally the resolved-identity table the CLI ships beside it.
 fn session_trust_contract(helper: Value, helper_module_files: Option<Value>) -> Value {

--- a/crates/drift-engine/tests/security_check_repo_phase4.rs
+++ b/crates/drift-engine/tests/security_check_repo_phase4.rs
@@ -613,76 +613,83 @@ fn session_trust_reason_is_a_member_of_the_wire_enum() {
     }
 }
 
-/// S4-01 RED: a barrel is the same helper, spelled shorter.
+/// B2 RED: a module the contract did not name, and nothing says it supplies the helper.
 ///
-/// The contract names `@/lib/auth`. The route reaches the identical module through `@/lib`, the
-/// barrel that re-exports it. Tier-1 matching compares the two spellings as bytes, decides they
-/// are different helpers, and reports a compliant route as having no trusted session - which is
-/// F3, reproduced here end to end through the real `check-repo` dispatch rather than against
-/// `helper_import_matches` in isolation.
+/// This test replaces an assertion I wrote earlier in this sprint that said the opposite. The
+/// first round accepted `@/lib` for a contract naming `@/lib/auth` on the theory that a barrel
+/// above the resolved module is probably the same helper. Probably is not a proof, and nothing in
+/// the engine can promote it to one: the CLI's closure runs OUTWARD from the contract's module,
+/// recording what that module re-exports, and never records who re-exports INTO it. So `@/lib`
+/// appears nowhere in the evidence, and accepting it was string arithmetic wearing the costume of
+/// module identity.
 ///
-/// The table is what makes the two spellings comparable: it says the accepted helper's module IS
-/// `lib/auth.ts`, and `@/lib` is the directory that module lives under.
+/// What it cost, concretely: put `export { requireUser } from "./no-op-auth";` in `lib/index.ts`
+/// and this route imports a helper that authenticates nobody. `main` calls that a finding. The
+/// first round of this sprint did not - a true positive removed from a security check, which is
+/// the one direction a false-positive fix must never move.
+///
+/// The sibling case is here for the same reason: `@/lib/other` shares a directory with the
+/// resolved module and that is all it shares.
+///
+/// This is a known limitation, not a closed question. The right answer needs the INBOUND closure -
+/// which modules re-export the accepted symbol into the helper's module - and that is computable
+/// only where the whole graph lives, which is the CLI. Until it ships, a contract whose routes
+/// import through a barrel should name the barrel: `barrel_contract_matches_the_module_it_reexports`
+/// shows that shape working, with evidence rather than a guess.
 #[test]
-fn barrel_imported_auth_helper_satisfies_session_trust() {
-    let repo_root = temp_repo("phase4_barrel_specifier");
-    write_route(
-        &repo_root,
-        "app/api/projects/route.ts",
-        &[
-            "import { requireUser } from '@/lib';",
-            "export async function GET(request: Request) {",
-            "  const session = await requireUser(request);",
-            "  return Response.json({ ok: Boolean(session) });",
-            "}",
-            "",
-        ],
-    );
+fn a_barrel_the_contract_did_not_name_is_not_evidence() {
+    for spelling in ["@/lib", "@/lib/other"] {
+        let repo_root = temp_repo(&format!(
+            "phase4_unproven_{}",
+            spelling.replace(['@', '/'], "_")
+        ));
+        write_route(
+            &repo_root,
+            "app/api/projects/route.ts",
+            &[
+                &format!("import {{ requireUser }} from '{spelling}';"),
+                "export async function GET(request: Request) {",
+                "  const session = await requireUser(request);",
+                "  return Response.json({ ok: Boolean(session) });",
+                "}",
+                "",
+            ],
+        );
 
-    let payload = run_check_repo(json!({
-        "repo": { "repo_id": "repo_phase4", "repo_root": repo_root.to_string_lossy() },
-        "scan": { "scan_id": "scan_phase4", "facts": [
-            fact("file_role_detected", "api_route", 1, 5, None, None),
-            fact("import_used", "requireUser", 1, 1, Some("@/lib"), Some("requireUser")),
-            fact("route_declared", "GET", 2, 5, None, None),
-            fact("symbol_called", "requireUser", 3, 3, None, None),
-            fact("route_returns_response", "json", 4, 4, Some("Response"), None)
-        ]},
-        "contract": session_trust_contract(
-            json!({ "symbol": "requireUser", "import": "@/lib/auth", "behavior": "returns_session" }),
-            Some(json!([{
-                "requires_key": "auth_helpers",
-                "symbol": "requireUser",
-                "specifier": "@/lib/auth",
-                "mode": "repo_resolved",
-                "files": ["lib/auth.ts"]
-            }])),
-        ),
-        "baseline": [],
-        "diff": { "mode": "full", "files": [] }
-    }));
+        let payload = run_check_repo(json!({
+            "repo": { "repo_id": "repo_phase4", "repo_root": repo_root.to_string_lossy() },
+            "scan": { "scan_id": "scan_phase4", "facts": [
+                fact("file_role_detected", "api_route", 1, 5, None, None),
+                fact("import_used", "requireUser", 1, 1, Some(spelling), Some("requireUser")),
+                fact("route_declared", "GET", 2, 5, None, None),
+                fact("symbol_called", "requireUser", 3, 3, None, None),
+                fact("route_returns_response", "json", 4, 4, Some("Response"), None)
+            ]},
+            "contract": session_trust_contract(
+                json!({ "symbol": "requireUser", "import": "@/lib/auth", "behavior": "returns_session" }),
+                Some(json!([{
+                    "requires_key": "auth_helpers",
+                    "symbol": "requireUser",
+                    "specifier": "@/lib/auth",
+                    "mode": "repo_resolved",
+                    "files": ["lib/auth.ts"]
+                }])),
+            ),
+            "baseline": [],
+            "diff": { "mode": "full", "files": [] }
+        }));
 
-    let session_trust = &payload["security_boundary_proofs"][0]["session_trust"];
-    assert_eq!(
-        session_trust["trusted_sessions"]
-            .as_array()
-            .expect("trusted_sessions")
-            .len(),
-        1,
-        "{payload:#?}"
-    );
-    assert!(
-        session_trust["missing_trust"]
-            .as_array()
-            .expect("missing_trust")
-            .is_empty(),
-        "{payload:#?}"
-    );
-    assert_eq!(
-        payload["findings"].as_array().expect("findings").len(),
-        0,
-        "{payload:#?}"
-    );
+        assert_eq!(
+            payload["security_boundary_proofs"][0]["session_trust"]["proven"],
+            json!(false),
+            "spelling {spelling}: {payload:#?}"
+        );
+        assert_eq!(
+            payload["findings"].as_array().expect("findings").len(),
+            1,
+            "spelling {spelling}: {payload:#?}"
+        );
+    }
 }
 
 /// S4-01 RED: `../../../lib/auth` and `@/lib/auth` are one file, and tier 1 says otherwise.

--- a/crates/drift-engine/tests/security_check_repo_phase4.rs
+++ b/crates/drift-engine/tests/security_check_repo_phase4.rs
@@ -612,3 +612,233 @@ fn session_trust_reason_is_a_member_of_the_wire_enum() {
         );
     }
 }
+
+/// S4-01 RED: a barrel is the same helper, spelled shorter.
+///
+/// The contract names `@/lib/auth`. The route reaches the identical module through `@/lib`, the
+/// barrel that re-exports it. Tier-1 matching compares the two spellings as bytes, decides they
+/// are different helpers, and reports a compliant route as having no trusted session - which is
+/// F3, reproduced here end to end through the real `check-repo` dispatch rather than against
+/// `helper_import_matches` in isolation.
+///
+/// The table is what makes the two spellings comparable: it says the accepted helper's module IS
+/// `lib/auth.ts`, and `@/lib` is the directory that module lives under.
+#[test]
+fn barrel_imported_auth_helper_satisfies_session_trust() {
+    let repo_root = temp_repo("phase4_barrel_specifier");
+    write_route(
+        &repo_root,
+        "app/api/projects/route.ts",
+        &[
+            "import { requireUser } from '@/lib';",
+            "export async function GET(request: Request) {",
+            "  const session = await requireUser(request);",
+            "  return Response.json({ ok: Boolean(session) });",
+            "}",
+            "",
+        ],
+    );
+
+    let payload = run_check_repo(json!({
+        "repo": { "repo_id": "repo_phase4", "repo_root": repo_root.to_string_lossy() },
+        "scan": { "scan_id": "scan_phase4", "facts": [
+            fact("file_role_detected", "api_route", 1, 5, None, None),
+            fact("import_used", "requireUser", 1, 1, Some("@/lib"), Some("requireUser")),
+            fact("route_declared", "GET", 2, 5, None, None),
+            fact("symbol_called", "requireUser", 3, 3, None, None),
+            fact("route_returns_response", "json", 4, 4, Some("Response"), None)
+        ]},
+        "contract": session_trust_contract(
+            json!({ "symbol": "requireUser", "import": "@/lib/auth", "behavior": "returns_session" }),
+            Some(json!([{
+                "requires_key": "auth_helpers",
+                "symbol": "requireUser",
+                "specifier": "@/lib/auth",
+                "mode": "repo_resolved",
+                "files": ["lib/auth.ts"]
+            }])),
+        ),
+        "baseline": [],
+        "diff": { "mode": "full", "files": [] }
+    }));
+
+    let session_trust = &payload["security_boundary_proofs"][0]["session_trust"];
+    assert_eq!(
+        session_trust["trusted_sessions"]
+            .as_array()
+            .expect("trusted_sessions")
+            .len(),
+        1,
+        "{payload:#?}"
+    );
+    assert!(
+        session_trust["missing_trust"]
+            .as_array()
+            .expect("missing_trust")
+            .is_empty(),
+        "{payload:#?}"
+    );
+    assert_eq!(
+        payload["findings"].as_array().expect("findings").len(),
+        0,
+        "{payload:#?}"
+    );
+}
+
+/// S4-01 RED: `../../../lib/auth` and `@/lib/auth` are one file, and tier 1 says otherwise.
+///
+/// Nothing about this route differs from a conforming one except how its author spelled the path.
+/// The table resolves the accepted helper to `lib/auth.ts`; normalising the relative spelling
+/// against the importing file reaches the same place.
+#[test]
+fn relative_spelling_satisfies_session_trust() {
+    let repo_root = temp_repo("phase4_relative_specifier");
+    write_route(
+        &repo_root,
+        "app/api/projects/route.ts",
+        &[
+            "import { requireUser } from '../../../lib/auth';",
+            "export async function GET(request: Request) {",
+            "  const session = await requireUser(request);",
+            "  return Response.json({ ok: Boolean(session) });",
+            "}",
+            "",
+        ],
+    );
+
+    let payload = run_check_repo(json!({
+        "repo": { "repo_id": "repo_phase4", "repo_root": repo_root.to_string_lossy() },
+        "scan": { "scan_id": "scan_phase4", "facts": [
+            fact("file_role_detected", "api_route", 1, 5, None, None),
+            fact("import_used", "requireUser", 1, 1, Some("../../../lib/auth"), Some("requireUser")),
+            fact("route_declared", "GET", 2, 5, None, None),
+            fact("symbol_called", "requireUser", 3, 3, None, None),
+            fact("route_returns_response", "json", 4, 4, Some("Response"), None)
+        ]},
+        "contract": session_trust_contract(
+            json!({ "symbol": "requireUser", "import": "@/lib/auth", "behavior": "returns_session" }),
+            Some(json!([{
+                "requires_key": "auth_helpers",
+                "symbol": "requireUser",
+                "specifier": "@/lib/auth",
+                "mode": "repo_resolved",
+                "files": ["lib/auth.ts"]
+            }])),
+        ),
+        "baseline": [],
+        "diff": { "mode": "full", "files": [] }
+    }));
+
+    let session_trust = &payload["security_boundary_proofs"][0]["session_trust"];
+    assert_eq!(
+        session_trust["trusted_sessions"]
+            .as_array()
+            .expect("trusted_sessions")
+            .len(),
+        1,
+        "{payload:#?}"
+    );
+    assert!(
+        session_trust["missing_trust"]
+            .as_array()
+            .expect("missing_trust")
+            .is_empty(),
+        "{payload:#?}"
+    );
+    assert_eq!(
+        payload["findings"].as_array().expect("findings").len(),
+        0,
+        "{payload:#?}"
+    );
+}
+
+/// S4-01 RED: `external` is an answer, and the proof has to say so.
+///
+/// `next-auth` resolves to nothing because the resolver only resolves into the scan snapshot -
+/// by design, not by failure. Matching therefore stays on the specifier and this route passes
+/// exactly as it did before. What must change is that the proof records WHICH rule decided it:
+/// a reader who cannot tell "matched a resolved module" from "matched a string" cannot tell a
+/// tier-2 answer from the tier-1 answer this sprint exists to replace.
+///
+/// This is also the assertion that makes "dispatch on mode, never on whether `files` is empty"
+/// checkable: `files` is empty here and the helper still matches.
+#[test]
+fn external_mode_records_its_degradation_in_the_proof() {
+    let repo_root = temp_repo("phase4_external_mode");
+    write_route(
+        &repo_root,
+        "app/api/projects/route.ts",
+        &[
+            "import { getServerSession } from 'next-auth';",
+            "export async function GET(request: Request) {",
+            "  const session = await getServerSession(request);",
+            "  return Response.json({ ok: Boolean(session) });",
+            "}",
+            "",
+        ],
+    );
+
+    let payload = run_check_repo(json!({
+        "repo": { "repo_id": "repo_phase4", "repo_root": repo_root.to_string_lossy() },
+        "scan": { "scan_id": "scan_phase4", "facts": [
+            fact("file_role_detected", "api_route", 1, 5, None, None),
+            fact("import_used", "getServerSession", 1, 1, Some("next-auth"), Some("getServerSession")),
+            fact("route_declared", "GET", 2, 5, None, None),
+            fact("symbol_called", "getServerSession", 3, 3, None, None),
+            fact("route_returns_response", "json", 4, 4, Some("Response"), None)
+        ]},
+        "contract": session_trust_contract(
+            json!({ "symbol": "getServerSession", "import": "next-auth", "behavior": "returns_session" }),
+            Some(json!([{
+                "requires_key": "auth_helpers",
+                "symbol": "getServerSession",
+                "specifier": "next-auth",
+                "mode": "external",
+                "files": []
+            }])),
+        ),
+        "baseline": [],
+        "diff": { "mode": "full", "files": [] }
+    }));
+
+    let session_trust = &payload["security_boundary_proofs"][0]["session_trust"];
+    let trusted = session_trust["trusted_sessions"]
+        .as_array()
+        .expect("trusted_sessions");
+    assert_eq!(trusted.len(), 1, "{payload:#?}");
+    assert_eq!(
+        trusted[0]["helper_resolution"]["mode"], "external",
+        "{payload:#?}"
+    );
+    assert_eq!(
+        trusted[0]["helper_resolution"]["specifier"], "next-auth",
+        "{payload:#?}"
+    );
+    assert_eq!(
+        payload["findings"].as_array().expect("findings").len(),
+        0,
+        "{payload:#?}"
+    );
+}
+
+/// A `session_object_must_come_from_trusted_helper` contract with one accepted auth helper, and
+/// optionally the resolved-identity table the CLI ships beside it.
+fn session_trust_contract(helper: Value, helper_module_files: Option<Value>) -> Value {
+    let mut matcher = json!({ "applies_to_file_roles": ["api_route"] });
+    if let Some(table) = helper_module_files {
+        matcher["accepted_helper_module_files"] = table;
+    }
+    json!({
+        "contract_id": "contract_phase4",
+        "contract_schema_version": 1,
+        "conventions": [{
+            "id": "security_session_trust",
+            "kind": "session_object_must_come_from_trusted_helper",
+            "matcher": matcher,
+            "requires": { "auth_helpers": [helper] },
+            "severity": "error",
+            "enforcement_mode": "block",
+            "enforcement_capability": "deterministic_check"
+        }]
+    })
+}

--- a/crates/drift-engine/tests/security_check_repo_phase4.rs
+++ b/crates/drift-engine/tests/security_check_repo_phase4.rs
@@ -910,6 +910,142 @@ fn barrel_contract_matches_the_module_it_reexports() {
     }
 }
 
+/// The join is `(requires_key, symbol)`, and here is the input that can tell.
+///
+/// Six requires lists can each carry the same name. Keyed by symbol alone, whichever entry the
+/// table happened to list last would win, and an `external` CSRF helper would overwrite an auth
+/// helper that had a resolved file identity - silently downgrading it to specifier matching, which
+/// is precisely the tier-1 behaviour this sprint removes. Nothing about the resulting run looks
+/// wrong; the route just quietly starts being reported again.
+///
+/// So the table below carries `requireUser` twice, under two lists, with the `csrf_helpers` entry
+/// second and deliberately `external`. The route uses a relative spelling, which only a
+/// `repo_resolved` identity accepts. If the entries collapse, the auth helper inherits `external`,
+/// the spelling stops matching and the route is a finding.
+#[test]
+fn a_symbol_two_requires_lists_share_keeps_two_identities() {
+    let repo_root = temp_repo("phase4_cross_list_symbol");
+    write_route(
+        &repo_root,
+        "app/api/projects/route.ts",
+        &[
+            "import { requireUser } from '../../../lib/auth';",
+            "export async function GET(request: Request) {",
+            "  const session = await requireUser(request);",
+            "  return Response.json({ ok: Boolean(session) });",
+            "}",
+            "",
+        ],
+    );
+
+    let payload = run_check_repo(json!({
+        "repo": { "repo_id": "repo_phase4", "repo_root": repo_root.to_string_lossy() },
+        "scan": { "scan_id": "scan_phase4", "facts": [
+            fact("file_role_detected", "api_route", 1, 5, None, None),
+            fact("import_used", "requireUser", 1, 1, Some("../../../lib/auth"), Some("requireUser")),
+            fact("route_declared", "GET", 2, 5, None, None),
+            fact("symbol_called", "requireUser", 3, 3, None, None),
+            fact("route_returns_response", "json", 4, 4, Some("Response"), None)
+        ]},
+        "contract": session_trust_contract(
+            json!({ "symbol": "requireUser", "import": "@/lib/auth", "behavior": "returns_session" }),
+            Some(json!([
+                {
+                    "requires_key": "auth_helpers",
+                    "symbol": "requireUser",
+                    "specifier": "@/lib/auth",
+                    "mode": "repo_resolved",
+                    "files": ["lib/auth.ts"]
+                },
+                {
+                    // Same name, different list, and listed second so a symbol-only key would
+                    // hand its mode to the auth helper above.
+                    "requires_key": "csrf_helpers",
+                    "symbol": "requireUser",
+                    "specifier": "next-auth",
+                    "mode": "external",
+                    "files": []
+                }
+            ])),
+        ),
+        "baseline": [],
+        "diff": { "mode": "full", "files": [] }
+    }));
+
+    let trusted = payload["security_boundary_proofs"][0]["session_trust"]["trusted_sessions"]
+        .as_array()
+        .expect("trusted_sessions");
+    assert_eq!(trusted.len(), 1, "{payload:#?}");
+    assert_eq!(
+        trusted[0]["helper_resolution"]["mode"], "repo_resolved",
+        "the auth helper must keep its own resolution: {payload:#?}"
+    );
+    assert_eq!(
+        trusted[0]["helper_resolution"]["specifier"], "@/lib/auth",
+        "{payload:#?}"
+    );
+    assert_eq!(
+        payload["findings"].as_array().expect("findings").len(),
+        0,
+        "{payload:#?}"
+    );
+}
+
+/// The third mode's turn in the proof.
+///
+/// `unresolved` is a repo-relative specifier the CLI could not resolve - the graph could not
+/// answer, and the match fell back to comparing strings. That is the mode a reader most needs to
+/// see, because it is the one where a passing proof rests on the weakest evidence, and it was the
+/// only one of the three the emitted proof was never checked to report.
+#[test]
+fn unresolved_mode_reaches_the_proof_too() {
+    let repo_root = temp_repo("phase4_unresolved_mode");
+    write_route(
+        &repo_root,
+        "app/api/projects/route.ts",
+        &[
+            "import { requireUser } from '../../../lib/auth';",
+            "export async function GET(request: Request) {",
+            "  const session = await requireUser(request);",
+            "  return Response.json({ ok: Boolean(session) });",
+            "}",
+            "",
+        ],
+    );
+
+    let payload = run_check_repo(json!({
+        "repo": { "repo_id": "repo_phase4", "repo_root": repo_root.to_string_lossy() },
+        "scan": { "scan_id": "scan_phase4", "facts": [
+            fact("file_role_detected", "api_route", 1, 5, None, None),
+            fact("import_used", "requireUser", 1, 1, Some("../../../lib/auth"), Some("requireUser")),
+            fact("route_declared", "GET", 2, 5, None, None),
+            fact("symbol_called", "requireUser", 3, 3, None, None),
+            fact("route_returns_response", "json", 4, 4, Some("Response"), None)
+        ]},
+        "contract": session_trust_contract(
+            json!({ "symbol": "requireUser", "import": "../../../lib/auth", "behavior": "returns_session" }),
+            Some(json!([{
+                "requires_key": "auth_helpers",
+                "symbol": "requireUser",
+                "specifier": "../../../lib/auth",
+                "mode": "unresolved",
+                "files": []
+            }])),
+        ),
+        "baseline": [],
+        "diff": { "mode": "full", "files": [] }
+    }));
+
+    let trusted = payload["security_boundary_proofs"][0]["session_trust"]["trusted_sessions"]
+        .as_array()
+        .expect("trusted_sessions");
+    assert_eq!(trusted.len(), 1, "{payload:#?}");
+    assert_eq!(
+        trusted[0]["helper_resolution"]["mode"], "unresolved",
+        "{payload:#?}"
+    );
+}
+
 /// A `session_object_must_come_from_trusted_helper` contract with one accepted auth helper, and
 /// optionally the resolved-identity table the CLI ships beside it.
 fn session_trust_contract(helper: Value, helper_module_files: Option<Value>) -> Value {

--- a/crates/drift-engine/tests/security_check_repo_phase6.rs
+++ b/crates/drift-engine/tests/security_check_repo_phase6.rs
@@ -356,6 +356,165 @@ fn check_repo_links_phase6_rate_limit_proof_to_normalized_entrypoint() {
     );
 }
 
+/// S4-04 RED: F3 on the CSRF guard, through the dispatch a user's run actually takes.
+///
+/// This route imports the accepted guard, calls it before the response, and is compliant. It
+/// reaches `@/security/csrf` by a relative path, and `accepted_security_imports` compared that
+/// spelling to the contract's as bytes, found them different, built an empty guard map and
+/// reported a missing CSRF proof.
+///
+/// Everything here is real: `scan-repo` produces the facts, `check-repo` evaluates them, and the
+/// helper table travels on the matcher exactly as the CLI sends it.
+#[test]
+fn check_repo_csrf_proof_survives_a_relative_spelling_of_the_helper_module() {
+    let source = [
+        r#"import { requireCsrf } from "../../../security/csrf";"#,
+        "export async function POST(request: Request) {",
+        "  requireCsrf(request);",
+        "  return Response.json({ ok: true });",
+        "}",
+        "",
+    ]
+    .join("\n");
+    let payload = run_phase6_fixture(
+        "csrf_relative",
+        "app/api/settings/route.ts",
+        &source,
+        csrf_convention(Some(json!([{
+            "requires_key": "csrf_helpers",
+            "symbol": "requireCsrf",
+            "specifier": "@/security/csrf",
+            "mode": "repo_resolved",
+            "files": ["security/csrf.ts"]
+        }]))),
+    );
+
+    assert_eq!(
+        payload["security_boundary_proofs"][0]["csrf"]["proven"],
+        json!(true),
+        "{payload:#?}"
+    );
+    assert_eq!(payload["findings"], json!([]), "{payload:#?}");
+}
+
+/// S4-04 RED: the same on the SSRF allowlist, which reads its helpers through `accepted_imports`.
+#[test]
+fn check_repo_ssrf_allowlist_survives_a_relative_spelling_of_the_helper_module() {
+    let source = [
+        r#"import { requireAllowedOutboundUrl } from "../../../security/outbound";"#,
+        "export async function GET(request: Request) {",
+        r#"  const target = request.nextUrl.searchParams.get("target");"#,
+        "  const safeTarget = requireAllowedOutboundUrl(target);",
+        "  await fetch(safeTarget);",
+        "  return Response.json({ ok: true });",
+        "}",
+        "",
+    ]
+    .join("\n");
+    let convention = |table: Value| {
+        json!({
+            "id": "security_api_no_ssrf",
+            "kind": "api_route_forbids_untrusted_ssrf",
+            "matcher": {
+                "applies_to_file_roles": ["api_route"],
+                "methods": ["GET"],
+                "accepted_helper_module_files": table
+            },
+            "requires": {
+                "outbound_url_allowlist_helpers": [{
+                    "helper_id": "outbound_allowlist",
+                    "module": "@/security/outbound",
+                    "symbol": "requireAllowedOutboundUrl"
+                }]
+            },
+            "severity": "error",
+            "enforcement_mode": "block",
+            "enforcement_capability": "deterministic_check"
+        })
+    };
+
+    let payload = run_phase6_fixture(
+        "ssrf_relative",
+        "app/api/proxy/route.ts",
+        &source,
+        convention(json!([{
+            "requires_key": "outbound_url_allowlist_helpers",
+            "symbol": "requireAllowedOutboundUrl",
+            "specifier": "@/security/outbound",
+            "mode": "repo_resolved",
+            "files": ["security/outbound.ts"]
+        }])),
+    );
+
+    assert_eq!(
+        payload["security_boundary_proofs"][0]["ssrf"]["proven"],
+        json!(true),
+        "{payload:#?}"
+    );
+    assert_eq!(payload["findings"], json!([]), "{payload:#?}");
+}
+
+/// A characterization, GREEN before this sprint and pinned so it stays that way.
+///
+/// The plan expected F4 - renamed imports producing findings on compliant routes - to be live
+/// here. It is not, and this is the test that says so: `accepted_security_imports` has always
+/// keyed its map by the LOCAL binding and matched on `imported_name`, so `as` never confused it.
+/// The rename defect was real only in `security_rules.rs`, which nothing in `src/` calls.
+///
+/// Pinned rather than deleted because the fix in the previous commit moved code on both sides of
+/// this question, and "the real path was already right" is worth exactly as much as the test that
+/// would notice it stopping being right.
+#[test]
+fn check_repo_csrf_proof_already_survived_a_renamed_import() {
+    let source = [
+        r#"import { requireCsrf as checkCsrf } from "@/security/csrf";"#,
+        "export async function POST(request: Request) {",
+        "  checkCsrf(request);",
+        "  return Response.json({ ok: true });",
+        "}",
+        "",
+    ]
+    .join("\n");
+    let payload = run_phase6_fixture(
+        "csrf_renamed",
+        "app/api/settings/route.ts",
+        &source,
+        csrf_convention(None),
+    );
+
+    assert_eq!(
+        payload["security_boundary_proofs"][0]["csrf"]["proven"],
+        json!(true),
+        "{payload:#?}"
+    );
+    assert_eq!(payload["findings"], json!([]), "{payload:#?}");
+}
+
+fn csrf_convention(helper_module_files: Option<Value>) -> Value {
+    let mut matcher = json!({
+        "applies_to_file_roles": ["api_route"],
+        "methods": ["POST"]
+    });
+    if let Some(table) = helper_module_files {
+        matcher["accepted_helper_module_files"] = table;
+    }
+    json!({
+        "id": "security_api_csrf",
+        "kind": "api_route_requires_csrf_for_mutation",
+        "matcher": matcher,
+        "requires": {
+            "csrf_helpers": [{
+                "helper_id": "csrf",
+                "module": "@/security/csrf",
+                "symbol": "requireCsrf"
+            }]
+        },
+        "severity": "error",
+        "enforcement_mode": "block",
+        "enforcement_capability": "deterministic_check"
+    })
+}
+
 fn run_phase6_fixture(name: &str, file_path: &str, source: &str, convention: Value) -> Value {
     let repo_root = temp_repo(name);
     let route_path = repo_root.join(file_path);

--- a/crates/drift-engine/tests/security_phase6.rs
+++ b/crates/drift-engine/tests/security_phase6.rs
@@ -64,6 +64,7 @@ export async function GET(request: Request) {
                 helper_id: "outbound_allowlist".to_string(),
                 module: "@/security/outbound".to_string(),
                 symbol: "requireAllowedOutboundUrl".to_string(),
+                identity: None,
             }],
         },
     )
@@ -522,6 +523,7 @@ fn phase6_csrf_contract() -> Phase6SecurityContract {
             helper_id: "csrf".to_string(),
             module: "@/security/csrf".to_string(),
             symbol: "requireCsrf".to_string(),
+            identity: None,
         }],
     }
 }
@@ -533,6 +535,7 @@ fn phase6_rate_limit_contract() -> Phase6SecurityContract {
             helper_id: "rate_limit".to_string(),
             module: "@/security/rate-limit".to_string(),
             symbol: "requireRateLimit".to_string(),
+            identity: None,
         }],
         route_paths: vec!["/api/login".to_string()],
     }

--- a/crates/drift-engine/tests/security_phase6.rs
+++ b/crates/drift-engine/tests/security_phase6.rs
@@ -498,6 +498,7 @@ fn phase6_ssrf_contract() -> Phase6SecurityContract {
             helper_id: "outbound_allowlist".to_string(),
             module: "@/security/outbound".to_string(),
             symbol: "requireAllowedOutboundUrl".to_string(),
+            identity: None,
         }],
     })
 }

--- a/crates/drift-engine/tests/security_rules.rs
+++ b/crates/drift-engine/tests/security_rules.rs
@@ -1,20 +1,23 @@
 use drift_engine::{
-    AcceptedAuthHelper, AcceptedAuthorizationHelper, AcceptedPhase5Contract,
-    AcceptedRequestValidator, AcceptedResponseSerializer, AcceptedSensitiveResponseField,
-    AcceptedTenantHelper, AuthGuardBehavior, AuthorizationHelperBehavior, AuthorizationHelperKind,
-    AuthorizationMissingReason, Phase4SecurityPolicy, RequestValidatorBehavior,
-    RequestValidatorKind, ResponseSerializerPolicy, SecurityAuthContract,
-    SecurityAuthorizationContract, SecurityContractCapability, SecurityEnforcementMode,
-    SecurityFindingResult, SecurityMiddlewareContract, SecurityParserGapCode,
-    SecurityPhase5Contract, SecurityProofStatus, SecurityRequestValidationContract,
-    SecurityTenantScopeContract, TenantMissingReason, build_phase4_security_proof_with_policy,
-    build_request_validation_proof, build_response_shape_proof, build_secret_exposure_proof,
+    AcceptedAuthHelper, AcceptedAuthorizationHelper, AcceptedOutboundUrlHelper,
+    AcceptedPhase5Contract, AcceptedRequestValidator, AcceptedResponseSerializer,
+    AcceptedSecurityHelper, AcceptedSensitiveResponseField, AcceptedTenantHelper,
+    AuthGuardBehavior, AuthorizationHelperBehavior, AuthorizationHelperKind,
+    AuthorizationMissingReason, HelperModuleIdentity, HelperResolutionMode, Phase4SecurityPolicy,
+    RequestValidatorBehavior, RequestValidatorKind, ResponseSerializerPolicy, SecurityAuthContract,
+    SecurityAuthorizationContract, SecurityContractCapability, SecurityCsrfContract,
+    SecurityEnforcementMode, SecurityFindingResult, SecurityMiddlewareContract,
+    SecurityParserGapCode, SecurityPhase5Contract, SecurityProofStatus,
+    SecurityRequestValidationContract, SecuritySsrfContract, SecurityTenantScopeContract,
+    TenantMissingReason, build_phase4_security_proof_with_policy, build_request_validation_proof,
+    build_response_shape_proof, build_secret_exposure_proof,
     evaluate_api_route_forbids_secret_exposure,
-    evaluate_api_route_forbids_sensitive_response_fields, evaluate_api_route_requires_auth_helper,
+    evaluate_api_route_forbids_sensitive_response_fields,
+    evaluate_api_route_forbids_untrusted_ssrf, evaluate_api_route_requires_auth_helper,
     evaluate_api_route_requires_auth_helper_with_middleware,
-    evaluate_api_route_requires_authorization, evaluate_api_route_requires_request_validation,
-    evaluate_api_route_requires_tenant_scope, evaluate_middleware_must_cover_routes,
-    extract_security_facts, static_middleware_coverage,
+    evaluate_api_route_requires_authorization, evaluate_api_route_requires_csrf_for_mutation,
+    evaluate_api_route_requires_request_validation, evaluate_api_route_requires_tenant_scope,
+    evaluate_middleware_must_cover_routes, extract_security_facts, static_middleware_coverage,
 };
 
 #[test]
@@ -1885,4 +1888,155 @@ export async function GET() {
         findings.is_empty(),
         "candidate-only heuristic middleware evidence must not block: {findings:#?}"
     );
+}
+
+/// S4-03 RED: `as` is not a different helper.
+///
+/// `accepted_helper_called` demanded `fact.name == helper.symbol` AND
+/// `fact.imported_name == helper.symbol`, which is the same demand written twice for a plain
+/// import and an impossible one for a renamed import: after `import { assertCsrf as checkCsrf }`
+/// the local name is `checkCsrf` and the imported name is `assertCsrf`, and no single symbol
+/// equals both. So a route that imports the accepted CSRF guard, calls it, and is in every sense
+/// compliant was reported as having no CSRF proof at all - purely for renaming the binding.
+///
+/// The imported name is the identity. The local name is how this file spells it, and the call
+/// site is what has to be looked for under that spelling.
+#[test]
+fn renamed_import_of_the_accepted_csrf_helper_satisfies() {
+    let source = r#"
+import { assertCsrf as checkCsrf } from "@/security/csrf";
+
+export async function POST(request: Request) {
+  checkCsrf(request);
+  return Response.json({ ok: true });
+}
+"#;
+
+    let findings = evaluate_api_route_requires_csrf_for_mutation(
+        "app/api/settings/route.ts",
+        source,
+        &csrf_contract(vec![AcceptedSecurityHelper {
+            helper_id: "csrf".to_string(),
+            module: "@/security/csrf".to_string(),
+            symbol: "assertCsrf".to_string(),
+            // No table needed: a rename is not a question about modules, and this must be fixed
+            // for a contract the CLI never resolved as much as for one it did.
+            identity: None,
+        }]),
+    )
+    .expect("security findings");
+
+    assert!(
+        findings.is_empty(),
+        "renaming the binding must not withdraw the CSRF proof: {findings:#?}"
+    );
+}
+
+/// S4-03 RED: the same defect on the SSRF allowlist, which asked the same impossible question and
+/// then looked for the accepted symbol's name in the source text - a name this file never writes.
+///
+/// The fixture reassigns `target` in place rather than introducing a second variable, and that is
+/// deliberate. Assigning to a fresh name breaks the taint chain to the outbound sink, so the route
+/// produces no unvalidated outbound use and the rule returns clean whatever the contract says -
+/// a test written that way passes with an EMPTY helper list and proves nothing about helpers at
+/// all. Here the sink really is reached by a request-derived variable, so the allowlist proof is
+/// the only thing standing between this route and a finding.
+#[test]
+fn renamed_import_of_the_ssrf_allowlist_helper_satisfies() {
+    let source = r#"
+import { requireAllowedOutboundUrl as allowOutbound } from "@/security/outbound";
+
+export async function GET(request: Request) {
+  let target = request.nextUrl.searchParams.get("target");
+  target = allowOutbound(target);
+  await fetch(target);
+  return Response.json({ ok: true });
+}
+"#;
+
+    let contract = |accepted_allowlist_helpers| SecuritySsrfContract {
+        contract_id: "security_api_no_ssrf".to_string(),
+        capability: SecurityContractCapability::DeterministicCheck,
+        enforcement_mode: SecurityEnforcementMode::Block,
+        accepted_allowlist_helpers,
+    };
+
+    // The negative control, first: with no accepted helper this route IS a finding. Without it
+    // the assertion below could be satisfied by a rule that never fires on this source.
+    let unprotected = evaluate_api_route_forbids_untrusted_ssrf(
+        "app/api/proxy/route.ts",
+        source,
+        &contract(Vec::new()),
+    )
+    .expect("security findings");
+    assert_eq!(
+        unprotected.len(),
+        1,
+        "fixture must reach the outbound sink with request-derived input: {unprotected:#?}"
+    );
+
+    let findings = evaluate_api_route_forbids_untrusted_ssrf(
+        "app/api/proxy/route.ts",
+        source,
+        &contract(vec![AcceptedOutboundUrlHelper {
+            helper_id: "outbound_allowlist".to_string(),
+            module: "@/security/outbound".to_string(),
+            symbol: "requireAllowedOutboundUrl".to_string(),
+            identity: None,
+        }]),
+    )
+    .expect("security findings");
+
+    assert!(
+        findings.is_empty(),
+        "renaming the binding must not withdraw the outbound allowlist proof: {findings:#?}"
+    );
+}
+
+/// S4-03 RED: F3 again, on the CSRF guard rather than the auth helper.
+///
+/// The contract names `@/security/csrf`; this route reaches the same file relatively. The
+/// resolved identity says the accepted helper IS `security/csrf.ts`, and normalising the relative
+/// spelling against the importing file lands on it.
+#[test]
+fn relative_spelling_of_the_csrf_helper_satisfies() {
+    let source = r#"
+import { assertCsrf } from "../../../security/csrf";
+
+export async function POST(request: Request) {
+  assertCsrf(request);
+  return Response.json({ ok: true });
+}
+"#;
+
+    let findings = evaluate_api_route_requires_csrf_for_mutation(
+        "app/api/settings/route.ts",
+        source,
+        &csrf_contract(vec![AcceptedSecurityHelper {
+            helper_id: "csrf".to_string(),
+            module: "@/security/csrf".to_string(),
+            symbol: "assertCsrf".to_string(),
+            identity: Some(HelperModuleIdentity {
+                specifier: "@/security/csrf".to_string(),
+                mode: HelperResolutionMode::RepoResolved,
+                files: vec!["security/csrf.ts".to_string()],
+                package_specifier_resolves_in_repo: false,
+            }),
+        }]),
+    )
+    .expect("security findings");
+
+    assert!(
+        findings.is_empty(),
+        "a relative spelling of the accepted helper's module must still prove CSRF: {findings:#?}"
+    );
+}
+
+fn csrf_contract(accepted_csrf_helpers: Vec<AcceptedSecurityHelper>) -> SecurityCsrfContract {
+    SecurityCsrfContract {
+        contract_id: "security_api_csrf".to_string(),
+        capability: SecurityContractCapability::DeterministicCheck,
+        enforcement_mode: SecurityEnforcementMode::Block,
+        accepted_csrf_helpers,
+    }
 }


### PR DESCRIPTION
Sprint 4. The engine now decides "is this the accepted helper?" by **resolved module identity** instead of by comparing import specifier strings.

Revised after adversarial review — two blockers, both fixed. See **Review round**.

## What was wrong

`helper_import_matches` was one string comparison, so `@/lib/auth` and `../../lib/auth` — the same file — were two different helpers.

## The rule

Dispatch is on the resolution `mode`, never on whether `files` is empty. External imports produce no resolution edge *by design*, so an emptiness shortcut would silently retain the old semantics for every external auth helper — the most common real contract.

| mode | rule |
|---|---|
| none / `External` / `Unresolved` | exact specifier equality — byte-for-byte the pre-sprint behavior |
| `RepoResolved` | equality, **or** the spelling denotes one of the resolved `files` |

Acceptance is **equality only**. There is no prefix, subpath, or ancestor relation anywhere in it.

## Review round

### B1 — the alias mapping was derived per-candidate-file, making the re-export closure unreachable *(fixed, `c34f4f43`)*

The old `rewrite_through_contract_alias` asked *each candidate file* to explain the `@/` ↔ repo-root mapping, and bailed when it couldn't. Every closure member fails that, because a closure selects modules by what they **export**, not by what they're **called**.

Reproduced end to end: with a contract naming `@/lib` and `files: ["lib/auth.ts", "lib/index.ts"]`, a route importing `'@/lib/auth'` — a file literally in that list — produced a blocking finding, while `'../../../lib/auth'`, the same file, passed clean. The precise defect this PR exists to eliminate, one layer down. It also invalidated the mitigation the code recommended for its own residual.

```
barrel_contract_matches_the_module_it_reexports
  assertion `left == right` failed: spelling @/lib/auth
    left: 0   right: 1
```

`contract_alias_mapping(expected_specifier, files)` now derives the mapping **once**, before any candidate is consulted, anchored on the file sharing the longest trailing run of segments with the specifier.

### B2 — the ancestor relation is deleted, not bounded *(`33db2d30`)*

It matched *every* ancestor directory of a resolved file with no evidence a barrel existed there, and it removed **true positives**: add `lib/index.ts` re-exporting a no-op `requireUser`, import from `@/lib`, and main flags it while the first draft did not.

**It does not survive B1's fix.** Once the mapping is derived correctly, the relation buys exactly one case — contract names the narrow module, route imports a barrel above it — and for that case there is no evidence in this engine and **no bound that helps**. `files` is the *outbound* closure, so a barrel re-exporting *into* it appears nowhere in the data. Bounding to one level would shrink the reach while leaving the true-positive removal intact, because the counterexample *is* one level.

On a security check the direction matters more than the magnitude. A named limitation beats a silent false negative.

Both measurements are now tests, both RED first:

```
a_barrel_the_contract_did_not_name_is_not_evidence
  assertion failed: spelling @/lib    left: Bool(true)   right: Bool(false)

an_ancestor_directory_is_not_evidence_of_anything
  @/src names a directory above the helper and proves nothing about it
```

### Docs and joins *(`f62778ea`)*

`protocol.rs` no longer claims `External` performs a local-shadow check, and `package_specifier_resolves_in_repo` is documented as input to the *proof*, not to a check — the CLI sets it only in the `repo_resolved` branch, so it could never have been that input.

The `External` invariant is restated accurately. The earlier claim that `mode == External` *is* the statement that no local shadow exists was overstated: `isBarePackageSpecifier` rejects only `.` `/` `@/` `~` `#`, so `@app/auth`, `$lib/...` and unresolved `baseUrl` imports all land in `external`. The mode means "bare-**looking**, and resolved to nothing". No behavior rides on it; the proof carries the label to readers.

## Two false premises in the plan, reported not worked around

1. **S4-03's claim that it fixes renamed imports (F4) is false for users.** `evaluate_api_route_requires_csrf_for_mutation` and friends are called from nowhere in `src/` — they exist only as `lib.rs` re-exports. The real dispatch already matched on `imported_name`, so renames always worked. Fixed anyway (a published function giving a wrong answer is a defect) and pinned at the check-repo level.
2. **A pre-existing SSRF test is vacuous.** `const safeTarget = allowOutbound(target); fetch(safeTarget)` passes with an *empty* helper list, because assigning to a fresh name breaks the taint chain. Untouched; worth its own fix. Review swept for the same shape elsewhere and found none.

## Verification

- **Mutations, round 2 — 5 run, each killed exactly its own tests.** Including: refuse to derive a mapping when `files` has >1 entry; anchor on the *shortest* shared suffix; reinstate the ancestor relation; collapse the join key to symbol alone; `as_wire` returning `"external"` for `Unresolved`.
- **A mutation that survived round 1 is now killed.** The "longest anchor" tie-break was argued in a comment and asserted nowhere; `the_anchor_is_the_file_that_best_explains_the_specifier` pins it with a decoy closure.
- **Correction on the record:** the round-1 claim that every mutation killed exactly one test was wrong — dropping the ancestor relation killed two.
- **Canary: 389 → 407 passing, +18**, matching the 18 tests added across both rounds, per-binary deltas `[+6,+6,+3,+3]`, **no count decreased**. The one removed test was this sprint's own, replaced by the assertion that contradicts it.
- `pnpm verify:ci` → `EXIT=0`, read without a pipe, release binary rebuilt first.

## Release note

> Drift no longer reports missing security proofs on routes that reach an accepted helper by a different spelling. A contract naming `@/lib/auth` is satisfied by `../../../lib/auth`; a contract naming a barrel (`@/lib`) is satisfied by any module the barrel re-exports the helper from, in either spelling — on the auth, CSRF, rate-limit and SSRF-allowlist paths alike. External helpers keep matching on the specifier, and the proof now records which rule decided.
>
> **Known limitation:** a route importing through a barrel the contract did *not* name is still reported. Accept the barrel instead of the module beneath it. Resolving this needs the inbound re-export closure, computable only in the CLI.
>
> **No new findings are introduced, and none are removed.**

*(An earlier draft claimed renamed imports were fixed and that every change was "byte-identical". Both were withdrawn — see the false-premise and B2 sections.)*

🤖 Generated with [Claude Code](https://claude.com/claude-code)